### PR TITLE
feat: ContentSaveMiddleware向けcontentStorage resolverのインターフェースを追加

### DIFF
--- a/doc/5_api/controller/middleware/resolver/IContentStorageResolver.md
+++ b/doc/5_api/controller/middleware/resolver/IContentStorageResolver.md
@@ -1,0 +1,37 @@
+# IContentStorageResolver
+
+## 概要
+`ContentSaveMiddleware` が受け取る `contentStorage`（resolver）のインターフェース。
+
+`contents` を保存し、保存順に対応した `contentIds` を返す責務を持つ。
+
+---
+
+## 機能
+### コンテンツ保存
+受け取ったコンテンツ配列を保存し、保存結果のコンテンツID配列を返す。
+
+#### メソッド
+- `async save(contents)`
+
+#### 入力
+```plantuml
+left to right direction
+
+struct ContentInput #pink {
+  + file : any
+  + position : number
+}
+```
+
+- `contents: array<ContentInput>`
+  - `ContentSaveMiddleware` 側で `position` 昇順に整列済みの配列を受け取る。
+
+#### 出力
+- `Promise<array<string>>`
+  - `contentIds[n]` は、入力 `contents[n]` に対応する保存済みコンテンツID。
+
+#### 例外
+- 保存に失敗した場合は例外を送出する。
+
+---

--- a/src/controller/middleware/resolver/IContentStorageResolver.js
+++ b/src/controller/middleware/resolver/IContentStorageResolver.js
@@ -1,0 +1,5 @@
+module.exports = class IContentStorageResolver {
+  async save() {
+    throw new Error();
+  }
+};


### PR DESCRIPTION
### Motivation
- `ContentSaveMiddleware` に渡す `contentStorage` の契約を明示して実装差し替えや認識ズレを防止するため。

### Description
- `src/controller/middleware/resolver/IContentStorageResolver.js` に `async save()` を定義したインターフェースクラスを追加し、`doc/5_api/controller/middleware/resolver/IContentStorageResolver.md` に責務・入力・出力・例外仕様を記述しました。

### Testing
- インターフェースのみの追加のため自動テストは追加しておらず、`git add`/`git commit` とファイル内容確認（`nl`/`git status` 等）を実行し成功しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b306be2970832bbe6b92cd5e601753)