### PR TITLE
Add MediaPostController docs, testcases, and middleware documentation

### DIFF
--- a/doc/5_api/controller/MediaPostController/readme.md
+++ b/doc/5_api/controller/MediaPostController/readme.md
@@ -1,0 +1,71 @@
+# MediaPostController
+
+## 概要
+- `POST /api/media` のHTTPリクエストを受け取り、メディア登録ユースケースへ橋渡しする。
+- セッション認証およびコンテンツ保存はミドルウェアで完了している前提で、リクエストコンテキストの `contentIds` と入力値（`title` / `tags`）から登録入力を組み立て、`RegisterMediaService` を呼び出してAPIレスポンス（成功 / 失敗）を整形する。
+- `contentIds` は1件以上存在することを前提とする。
+
+## 対象API
+- `POST /api/media`
+
+## バリデーション
+- `title` は空文字を許可しない。
+- `tags` は空配列を許可する。
+- `tags` の未指定は許可する（未指定には `null` を含む）。
+- `tags` 配列要素に `null` は許可しない。
+- `tags[n].category` は空文字を許可しない。
+- `tags[n].label` は空文字を許可しない。
+
+## 依存
+- SessionAuthMiddleware: `doc/5_api/controller/middleware/SessionAuthMiddleware.md`
+- ContentSaveMiddleware: `doc/5_api/controller/middleware/ContentSaveMiddleware.md`
+- Application Service: `RegisterMediaService`
+
+## 処理フロー
+```plantuml
+@startuml
+title MediaPostController フロー
+
+participant Client
+box "Controller Layer" #LightBlue
+  participant MediaPostController as Controller
+end box
+box "Application Layer" #LightGreen
+  participant RegisterMediaService as Application
+end box
+
+Client -> Controller: POST /api/media
+Controller -> Controller: title / tags / contentIds を取得
+Controller -> Controller: リクエストバリデーションチェック
+
+opt バリデーションチェック失敗
+  Controller --> Controller: code=1 を生成
+  Controller --> Client: 200 レスポンス
+  destroy Controller
+end
+
+Controller -> Application: execute
+Application --> Controller: mediaId or failure
+
+opt 登録失敗
+  Controller --> Controller: code=1 を生成
+  Controller --> Client: 200 レスポンス
+  destroy Controller
+end
+
+Controller --> Controller: code=0, mediaId を生成
+Controller --> Client: 200 レスポンス
+@enduml
+```
+
+## エラーハンドリング
+- 入力不正や登録失敗: `200` + `code: 1`（Controller / Application）
+- 永続化失敗: `200` + `code: 1`（Application）
+
+## 関連ドキュメント
+- SessionAuthMiddleware: `doc/5_api/controller/middleware/SessionAuthMiddleware.md`
+- ContentSaveMiddleware: `doc/5_api/controller/middleware/ContentSaveMiddleware.md`
+- OpenAPI: `doc/5_api/openapi/paths/api/media.yaml`
+- シーケンス図: `doc/5_api/sequence/api/media.post.puml`
+- APIテストケース: `doc/5_api/testcase/api/media.post.md`
+- Application設計: `doc/4_application/media/command/RegisterMediaService/readme.md`

--- a/doc/5_api/controller/MediaPostController/testcase.md
+++ b/doc/5_api/controller/MediaPostController/testcase.md
@@ -1,0 +1,203 @@
+# MediaPostController テストケース
+
+## テストケース一覧
+- [ミドルウェアで設定されたcontentIdsを使ってメディア登録に成功する](#ミドルウェアで設定されたcontentidsを使ってメディア登録に成功する)
+- [tags未指定null含むでもメディア登録に成功する](#tags未指定null含むでもメディア登録に成功する)
+- [tagsが空配列でもメディア登録に成功する](#tagsが空配列でもメディア登録に成功する)
+- [重複タグを含んでもメディア登録に成功する](#重複タグを含んでもメディア登録に成功する)
+- [RegisterMediaServiceが失敗した場合はcode=1を返す](#registermediaserviceが失敗した場合はcode1を返す)
+- [titleが空文字の場合は登録失敗を返す](#titleが空文字の場合は登録失敗を返す)
+- [tags配列要素がnullの場合は登録失敗を返す](#tags配列要素がnullの場合は登録失敗を返す)
+- [tagsのcategoryが空文字の場合は登録失敗を返す](#tagsのcategoryが空文字の場合は登録失敗を返す)
+- [tagsのlabelが空文字の場合は登録失敗を返す](#tagsのlabelが空文字の場合は登録失敗を返す)
+- [contentIdsが未設定の場合は登録失敗を返す](#contentidsが未設定の場合は登録失敗を返す)
+- [contentIdsが空配列の場合は登録失敗を返す](#contentidsが空配列の場合は登録失敗を返す)
+- [contentIdsの順序を維持して処理される](#contentidsの順序を維持して処理される)
+- [contentIdsの型不正時は登録失敗を返す](#contentidsの型不正時は登録失敗を返す)
+- [想定外例外発生時も失敗レスポンス形式を維持する](#想定外例外発生時も失敗レスポンス形式を維持する)
+
+---
+
+## 正常系
+
+### ミドルウェアで設定されたcontentIdsを使ってメディア登録に成功する
+
+- **前提**
+  - `title` が空文字ではない。
+  - `tags` が指定される場合、各要素の `category` / `label` は空文字ではない。
+  - リクエストコンテキストに1件以上の `contentIds` が設定されている。
+  - `RegisterMediaService` が成功し `mediaId` を返す。
+- **操作**
+  - `MediaPostController` を実行する。
+- **結果**
+  - `RegisterMediaService` に `title` / `tags` / `contentIds` を渡して呼び出す。
+  - HTTPステータス `200` を返す。
+  - レスポンスボディに `code: 0` と `mediaId` を含む。
+
+---
+
+### tags未指定null含むでもメディア登録に成功する
+
+- **前提**
+  - `title` が空文字ではない。
+  - `tags` は未指定（`null` を含む）である。
+  - リクエストコンテキストに1件以上の `contentIds` が設定されている。
+  - `RegisterMediaService` が成功する。
+- **操作**
+  - `MediaPostController` を実行する。
+- **結果**
+  - HTTPステータス `200` を返す。
+  - レスポンスボディに `code: 0` と `mediaId` を含む。
+
+---
+
+### tagsが空配列でもメディア登録に成功する
+
+- **前提**
+  - `title` が空文字ではない。
+  - `tags` は空配列である。
+  - リクエストコンテキストに1件以上の `contentIds` が設定されている。
+  - `RegisterMediaService` が成功する。
+- **操作**
+  - `MediaPostController` を実行する。
+- **結果**
+  - HTTPステータス `200` を返す。
+  - レスポンスボディに `code: 0` と `mediaId` を含む。
+
+---
+
+### 重複タグを含んでもメディア登録に成功する
+
+- **前提**
+  - 同一 `category` + `label` のタグ重複を含む。
+  - 各タグの `category` / `label` は空文字ではない。
+  - リクエストコンテキストに1件以上の `contentIds` が設定されている。
+  - `RegisterMediaService` は成功する。
+- **操作**
+  - `MediaPostController` を実行する。
+- **結果**
+  - HTTPステータス `200` を返す。
+  - レスポンスボディに `code: 0` と `mediaId` を含む。
+
+---
+
+## 異常系
+
+### RegisterMediaServiceが失敗した場合はcode=1を返す
+
+- **前提**
+  - リクエストコンテキストに1件以上の `contentIds` が設定されている。
+  - `RegisterMediaService` が失敗を返す。
+- **操作**
+  - `MediaPostController` を実行する。
+- **結果**
+  - HTTPステータス `200` を返す。
+  - レスポンスボディは `code: 1` となる。
+
+---
+
+### titleが空文字の場合は登録失敗を返す
+
+- **前提**
+  - `title` が空文字である。
+- **操作**
+  - `MediaPostController` を実行する。
+- **結果**
+  - HTTPステータス `200` を返す。
+  - レスポンスボディは `code: 1` となる。
+
+---
+
+### tags配列要素がnullの場合は登録失敗を返す
+
+- **前提**
+  - `tags` 配列の要素に `null` が含まれる。
+- **操作**
+  - `MediaPostController` を実行する。
+- **結果**
+  - HTTPステータス `200` を返す。
+  - レスポンスボディは `code: 1` となる。
+
+---
+
+### tagsのcategoryが空文字の場合は登録失敗を返す
+
+- **前提**
+  - `tags[0].category` が空文字である。
+- **操作**
+  - `MediaPostController` を実行する。
+- **結果**
+  - HTTPステータス `200` を返す。
+  - レスポンスボディは `code: 1` となる。
+
+---
+
+### tagsのlabelが空文字の場合は登録失敗を返す
+
+- **前提**
+  - `tags[0].label` が空文字である。
+- **操作**
+  - `MediaPostController` を実行する。
+- **結果**
+  - HTTPステータス `200` を返す。
+  - レスポンスボディは `code: 1` となる。
+
+---
+
+### contentIdsが未設定の場合は登録失敗を返す
+
+- **前提**
+  - リクエストコンテキストに `contentIds` が設定されていない。
+- **操作**
+  - `MediaPostController` を実行する。
+- **結果**
+  - HTTPステータス `200` を返す。
+  - レスポンスボディは `code: 1` となる。
+
+---
+
+### contentIdsが空配列の場合は登録失敗を返す
+
+- **前提**
+  - リクエストコンテキストの `contentIds` が空配列である。
+- **操作**
+  - `MediaPostController` を実行する。
+- **結果**
+  - HTTPステータス `200` を返す。
+  - レスポンスボディは `code: 1` となる。
+
+---
+
+### contentIdsの順序を維持して処理される
+
+- **前提**
+  - リクエストコンテキストに順序付きの `contentIds` が設定されている。
+  - `RegisterMediaService` は受け取った順序を維持して処理する。
+- **操作**
+  - `MediaPostController` を実行する。
+- **結果**
+  - `RegisterMediaService` に `contentIds` が順序を保持したまま渡される。
+
+---
+
+### contentIdsの型不正時は登録失敗を返す
+
+- **前提**
+  - `contentIds` が配列ではない、または要素型が不正である。
+- **操作**
+  - `MediaPostController` を実行する。
+- **結果**
+  - HTTPステータス `200` を返す。
+  - レスポンスボディは `code: 1` となる。
+
+---
+
+### 想定外例外発生時も失敗レスポンス形式を維持する
+
+- **前提**
+  - Controller内部で想定外例外が発生する。
+- **操作**
+  - `MediaPostController` を実行する。
+- **結果**
+  - HTTPステータス `200` を返す。
+  - レスポンスボディは `code: 1` となる。

--- a/doc/5_api/controller/middleware/ContentSaveMiddleware.md
+++ b/doc/5_api/controller/middleware/ContentSaveMiddleware.md
@@ -1,0 +1,20 @@
+# ContentSaveMiddleware
+
+## 概要
+- `multipart/form-data` の `contents` を保存するミドルウェア。
+- コンテンツ順は `contents[].position` を正として決定する。
+- 保存済みコンテンツに対応する `contentIds` を、`contents[].position` の順序でリクエストコンテキストへ設定する。
+- `contents` 内の `file` が0件（空）の場合は無効入力として扱う。
+
+## position ルール
+- `position` は `1, 2, 3, ...` の連番で存在する必要がある。
+- `1, 2, 4` のように欠番がある場合は異常とみなす。
+- `2, 3, 4` のように `1` から開始していない場合は異常とみなす。
+- `position` の重複は許可しない。
+- `2, 1, 3, 5, 4` のように受信順が不規則でも、欠番がなく `1..N` を満たしていれば正常とみなす。
+
+## 振る舞い
+- `contents` の `file` が1件以上かつ `position` が有効で、保存に成功した場合、`position` 順でファイルを保存し、同順序の `contentIds` を設定して次のControllerへ処理を委譲する。
+- `contents` の `file` が0件（空）の場合は無効として失敗レスポンスを返し、後続のControllerは実行しない。
+- `position` が無効な場合は失敗レスポンスを返し、後続のControllerは実行しない。
+- コンテンツ保存に失敗した場合、失敗レスポンスを返し、後続のControllerは実行しない。

--- a/doc/5_api/controller/middleware/SessionAuthMiddleware.md
+++ b/doc/5_api/controller/middleware/SessionAuthMiddleware.md
@@ -1,0 +1,10 @@
+# SessionAuthMiddleware
+
+## 概要
+- Cookieの `sessionId` を検証するミドルウェア。
+- 認証に失敗した場合は後続処理を中断する。
+- 認証成功時は、後続のController要件に応じて認証コンテキストをリクエストへ設定する（`userId` が必要なControllerでは文字列の `userId` を設定する）。
+
+## 振る舞い
+- `sessionId` が有効な場合は、Controller要件に応じた認証コンテキスト（必要に応じて `userId`（string））を設定し、次のミドルウェア / Controllerへ処理を委譲する。
+- `sessionId` が未指定・無効・期限切れの場合は `401` を返し、後続のControllerは実行しない。


### PR DESCRIPTION
### Motivation
- Provide comprehensive API documentation for the `POST /api/media` controller including validation rules and error behavior.
- Specify middleware contracts for session authentication and content saving to ensure consistent request context and content ordering.
- Capture expected controller test cases to make behavior and edge cases explicit for implementation and QA.

### Description
- Added `doc/5_api/controller/MediaPostController/readme.md` describing the controller flow, input validation, error handling, sequence diagram, and related links.
- Added `doc/5_api/controller/MediaPostController/testcase.md` enumerating positive and negative test cases for `MediaPostController`, including content ordering and validation edge cases.
- Added `doc/5_api/controller/middleware/ContentSaveMiddleware.md` documenting `multipart/form-data` content saving behavior, `contents[].position` rules, and how `contentIds` are set on the request context.
- Added `doc/5_api/controller/middleware/SessionAuthMiddleware.md` documenting session cookie validation and how authentication context (e.g. `userId`) is provided or `401` is returned.

### Testing
- No automated tests were executed as part of this change; the PR adds documented test cases in `doc/5_api/controller/MediaPostController/testcase.md` for future automated or manual test implementation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a94dd563f0832ba6d9982b2043f229)