### PR TITLE
Add MediaPostController with validation, priorityCategories generation, docs and tests

### DIFF
--- a/__tests__/small/controller/MediaPostController.test.js
+++ b/__tests__/small/controller/MediaPostController.test.js
@@ -1,0 +1,205 @@
+const MediaPostController = require('../../../src/controller/MediaPostController');
+const {
+  RegisterMediaServiceInput,
+} = require('../../../src/application/media/command/RegisterMediaService');
+
+describe('MediaPostController', () => {
+  let registerMediaService;
+  let controller;
+
+  const createRes = () => {
+    const res = {
+      status: jest.fn(),
+      json: jest.fn(),
+    };
+    res.status.mockReturnValue(res);
+    return res;
+  };
+
+  const execute = async ({ body, contentIds }) => {
+    const req = {
+      body,
+      context: {
+        contentIds,
+      },
+    };
+    const res = createRes();
+
+    await controller.execute(req, res);
+
+    return { res };
+  };
+
+  beforeEach(() => {
+    registerMediaService = {
+      execute: jest.fn().mockResolvedValue({ mediaId: 'm1' }),
+    };
+
+    controller = new MediaPostController({ registerMediaService });
+  });
+
+  it('contentIdsを使ってメディア登録に成功する', async () => {
+    const { res } = await execute({
+      body: {
+        title: 'title',
+        tags: [{ category: '作者', label: 'A' }],
+      },
+      contentIds: ['c1', 'c2'],
+    });
+
+    expect(registerMediaService.execute).toHaveBeenCalledTimes(1);
+    const input = registerMediaService.execute.mock.calls[0][0];
+    expect(input).toBeInstanceOf(RegisterMediaServiceInput);
+    expect(input).toMatchObject({
+      title: 'title',
+      contents: ['c1', 'c2'],
+      tags: [{ category: '作者', label: 'A' }],
+      priorityCategories: ['作者'],
+    });
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      code: 0,
+      mediaId: 'm1',
+    });
+  });
+
+  it('tagsが空配列でもメディア登録に成功する', async () => {
+    const { res } = await execute({
+      body: {
+        title: 'title',
+        tags: [],
+      },
+      contentIds: ['c1'],
+    });
+
+    expect(registerMediaService.execute).toHaveBeenCalledTimes(1);
+    expect(res.json).toHaveBeenCalledWith({
+      code: 0,
+      mediaId: 'm1',
+    });
+  });
+
+  it('重複タグを含んでもメディア登録に成功する', async () => {
+    const { res } = await execute({
+      body: {
+        title: 'title',
+        tags: [
+          { category: '作者', label: 'A' },
+          { category: '作者', label: 'A' },
+        ],
+      },
+      contentIds: ['c1'],
+    });
+
+    expect(registerMediaService.execute).toHaveBeenCalledTimes(1);
+    const input = registerMediaService.execute.mock.calls[0][0];
+    expect(input.tags).toMatchObject([
+      { category: '作者', label: 'A' },
+      { category: '作者', label: 'A' },
+    ]);
+    expect(input.priorityCategories).toEqual(['作者']);
+    expect(res.json).toHaveBeenCalledWith({
+      code: 0,
+      mediaId: 'm1',
+    });
+  });
+
+  it('contentIdsの順序を維持して処理される', async () => {
+    await execute({
+      body: {
+        title: 'title',
+        tags: [],
+      },
+      contentIds: ['c3', 'c1', 'c2'],
+    });
+
+    const input = registerMediaService.execute.mock.calls[0][0];
+    expect(input.contents).toEqual(['c3', 'c1', 'c2']);
+  });
+
+
+  it('priorityCategoriesはtags.categoryの出現順で重複なく生成される', async () => {
+    await execute({
+      body: {
+        title: 'title',
+        tags: [
+          { category: '作者', label: 'A' },
+          { category: 'ジャンル', label: 'バトル' },
+          { category: '作者', label: 'B' },
+          { category: 'シリーズ', label: 'X' },
+          { category: 'ジャンル', label: 'アクション' },
+        ],
+      },
+      contentIds: ['c1'],
+    });
+
+    const input = registerMediaService.execute.mock.calls[0][0];
+    expect(input.priorityCategories).toEqual(['作者', 'ジャンル', 'シリーズ']);
+  });
+
+  it('RegisterMediaServiceが失敗した場合はcode=1を返す', async () => {
+    registerMediaService.execute.mockRejectedValue(new Error('fail'));
+
+    const { res } = await execute({
+      body: {
+        title: 'title',
+        tags: [],
+      },
+      contentIds: ['c1'],
+    });
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      code: 1,
+    });
+  });
+
+  it.each([
+    ['titleが空文字', { title: '', tags: [] }, ['c1']],
+    ['titleがstring以外', { title: 1, tags: [] }, ['c1']],
+    ['tagsが未設定', { title: 'title' }, ['c1']],
+    ['tagsが配列以外', { title: 'title', tags: {} }, ['c1']],
+    ['tags配列要素がnull', { title: 'title', tags: [null] }, ['c1']],
+    ['tags配列要素がオブジェクト以外', { title: 'title', tags: [1] }, ['c1']],
+    ['tagsのcategoryがstring以外', { title: 'title', tags: [{ category: 1, label: 'A' }] }, ['c1']],
+    ['tagsのcategoryが空文字', { title: 'title', tags: [{ category: '', label: 'A' }] }, ['c1']],
+    ['tagsのlabelがstring以外', { title: 'title', tags: [{ category: 'A', label: 1 }] }, ['c1']],
+    ['tagsのlabelが空文字', { title: 'title', tags: [{ category: 'A', label: '' }] }, ['c1']],
+    ['contentIdsが未設定', { title: 'title', tags: [] }, undefined],
+    ['contentIdsが配列以外', { title: 'title', tags: [] }, {}],
+    ['contentIdsが空配列', { title: 'title', tags: [] }, []],
+    ['contentIds要素がstring以外', { title: 'title', tags: [] }, [1]],
+    ['contentIds要素が空文字', { title: 'title', tags: [] }, ['']],
+    ['contentIdsに重複がある', { title: 'title', tags: [] }, ['c1', 'c1']],
+  ])('%sの場合は登録失敗を返す', async (_name, body, contentIds) => {
+    const { res } = await execute({ body, contentIds });
+
+    expect(registerMediaService.execute).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      code: 1,
+    });
+  });
+
+  it('想定外例外発生時も失敗レスポンス形式を維持する', async () => {
+    const req = {
+      body: {
+        get title() {
+          throw new Error('unexpected');
+        },
+      },
+      context: {
+        contentIds: ['c1'],
+      },
+    };
+    const res = createRes();
+
+    await controller.execute(req, res);
+
+    expect(registerMediaService.execute).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      code: 1,
+    });
+  });
+});

--- a/__tests__/small/controller/MediaPostController.test.js
+++ b/__tests__/small/controller/MediaPostController.test.js
@@ -39,6 +39,9 @@ describe('MediaPostController', () => {
   });
 
   it('contentIdsを使ってメディア登録に成功する', async () => {
+    // arrange
+
+    // action
     const { res } = await execute({
       body: {
         title: 'title',
@@ -47,6 +50,7 @@ describe('MediaPostController', () => {
       contentIds: ['c1', 'c2'],
     });
 
+    // assert
     expect(registerMediaService.execute).toHaveBeenCalledTimes(1);
     const input = registerMediaService.execute.mock.calls[0][0];
     expect(input).toBeInstanceOf(RegisterMediaServiceInput);
@@ -64,6 +68,9 @@ describe('MediaPostController', () => {
   });
 
   it('tagsが空配列でもメディア登録に成功する', async () => {
+    // arrange
+
+    // action
     const { res } = await execute({
       body: {
         title: 'title',
@@ -72,6 +79,7 @@ describe('MediaPostController', () => {
       contentIds: ['c1'],
     });
 
+    // assert
     expect(registerMediaService.execute).toHaveBeenCalledTimes(1);
     expect(res.json).toHaveBeenCalledWith({
       code: 0,
@@ -80,6 +88,9 @@ describe('MediaPostController', () => {
   });
 
   it('重複タグを含んでもメディア登録に成功する', async () => {
+    // arrange
+
+    // action
     const { res } = await execute({
       body: {
         title: 'title',
@@ -91,6 +102,7 @@ describe('MediaPostController', () => {
       contentIds: ['c1'],
     });
 
+    // assert
     expect(registerMediaService.execute).toHaveBeenCalledTimes(1);
     const input = registerMediaService.execute.mock.calls[0][0];
     expect(input.tags).toMatchObject([
@@ -105,6 +117,9 @@ describe('MediaPostController', () => {
   });
 
   it('contentIdsの順序を維持して処理される', async () => {
+    // arrange
+
+    // action
     await execute({
       body: {
         title: 'title',
@@ -113,12 +128,15 @@ describe('MediaPostController', () => {
       contentIds: ['c3', 'c1', 'c2'],
     });
 
+    // assert
     const input = registerMediaService.execute.mock.calls[0][0];
     expect(input.contents).toEqual(['c3', 'c1', 'c2']);
   });
 
-
   it('priorityCategoriesはtags.categoryの出現順で重複なく生成される', async () => {
+    // arrange
+
+    // action
     await execute({
       body: {
         title: 'title',
@@ -133,13 +151,16 @@ describe('MediaPostController', () => {
       contentIds: ['c1'],
     });
 
+    // assert
     const input = registerMediaService.execute.mock.calls[0][0];
     expect(input.priorityCategories).toEqual(['作者', 'ジャンル', 'シリーズ']);
   });
 
   it('RegisterMediaServiceが失敗した場合はcode=1を返す', async () => {
+    // arrange
     registerMediaService.execute.mockRejectedValue(new Error('fail'));
 
+    // action
     const { res } = await execute({
       body: {
         title: 'title',
@@ -148,6 +169,7 @@ describe('MediaPostController', () => {
       contentIds: ['c1'],
     });
 
+    // assert
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith({
       code: 1,
@@ -172,8 +194,12 @@ describe('MediaPostController', () => {
     ['contentIds要素が空文字', { title: 'title', tags: [] }, ['']],
     ['contentIdsに重複がある', { title: 'title', tags: [] }, ['c1', 'c1']],
   ])('%sの場合は登録失敗を返す', async (_name, body, contentIds) => {
+    // arrange
+
+    // action
     const { res } = await execute({ body, contentIds });
 
+    // assert
     expect(registerMediaService.execute).not.toHaveBeenCalled();
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith({
@@ -182,6 +208,7 @@ describe('MediaPostController', () => {
   });
 
   it('想定外例外発生時も失敗レスポンス形式を維持する', async () => {
+    // arrange
     const req = {
       body: {
         get title() {
@@ -194,8 +221,10 @@ describe('MediaPostController', () => {
     };
     const res = createRes();
 
+    // action
     await controller.execute(req, res);
 
+    // assert
     expect(registerMediaService.execute).not.toHaveBeenCalled();
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith({

--- a/__tests__/small/controller/MediaPostController.test.js
+++ b/__tests__/small/controller/MediaPostController.test.js
@@ -183,6 +183,7 @@ describe('MediaPostController', () => {
     ['tagsが配列以外', { title: 'title', tags: {} }, ['c1']],
     ['tags配列要素がnull', { title: 'title', tags: [null] }, ['c1']],
     ['tags配列要素がオブジェクト以外', { title: 'title', tags: [1] }, ['c1']],
+    ['tags配列が疎配列', (() => { const tags = []; tags[1] = { category: '作者', label: 'A' }; return { title: 'title', tags }; })(), ['c1']],
     ['tagsのcategoryがstring以外', { title: 'title', tags: [{ category: 1, label: 'A' }] }, ['c1']],
     ['tagsのcategoryが空文字', { title: 'title', tags: [{ category: '', label: 'A' }] }, ['c1']],
     ['tagsのlabelがstring以外', { title: 'title', tags: [{ category: 'A', label: 1 }] }, ['c1']],
@@ -192,6 +193,7 @@ describe('MediaPostController', () => {
     ['contentIdsが空配列', { title: 'title', tags: [] }, []],
     ['contentIds要素がstring以外', { title: 'title', tags: [] }, [1]],
     ['contentIds要素が空文字', { title: 'title', tags: [] }, ['']],
+    ['contentIds配列が疎配列', { title: 'title', tags: [] }, (() => { const ids = []; ids[1] = 'c1'; return ids; })()],
     ['contentIdsに重複がある', { title: 'title', tags: [] }, ['c1', 'c1']],
   ])('%sの場合は登録失敗を返す', async (_name, body, contentIds) => {
     // arrange

--- a/__tests__/small/controller/api/MediaPostController.test.js
+++ b/__tests__/small/controller/api/MediaPostController.test.js
@@ -1,7 +1,7 @@
-const MediaPostController = require('../../../src/controller/MediaPostController');
+const MediaPostController = require('../../../../src/controller/MediaPostController');
 const {
   RegisterMediaServiceInput,
-} = require('../../../src/application/media/command/RegisterMediaService');
+} = require('../../../../src/application/media/command/RegisterMediaService');
 
 describe('MediaPostController', () => {
   let registerMediaService;

--- a/doc/5_api/controller/MediaPostController/readme.md
+++ b/doc/5_api/controller/MediaPostController/readme.md
@@ -3,6 +3,7 @@
 ## 概要
 - `POST /api/media` のHTTPリクエストを受け取り、メディア登録ユースケースへ橋渡しする。
 - セッション認証およびコンテンツ保存はミドルウェアで完了している前提で、リクエストコンテキストの `contentIds` と入力値（`title` / `tags`）から登録入力を組み立て、`RegisterMediaService` を呼び出してAPIレスポンス（成功 / 失敗）を整形する。`contentIds` は `contents[n].position` 順に並んでいるものを受け取る。
+- `RegisterMediaServiceInput.priorityCategories` は `tags[n].category` から生成する。重複は除去し、先頭から見た出現順を維持する。
 - `contentIds` は1件以上存在し、要素は `string` かつ空文字ではなく、重複しないことを前提とする。
 
 ## 対象API
@@ -39,6 +40,7 @@ end box
 Client -> Controller: POST /api/media
 Controller -> Controller: title / tags / contentIds を取得
 Controller -> Controller: リクエストバリデーションチェック
+Controller -> Controller: priorityCategories を tags.category から生成
 
 opt バリデーションチェック失敗
   Controller --> Controller: code=1 を生成

--- a/doc/5_api/controller/MediaPostController/testcase.md
+++ b/doc/5_api/controller/MediaPostController/testcase.md
@@ -5,6 +5,7 @@
 - [tagsが空配列でもメディア登録に成功する](#tagsが空配列でもメディア登録に成功する)
 - [重複タグを含んでもメディア登録に成功する](#重複タグを含んでもメディア登録に成功する)
 - [contentIdsの順序を維持して処理される](#contentidsの順序を維持して処理される)
+- [priorityCategoriesはtags.categoryの出現順で重複なく生成される](#prioritycategoriesはtagscategoryの出現順で重複なく生成される)
 - [RegisterMediaServiceが失敗した場合はcode=1を返す](#registermediaserviceが失敗した場合はcode1を返す)
 - [titleが空文字の場合は登録失敗を返す](#titleが空文字の場合は登録失敗を返す)
 - [titleがstring以外の場合は登録失敗を返す](#titleがstring以外の場合は登録失敗を返す)
@@ -41,6 +42,7 @@
   - `MediaPostController` を実行する。
 - **結果**
   - `RegisterMediaService` に `title` / `tags` / `contentIds` を渡して呼び出す。
+  - `RegisterMediaService` に渡す `priorityCategories` は `tags[n].category` を先頭から見た出現順で重複除去した値となる。
   - HTTPステータス `200` を返す。
   - レスポンスボディに `code: 0` と `mediaId` を含む。
 
@@ -89,6 +91,23 @@
   - `MediaPostController` を実行する。
 - **結果**
   - `RegisterMediaService` に `contentIds` が順序を保持したまま渡される。
+
+---
+
+### priorityCategoriesはtags.categoryの出現順で重複なく生成される
+
+- **前提**
+  - `title` は `string` かつ空文字ではない。
+  - `tags` に異なる `category` と重複する `category` が混在する。
+  - 各タグの `category` / `label` は `string` かつ空文字ではない。
+  - `contentIds` は1件以上で、各要素は `string` かつ空文字ではない（要素数1以上）。
+  - `contentIds` に重複はない。
+  - `RegisterMediaService` は成功する。
+- **操作**
+  - `MediaPostController` を実行する。
+- **結果**
+  - `RegisterMediaService` に渡す `priorityCategories` は、`tags[n].category` を先頭から見て重複除去した順序となる。
+  - 例: `['作者', 'ジャンル', '作者', 'シリーズ', 'ジャンル']` を入力した場合、`['作者', 'ジャンル', 'シリーズ']` を渡す。
 
 ---
 

--- a/src/controller/MediaPostController.js
+++ b/src/controller/MediaPostController.js
@@ -1,0 +1,89 @@
+const {
+  RegisterMediaServiceInput,
+} = require('../application/media/command/RegisterMediaService');
+
+class MediaPostController {
+  #registerMediaService;
+
+  constructor({ registerMediaService }) {
+    if (!registerMediaService || typeof registerMediaService.execute !== 'function') {
+      throw new Error();
+    }
+
+    this.#registerMediaService = registerMediaService;
+  }
+
+  async execute(req, res) {
+    try {
+      const title = req?.body?.title;
+      const tags = req?.body?.tags;
+      const contentIds = req?.context?.contentIds;
+
+      if (!this.#validateTitle(title)
+        || !this.#validateTags(tags)
+        || !this.#validateContentIds(contentIds)) {
+        return this.#fail(res);
+      }
+
+      const input = new RegisterMediaServiceInput({
+        title,
+        contents: contentIds,
+        tags,
+        priorityCategories: this.#createPriorityCategories(tags),
+      });
+
+      const output = await this.#registerMediaService.execute(input);
+
+      return res.status(200).json({
+        code: 0,
+        mediaId: output.mediaId,
+      });
+    } catch (error) {
+      return this.#fail(res);
+    }
+  }
+
+
+  #createPriorityCategories(tags) {
+    return [...new Set(tags.map(tag => tag.category))];
+  }
+
+  #fail(res) {
+    return res.status(200).json({
+      code: 1,
+    });
+  }
+
+  #validateTitle(title) {
+    return typeof title === 'string' && title.length > 0;
+  }
+
+  #validateTags(tags) {
+    if (!Array.isArray(tags)) {
+      return false;
+    }
+
+    return tags.every((tag) => {
+      if (!tag || typeof tag !== 'object' || Array.isArray(tag)) {
+        return false;
+      }
+
+      return typeof tag.category === 'string' && tag.category.length > 0
+        && typeof tag.label === 'string' && tag.label.length > 0;
+    });
+  }
+
+  #validateContentIds(contentIds) {
+    if (!Array.isArray(contentIds) || contentIds.length === 0) {
+      return false;
+    }
+
+    if (!contentIds.every(id => typeof id === 'string' && id.length > 0)) {
+      return false;
+    }
+
+    return new Set(contentIds).size === contentIds.length;
+  }
+}
+
+module.exports = MediaPostController;

--- a/src/controller/MediaPostController.js
+++ b/src/controller/MediaPostController.js
@@ -63,18 +63,18 @@ class MediaPostController {
       return false;
     }
 
-    return tags.every((tag, index) => {
-      if (!Object.hasOwn(tags, index)) {
-        return false;
-      }
-
+    for (const tag of tags) {
       if (!tag || typeof tag !== 'object') {
         return false;
       }
 
-      return typeof tag.category === 'string' && tag.category.length > 0
-        && typeof tag.label === 'string' && tag.label.length > 0;
-    });
+      if (!(typeof tag.category === 'string' && tag.category.length > 0
+        && typeof tag.label === 'string' && tag.label.length > 0)) {
+        return false;
+      }
+    }
+
+    return true;
   }
 
   #validateContentIds(contentIds) {
@@ -82,10 +82,10 @@ class MediaPostController {
       return false;
     }
 
-    if (!contentIds.every((id, index) => Object.hasOwn(contentIds, index)
-      && typeof id === 'string'
-      && id.length > 0)) {
-      return false;
+    for (const id of contentIds) {
+      if (!(typeof id === 'string' && id.length > 0)) {
+        return false;
+      }
     }
 
     return new Set(contentIds).size === contentIds.length;

--- a/src/controller/MediaPostController.js
+++ b/src/controller/MediaPostController.js
@@ -63,8 +63,12 @@ class MediaPostController {
       return false;
     }
 
-    return tags.every((tag) => {
-      if (!tag || typeof tag !== 'object' || Array.isArray(tag)) {
+    return tags.every((tag, index) => {
+      if (!Object.hasOwn(tags, index)) {
+        return false;
+      }
+
+      if (!tag || typeof tag !== 'object') {
         return false;
       }
 
@@ -78,7 +82,9 @@ class MediaPostController {
       return false;
     }
 
-    if (!contentIds.every(id => typeof id === 'string' && id.length > 0)) {
+    if (!contentIds.every((id, index) => Object.hasOwn(contentIds, index)
+      && typeof id === 'string'
+      && id.length > 0)) {
       return false;
     }
 


### PR DESCRIPTION
### Motivation
- Implement the HTTP handler for `POST /api/media` to assemble input from `title` / `tags` / `contentIds` and call the `RegisterMediaService` application use case. 
- Enforce input validation and maintain a consistent failure response shape (`200` + `code: 1`) for both validation and unexpected errors. 
- Generate `RegisterMediaServiceInput.priorityCategories` from `tags[n].category` by removing duplicates while preserving first-seen order. 

### Description
- Add `src/controller/MediaPostController.js` which validates `title`, `tags`, and `contentIds`, builds a `RegisterMediaServiceInput`, calls the injected `registerMediaService.execute`, and returns success/failure JSON responses. 
- Implement `#createPriorityCategories(tags)` using `[...]new Set(tags.map(...))` to produce de-duplicated categories in appearance order. 
- Add comprehensive unit tests in `__tests__/small/controller/MediaPostController.test.js` covering normal flows, validation failures, service failure, order preservation, duplicate tags, and unexpected exceptions. 
- Update documentation and test case specs in `doc/5_api/controller/MediaPostController/readme.md` and `doc/5_api/controller/MediaPostController/testcase.md` to describe validation rules and the `priorityCategories` generation behavior. 

### Testing
- Executed the new controller unit tests with `jest` targeting `__tests__/small/controller/MediaPostController.test.js`. 
- The test suite for `MediaPostController` passed successfully. 
- No changes to other automated test suites were required for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab5c302060832bac4dec245f12ab51)