### PR TITLE
test: SequelizeUnitOfWorkの設計書とテストコードを追加する

### DIFF
--- a/__tests__/middle/infrastructure/SequelizeUnitOfWork.test.js
+++ b/__tests__/middle/infrastructure/SequelizeUnitOfWork.test.js
@@ -1,0 +1,69 @@
+const SequelizeUnitOfWork = require('../../../src/infrastructure/SequelizeUnitOfWork');
+
+describe('SequelizeUnitOfWork', () => {
+  test('run で開始した実行文脈内では getCurrent でトランザクションを取得できる', async () => {
+    const executionScope = { id: 'tx-1' };
+    const sequelize = {
+      transaction: async work => work(executionScope),
+    };
+    const unitOfWork = new SequelizeUnitOfWork({ sequelize });
+
+    await unitOfWork.run(async () => {
+      expect(unitOfWork.getCurrent()).toBe(executionScope);
+    });
+  });
+
+  test('run 実行文脈の外では getCurrent は null を返す', async () => {
+    const sequelize = {
+      transaction: async work => work({ id: 'tx-1' }),
+    };
+    const unitOfWork = new SequelizeUnitOfWork({ sequelize });
+
+    expect(unitOfWork.getCurrent()).toBeNull();
+
+    await unitOfWork.run(async () => {
+      expect(unitOfWork.getCurrent()).not.toBeNull();
+    });
+
+    expect(unitOfWork.getCurrent()).toBeNull();
+  });
+
+  test('run 内で例外が発生した場合は rollback され例外が再送出される', async () => {
+    const state = { committed: false, rolledBack: false };
+    const sequelize = {
+      transaction: async work => {
+        const executionScope = { id: 'tx-1' };
+
+        try {
+          const result = await work(executionScope);
+          state.committed = true;
+          return result;
+        } catch (error) {
+          state.rolledBack = true;
+          throw error;
+        }
+      },
+    };
+    const unitOfWork = new SequelizeUnitOfWork({ sequelize });
+
+    await expect(unitOfWork.run(async () => {
+      throw new Error('rollback');
+    })).rejects.toThrow('rollback');
+
+    expect(state.committed).toBe(false);
+    expect(state.rolledBack).toBe(true);
+  });
+
+  test('constructor は transaction 関数を持たない sequelize を受け取ると例外を送出する', () => {
+    expect(() => new SequelizeUnitOfWork({ sequelize: {} })).toThrow(Error);
+  });
+
+  test('run は関数以外の引数を受け取ると例外を送出する', async () => {
+    const sequelize = {
+      transaction: async work => work({ id: 'tx-1' }),
+    };
+    const unitOfWork = new SequelizeUnitOfWork({ sequelize });
+
+    await expect(unitOfWork.run('not-function')).rejects.toThrow(Error);
+  });
+});

--- a/doc/7_infrastructure/SequelizeUnitOfWork/readme.md
+++ b/doc/7_infrastructure/SequelizeUnitOfWork/readme.md
@@ -1,0 +1,31 @@
+# SequelizeUnitOfWork 設計書
+
+## 概要
+`SequelizeUnitOfWork` は、Sequelize のトランザクションと `AsyncLocalStorage` を組み合わせて、アプリケーションサービス境界で開始した実行文脈をインフラ層から参照可能にするクラスです。  
+Repository は `getCurrent()` で現在の実行文脈（トランザクション）を取得し、同一文脈に参加して永続化処理を行います。
+
+## クラス
+- 配置: `src/infrastructure/SequelizeUnitOfWork.js`
+- クラス名: `SequelizeUnitOfWork`
+
+## 公開メソッド
+- `run(work)`
+  - Sequelize のトランザクションを開始し、`work` を実行する
+  - 実行中のトランザクションを `AsyncLocalStorage` に保持する
+  - `work` が例外を送出した場合はロールバックされ、例外を上位へ伝播する
+- `getCurrent()`
+  - 現在の実行文脈に紐づくトランザクションを返す
+  - 実行文脈外では `null` を返す
+
+## 初期化方針
+- `constructor({ sequelize })` は `sequelize.transaction` 関数の存在を必須とする
+- `sequelize` が不正な場合は `Error` を送出する
+
+## 実行文脈方針
+- `run(work)` の中で `getCurrent()` を呼ぶと、同一トランザクションオブジェクトを取得できる
+- `run(work)` 実行後に `getCurrent()` を呼ぶと `null` になる
+- `work` 引数が関数でない場合は `Error` を送出する
+
+## エラー方針
+- 引数バリデーション違反（`sequelize` 不正 / `work` 不正）は `Error` を送出する
+- `work` 内の例外は握り潰さず上位へ再送出する

--- a/doc/7_infrastructure/SequelizeUnitOfWork/testcase.md
+++ b/doc/7_infrastructure/SequelizeUnitOfWork/testcase.md
@@ -1,0 +1,51 @@
+# SequelizeUnitOfWork テストケース
+
+## テストケース一覧
+- [run で開始した実行文脈内では getCurrent でトランザクションを取得できる](#run-で開始した実行文脈内では-getcurrent-でトランザクションを取得できる)
+- [run 実行文脈の外では getCurrent は null を返す](#run-実行文脈の外では-getcurrent-は-null-を返す)
+- [run 内で例外が発生した場合は rollback され例外が再送出される](#run-内で例外が発生した場合は-rollback-され例外が再送出される)
+- [constructor は transaction 関数を持たない sequelize を受け取ると例外を送出する](#constructor-は-transaction-関数を持たない-sequelize-を受け取ると例外を送出する)
+- [run は関数以外の引数を受け取ると例外を送出する](#run-は関数以外の引数を受け取ると例外を送出する)
+
+---
+
+### run で開始した実行文脈内では getCurrent でトランザクションを取得できる
+- 前提
+  - `SequelizeUnitOfWork` が有効な Sequelize で生成済みである
+- 操作
+  - `run(async () => { ... })` を実行し、コールバック内で `getCurrent()` を呼ぶ
+- 期待結果
+  - `getCurrent()` が `null` ではないトランザクションオブジェクトを返す
+
+### run 実行文脈の外では getCurrent は null を返す
+- 前提
+  - `SequelizeUnitOfWork` が生成済みである
+- 操作
+  - `run` 実行前後に `getCurrent()` を呼ぶ
+- 期待結果
+  - いずれも `null` が返る
+
+### run 内で例外が発生した場合は rollback され例外が再送出される
+- 前提
+  - `SequelizeUnitOfWork` が有効な Sequelize で生成済みである
+- 操作
+  - `run` のコールバック内で SQL を実行した後、意図的に例外を送出する
+- 期待結果
+  - `run` 呼び出しは例外で reject される
+  - トランザクションは rollback され、保存したデータは残らない
+
+### constructor は transaction 関数を持たない sequelize を受け取ると例外を送出する
+- 前提
+  - なし
+- 操作
+  - `new SequelizeUnitOfWork({ sequelize: {} })` を実行する
+- 期待結果
+  - `Error` が送出される
+
+### run は関数以外の引数を受け取ると例外を送出する
+- 前提
+  - `SequelizeUnitOfWork` が生成済みである
+- 操作
+  - `run` に関数以外の値を渡して実行する
+- 期待結果
+  - `Error` が送出される


### PR DESCRIPTION
### Motivation

- `SequelizeUnitOfWork` の振る舞い（トランザクション文脈の提供・取得、例外時のロールバック、引数バリデーション）を明文化して回帰を防止するために設計書とテストを追加する必要があった。

### Description

- `doc/7_infrastructure/SequelizeUnitOfWork/readme.md` を追加し、クラスの責務・公開メソッド・初期化方針・実行文脈方針・エラー方針を整理した。
- `doc/7_infrastructure/SequelizeUnitOfWork/testcase.md` を追加し、主要な検証観点をテストケースとして定義した。
- `__tests__/middle/infrastructure/SequelizeUnitOfWork.test.js` を追加し、`run` と `getCurrent` の文脈動作、例外時のロールバック相当動作、引数バリデーションを検証する5件のテストを実装した（`sequelize.transaction` をモック化して DB 依存を排除）。
- 追加したドキュメント・テストは指定どおり CRLF 改行で作成した。

### Testing

- `npm test -- __tests__/middle/infrastructure/SequelizeUnitOfWork.test.js` を実行し、最終的に全テストが通過して `5 passed` を確認した。 
- 当初、実 DB（`sqlite3`）を用いる試行でバイナリ読み込みエラーが発生したため、テストをモック化して依存性を排除し再実行して成功させた。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2f16e7970832b84ef1713a4587478)