### PR TITLE
UUIDMediaIdValueGeneratorを追加しUUIDベースのメディアID生成を実装

### DIFF
--- a/__tests__/small/infrastructure/UUIDMediaIdValueGenerator.test.js
+++ b/__tests__/small/infrastructure/UUIDMediaIdValueGenerator.test.js
@@ -1,0 +1,20 @@
+const UUIDMediaIdValueGenerator = require('../../../src/infrastructure/UUIDMediaIdValueGenerator');
+
+describe('UUIDMediaIdValueGenerator', () => {
+  test('generate はハイフンなし 32 文字の UUID を返す', () => {
+    const generator = new UUIDMediaIdValueGenerator();
+
+    const actual = generator.generate();
+
+    expect(actual).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  test('generate は呼び出しごとに異なる値を返す', () => {
+    const generator = new UUIDMediaIdValueGenerator();
+
+    const first = generator.generate();
+    const second = generator.generate();
+
+    expect(first).not.toBe(second);
+  });
+});

--- a/doc/7_infrastructure/UUIDMediaIdValueGenerator/readme.md
+++ b/doc/7_infrastructure/UUIDMediaIdValueGenerator/readme.md
@@ -1,0 +1,22 @@
+# UUIDMediaIdValueGenerator 設計書
+
+## 概要
+`UUIDMediaIdValueGenerator` は `IMediaIdValueGenerator` の具象実装です。  
+`crypto.randomUUID()` で UUID をランダム生成し、ハイフンを除去した 32 文字の文字列をメディア ID 値として返します。
+
+## クラス
+- 配置: `src/infrastructure/UUIDMediaIdValueGenerator.js`
+- クラス名: `UUIDMediaIdValueGenerator`
+- 継承: `IMediaIdValueGenerator`
+
+## 公開メソッド
+- `generate()`
+  - `crypto.randomUUID()` で UUID を生成する
+  - 生成文字列から `-` を除去し、32 文字の 16 進文字列を返す
+
+## 生成方針
+- 返却値の形式は `^[0-9a-f]{32}$` とする
+- 呼び出しごとに新しい UUID を生成する
+
+## エラー方針
+- UUID 生成で発生した例外は握り潰さず上位へ伝播する

--- a/doc/7_infrastructure/UUIDMediaIdValueGenerator/testcase.md
+++ b/doc/7_infrastructure/UUIDMediaIdValueGenerator/testcase.md
@@ -1,0 +1,24 @@
+# UUIDMediaIdValueGenerator テストケース
+
+## テストケース一覧
+- [generate はハイフンなし 32 文字の UUID を返す](#generate-はハイフンなし-32-文字の-uuid-を返す)
+- [generate は呼び出しごとに異なる値を返す](#generate-は呼び出しごとに異なる値を返す)
+
+---
+
+### generate はハイフンなし 32 文字の UUID を返す
+- 前提
+  - `UUIDMediaIdValueGenerator` のインスタンスが生成済みである
+- 操作
+  - `generate()` を実行する
+- 期待結果
+  - 返却値が `^[0-9a-f]{32}$` に一致する
+  - 返却値にハイフンが含まれない
+
+### generate は呼び出しごとに異なる値を返す
+- 前提
+  - `UUIDMediaIdValueGenerator` のインスタンスが生成済みである
+- 操作
+  - `generate()` を 2 回実行する
+- 期待結果
+  - 1 回目と 2 回目の返却値が異なる

--- a/src/infrastructure/UUIDMediaIdValueGenerator.js
+++ b/src/infrastructure/UUIDMediaIdValueGenerator.js
@@ -1,0 +1,9 @@
+const { randomUUID } = require('crypto');
+
+const IMediaIdValueGenerator = require('../domain/media/IMediaIdValueGenerator');
+
+module.exports = class UUIDMediaIdValueGenerator extends IMediaIdValueGenerator {
+  generate() {
+    return randomUUID().replace(/-/g, '');
+  }
+};


### PR DESCRIPTION
### Motivation
- `IMediaIdValueGenerator` の具象実装が必要であったため、ランダムで一意なメディアIDを生成する実装を追加する目的で変更しました。 
- メディアIDは外部との衝突リスクを下げるため UUID を利用し、システム内で扱いやすいようハイフンを除去した 32 文字形式に揃える方針としました。

### Description
- 新規クラス `UUIDMediaIdValueGenerator` を `src/infrastructure/UUIDMediaIdValueGenerator.js` に追加し、`IMediaIdValueGenerator` を継承して `generate()` を実装しました。
- `generate()` は `crypto.randomUUID()` を用いて UUID を生成し、`replace(/-/g, '')` でハイフンを除去した 32 文字の文字列を返却します。 
- ユニットテストを `__tests__/small/infrastructure/UUIDMediaIdValueGenerator.test.js` に追加し、返却形式が `^[0-9a-f]{32}$` に一致することと連続呼び出しで一意になることを検証しました。 
- 設計書・テストケースを `doc/7_infrastructure/UUIDMediaIdValueGenerator/readme.md` と `doc/7_infrastructure/UUIDMediaIdValueGenerator/testcase.md` に追加し、実装方針と期待挙動を明記しました（ファイルは CRLF で作成）。

### Testing
- `npm test -- __tests__/small/infrastructure/UUIDMediaIdValueGenerator.test.js` を実行し、該当テストはすべて成功しました（Test Suites: 1 passed, Tests: 2 passed）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2f0c90af4832b982ec9b2e436ce47)