### PR TITLE
Add comprehensive Jest tests for POST /api/media router middleware

### DIFF
--- a/8_testcases/middle/controller/router/media/setRouterApiMediaPost.md
+++ b/8_testcases/middle/controller/router/media/setRouterApiMediaPost.md
@@ -1,0 +1,12 @@
+# setRouterApiMediaPost.js middleテストケース
+
+| No | 観点 | 入力条件 | 期待結果 |
+| --- | --- | --- | --- |
+| 1 | 正常系: ルーター登録とPOST実行成功 | 有効なsession_token、妥当なcontents/title/tags、saveResolverがcontentId配列を返却 | `/api/media` に3ハンドラーが登録される。認証→保存→登録が順に実行され、`200 { code: 0, mediaId }` を返す。 |
+| 2 | 異常系: session未設定 | `req.session` が未設定 | 認証ミドルウェアで `401 { message: '認証に失敗しました' }` を返し、後続処理は実行されない。 |
+| 3 | 異常系: 認証解決失敗 | authResolverが空文字のuserIdを返却 | 認証ミドルウェアで `401 { message: '認証に失敗しました' }` を返し、後続処理は実行されない。 |
+| 4 | 異常系: contents不正 | `contents.position` が連番になっていない | 保存ミドルウェアで `200 { code: 1 }` を返し、メディア登録は実行されない。 |
+| 5 | 異常系: 保存結果不正 | saveResolverがcontents数と異なるcontentId配列を返却 | 保存ミドルウェアで `200 { code: 1 }` を返し、メディア登録は実行されない。 |
+| 6 | 異常系: コントローラー入力不正 | `title` が空文字 | コントローラーで `200 { code: 1 }` を返し、RegisterMediaServiceは実行されない。 |
+| 7 | 異常系: 登録サービス失敗 | mediaRepository.saveが例外送出 | コントローラーで `200 { code: 1 }` を返す。 |
+| 8 | 異常系: 初期化不正 | authResolverにexecuteが無い | `setRouterApiMediaPost` 呼び出し時に例外送出。 |

--- a/__tests__/middle/router/media/setRouterApiMediaPost.test.js
+++ b/__tests__/middle/router/media/setRouterApiMediaPost.test.js
@@ -1,0 +1,274 @@
+const express = require('express');
+const request = require('supertest');
+
+const setRouterApiMediaPost = require('../../../../src/controller/router/media/setRouterApiMediaPost');
+const Media = require('../../../../src/domain/media/media');
+
+class RouterCollector {
+  constructor() {
+    this.routes = [];
+  }
+
+  post(path, ...handlers) {
+    this.routes.push({ method: 'post', path, handlers });
+  }
+}
+
+class AuthResolver {
+  constructor(resolver = token => `user:${token}`) {
+    this.resolver = resolver;
+  }
+
+  async execute(token) {
+    return this.resolver(token);
+  }
+}
+
+class SaveResolver {
+  constructor({ save = contents => contents.map((_, index) => `c${index + 1}`) } = {}) {
+    this.save = save;
+    this.lastInput = null;
+  }
+
+  async execute(contents) {
+    this.lastInput = contents;
+    return this.save(contents);
+  }
+}
+
+class MediaIdValueGenerator {
+  constructor({ mediaId = 'm1' } = {}) {
+    this.mediaId = mediaId;
+  }
+
+  generate() {
+    return this.mediaId;
+  }
+}
+
+class MediaRepository {
+  constructor({ failOnSave = false } = {}) {
+    this.failOnSave = failOnSave;
+    this.saved = [];
+  }
+
+  async save(media) {
+    if (this.failOnSave) {
+      throw new Error('db error');
+    }
+
+    this.saved.push(media);
+  }
+}
+
+class UnitOfWork {
+  constructor() {
+    this.runCount = 0;
+  }
+
+  async run(work) {
+    this.runCount += 1;
+    return work();
+  }
+}
+
+describe('setRouterApiMediaPost middle', () => {
+  const createDependencies = (overrides = {}) => ({
+    authResolver: overrides.authResolver ?? new AuthResolver(() => 'u1'),
+    saveResolver: overrides.saveResolver ?? new SaveResolver(),
+    mediaIdValueGenerator: overrides.mediaIdValueGenerator ?? new MediaIdValueGenerator({ mediaId: 'm1' }),
+    mediaRepository: overrides.mediaRepository ?? new MediaRepository(),
+    unitOfWork: overrides.unitOfWork ?? new UnitOfWork(),
+  });
+
+  const createBody = (overrides = {}) => ({
+    title: 'sample title',
+    contents: [
+      { file: { name: '2.png' }, position: 2 },
+      { file: { name: '1.png' }, position: 1 },
+    ],
+    tags: [
+      { category: '作者', label: '山田' },
+      { category: 'ジャンル', label: 'バトル' },
+    ],
+    ...overrides,
+  });
+
+  const createApp = (dependencies) => {
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      const token = req.get('x-session-token');
+      if (typeof token === 'string' && token.length > 0) {
+        req.session = { session_token: token };
+      }
+
+      next();
+    });
+
+    const router = express.Router();
+    setRouterApiMediaPost({
+      router,
+      ...dependencies,
+    });
+    app.use(router);
+
+    return app;
+  };
+
+  test('POST /api/media に認証・保存・登録の順でハンドラーを登録できる', () => {
+    const router = new RouterCollector();
+
+    setRouterApiMediaPost({
+      router,
+      ...createDependencies(),
+    });
+
+    expect(router.routes).toHaveLength(1);
+    expect(router.routes[0].path).toBe('/api/media');
+    expect(router.routes[0].handlers).toHaveLength(3);
+  });
+
+  test('POST /api/media で認証・保存・登録の統合フローが成功する', async () => {
+    const dependencies = createDependencies();
+    const app = createApp(dependencies);
+
+    const response = await request(app)
+      .post('/api/media')
+      .set('x-session-token', 'token-1')
+      .send(createBody());
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ code: 0, mediaId: 'm1' });
+
+    expect(dependencies.saveResolver.lastInput).toEqual([
+      { file: { name: '1.png' }, position: 1 },
+      { file: { name: '2.png' }, position: 2 },
+    ]);
+
+    expect(dependencies.mediaRepository.saved).toHaveLength(1);
+    const savedMedia = dependencies.mediaRepository.saved[0];
+    expect(savedMedia).toBeInstanceOf(Media);
+    expect(savedMedia.getId().getId()).toBe('m1');
+    expect(savedMedia.getContents().map(content => content.getId())).toEqual(['c1', 'c2']);
+    expect(savedMedia.getPriorityCategories().map(category => category.getValue())).toEqual(['作者', 'ジャンル']);
+  });
+
+  test('session未設定の場合は401を返し後続処理を実行しない', async () => {
+    const dependencies = createDependencies();
+    const app = createApp(dependencies);
+
+    const response = await request(app)
+      .post('/api/media')
+      .send(createBody());
+
+    expect(response.status).toBe(401);
+    expect(response.body).toEqual({ message: '認証に失敗しました' });
+    expect(dependencies.saveResolver.lastInput).toBeNull();
+    expect(dependencies.mediaRepository.saved).toHaveLength(0);
+  });
+
+  test('authResolverが空文字を返す場合は401を返す', async () => {
+    const dependencies = createDependencies({
+      authResolver: new AuthResolver(() => ''),
+    });
+    const app = createApp(dependencies);
+
+    const response = await request(app)
+      .post('/api/media')
+      .set('x-session-token', 'token-1')
+      .send(createBody());
+
+    expect(response.status).toBe(401);
+    expect(response.body).toEqual({ message: '認証に失敗しました' });
+    expect(dependencies.saveResolver.lastInput).toBeNull();
+    expect(dependencies.mediaRepository.saved).toHaveLength(0);
+  });
+
+  test('contentsが不正な場合はcode=1を返し登録しない', async () => {
+    const dependencies = createDependencies();
+    const app = createApp(dependencies);
+
+    const response = await request(app)
+      .post('/api/media')
+      .set('x-session-token', 'token-1')
+      .send(createBody({
+        contents: [
+          { file: { name: '1.png' }, position: 1 },
+          { file: { name: '2.png' }, position: 3 },
+        ],
+      }));
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ code: 1 });
+    expect(dependencies.saveResolver.lastInput).toBeNull();
+    expect(dependencies.mediaRepository.saved).toHaveLength(0);
+  });
+
+  test('saveResolverの戻り値が不正な場合はcode=1を返し登録しない', async () => {
+    const dependencies = createDependencies({
+      saveResolver: new SaveResolver({
+        save: () => ['c1'],
+      }),
+    });
+    const app = createApp(dependencies);
+
+    const response = await request(app)
+      .post('/api/media')
+      .set('x-session-token', 'token-1')
+      .send(createBody());
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ code: 1 });
+    expect(dependencies.saveResolver.lastInput).toEqual([
+      { file: { name: '1.png' }, position: 1 },
+      { file: { name: '2.png' }, position: 2 },
+    ]);
+    expect(dependencies.mediaRepository.saved).toHaveLength(0);
+  });
+
+  test('titleが空文字の場合はcode=1を返し登録しない', async () => {
+    const dependencies = createDependencies();
+    const app = createApp(dependencies);
+
+    const response = await request(app)
+      .post('/api/media')
+      .set('x-session-token', 'token-1')
+      .send(createBody({ title: '' }));
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ code: 1 });
+    expect(dependencies.saveResolver.lastInput).toEqual([
+      { file: { name: '1.png' }, position: 1 },
+      { file: { name: '2.png' }, position: 2 },
+    ]);
+    expect(dependencies.mediaRepository.saved).toHaveLength(0);
+  });
+
+  test('mediaRepository.saveが失敗した場合はcode=1を返す', async () => {
+    const dependencies = createDependencies({
+      mediaRepository: new MediaRepository({ failOnSave: true }),
+    });
+    const app = createApp(dependencies);
+
+    const response = await request(app)
+      .post('/api/media')
+      .set('x-session-token', 'token-1')
+      .send(createBody());
+
+    expect(dependencies.unitOfWork.runCount).toBe(1);
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ code: 1 });
+  });
+
+  test('authResolverが不正な場合は初期化時に例外となる', () => {
+    const router = new RouterCollector();
+
+    expect(() => {
+      setRouterApiMediaPost({
+        router,
+        ...createDependencies({ authResolver: {} }),
+      });
+    }).toThrow();
+  });
+});


### PR DESCRIPTION
### Motivation

- Add unit and integration-style tests to validate the middleware and controller flow for the `POST /api/media` API, covering normal and edge cases.  
- Encode expected behaviors for authentication, content saving, validation, and media registration to prevent regressions.

### Description

- Add a test specification file `8_testcases/middle/controller/router/media/setRouterApiMediaPost.md` that lists 8 test scenarios and expected results.  
- Add Jest tests in `__tests__/middle/router/media/setRouterApiMediaPost.test.js` that use `express` and `supertest` to exercise the router and cover authentication, save resolution, validation of `contents` and `title`, repository failures, and initialization errors.  
- Provide lightweight test doubles and helpers (`RouterCollector`, `AuthResolver`, `SaveResolver`, `MediaIdValueGenerator`, `MediaRepository`, `UnitOfWork`) to simulate dependencies and assert interactions and saved entities.  
- Verify router registration (three middleware handlers) and the full happy-path integration that creates a `Media` domain instance with expected IDs and priority categories.

### Testing

- Added Jest test file `__tests__/middle/router/media/setRouterApiMediaPost.test.js` and the supporting testcase markdown; tests are executed via the project test runner (e.g. `npm test`).  
- All tests in the new suite passed when run locally against the implemented middleware.  
- The test suite validates both success and multiple failure modes (authentication failure, invalid contents, save mismatch, empty title, repository exception, and invalid initializers).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1b48bc5d8832b9b260000b2ab416c)