### PR TITLE
MulterContentStorageResolverを追加しUUIDベースのcontentId付与を実装

### DIFF
--- a/__tests__/middle/infrastructure/MulterContentStorageResolver.test.js
+++ b/__tests__/middle/infrastructure/MulterContentStorageResolver.test.js
@@ -1,0 +1,55 @@
+const express = require('express');
+const multer = require('multer');
+const request = require('supertest');
+const MulterContentStorageResolver = require('../../../src/infrastructure/MulterContentStorageResolver');
+
+describe('MulterContentStorageResolver', () => {
+  test('constructor: multer() の戻り値以外はエラーになる', () => {
+    expect(() => new MulterContentStorageResolver()).toThrow('multer() の戻り値を指定してください。');
+    expect(() => new MulterContentStorageResolver({})).toThrow('multer() の戻り値を指定してください。');
+  });
+
+  test('resolveSingle: contents のアップロード時に filename/contentId を UUID(ハイフン無し)で設定する', async () => {
+    const app = express();
+    const uploader = multer({ storage: multer.memoryStorage() });
+    const resolver = new MulterContentStorageResolver(uploader);
+
+    app.post('/upload', resolver.resolveSingle('contents'), (req, res) => {
+      res.status(200).json({
+        contentId: req.contentId,
+        filename: req.file && req.file.filename,
+        fileContentId: req.file && req.file.contentId,
+      });
+    });
+
+    const response = await request(app)
+      .post('/upload')
+      .attach('contents', Buffer.from('dummy data'), 'sample.txt');
+
+    expect(response.status).toBe(200);
+    expect(response.body.contentId).toMatch(/^[0-9a-f]{32}$/);
+    expect(response.body.filename).toBe(response.body.contentId);
+    expect(response.body.fileContentId).toBe(response.body.contentId);
+  });
+
+  test('resolveSingle: 対象フィールドにファイルが無い場合は contentId を設定しない', async () => {
+    const app = express();
+    const uploader = multer({ storage: multer.memoryStorage() });
+    const resolver = new MulterContentStorageResolver(uploader);
+
+    app.post('/upload', resolver.resolveSingle('contents'), (req, res) => {
+      res.status(200).json({
+        contentId: req.contentId || null,
+        hasFile: Boolean(req.file),
+      });
+    });
+
+    const response = await request(app)
+      .post('/upload')
+      .field('title', 'no-file');
+
+    expect(response.status).toBe(200);
+    expect(response.body.hasFile).toBe(false);
+    expect(response.body.contentId).toBeNull();
+  });
+});

--- a/doc/7_infrastructure/MulterContentStorageResolver/readme.md
+++ b/doc/7_infrastructure/MulterContentStorageResolver/readme.md
@@ -1,0 +1,26 @@
+# MulterContentStorageResolver 設計書
+
+## 目的
+`IContentStorageResolver.js` の具象クラスとして、`multer()` の戻り値を利用したアップロード処理を提供する。
+
+## クラス
+- クラス名: `MulterContentStorageResolver`
+- 配置: `src/infrastructure/MulterContentStorageResolver.js`
+
+## 入力仕様
+- コンストラクタは `multer()` の戻り値を受け取る。
+- `multer()` の戻り値でない場合はエラーを送出する。
+
+## 振る舞い
+- `resolveSingle(fieldName = 'contents')` で単一ファイルアップロード用の Express ミドルウェアを返す。
+- `fieldName` に対応するファイルがアップロードされた場合、以下を設定する。
+  - `contentId`: `UUID` のハイフンを除去した32文字の文字列
+  - `req.file.filename`: `contentId` と同じ値
+  - `req.file.contentId`: `contentId` と同じ値
+  - `req.contentId`: `contentId` と同じ値
+- `fieldName` にファイルが存在しない場合は `contentId` を設定しない。
+
+## 設計判断
+- UUID生成は Node.js 標準の `crypto.randomUUID()` を利用し、外部依存を増やさない。
+- `multer.memoryStorage()` でもファイル名情報を扱えるよう、`req.file` に `filename` / `contentId` を付与する。
+- 生成した `contentId` を `req` にも載せることで、後続処理の実装を簡素化する。

--- a/doc/7_infrastructure/MulterContentStorageResolver/testcase.md
+++ b/doc/7_infrastructure/MulterContentStorageResolver/testcase.md
@@ -1,0 +1,26 @@
+# MulterContentStorageResolver テストケース
+
+## 前提
+- `multer.memoryStorage()` を使ってテストする。
+- HTTP レイヤーを通した実挙動確認のため、Express + Supertest で検証する。
+
+## テストケース一覧
+
+### TC-01: コンストラクタ異常系
+- 条件: `multer()` の戻り値以外（`undefined`, `{}`）を渡す
+- 期待値: `multer() の戻り値を指定してください。` エラーを送出する
+
+### TC-02: contents アップロード正常系
+- 条件: `resolveSingle('contents')` で `contents` フィールドに1ファイルを送信
+- 期待値:
+  - ステータス `200`
+  - `contentId` はハイフン無し UUID（32桁16進文字列）
+  - `filename === contentId`
+  - `fileContentId === contentId`
+
+### TC-03: ファイル未送信時の正常系
+- 条件: `resolveSingle('contents')` に対してファイルなしで送信
+- 期待値:
+  - ステータス `200`
+  - `req.file` は未設定（`hasFile === false`）
+  - `contentId` は未設定（`null` で返却）

--- a/package.json
+++ b/package.json
@@ -4,14 +4,17 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "express": "^4.18.1"
+    "express": "^4.18.1",
+    "multer": "^1.4.5-lts.2"
   },
   "devDependencies": {
-    "aglio": "^2.3.0"
+    "aglio": "^2.3.0",
+    "jest": "^29.7.0",
+    "supertest": "^7.0.0"
   }
 }

--- a/src/infrastructure/MulterContentStorageResolver.js
+++ b/src/infrastructure/MulterContentStorageResolver.js
@@ -1,0 +1,33 @@
+const { randomUUID } = require('crypto');
+
+class MulterContentStorageResolver {
+  constructor(multerInstance) {
+    if (!multerInstance || typeof multerInstance.single !== 'function') {
+      throw new Error('multer() の戻り値を指定してください。');
+    }
+
+    this.multerInstance = multerInstance;
+  }
+
+  resolveSingle(fieldName = 'contents') {
+    return (req, res, next) => {
+      this.multerInstance.single(fieldName)(req, res, (error) => {
+        if (error) {
+          next(error);
+          return;
+        }
+
+        if (req.file) {
+          const contentId = randomUUID().replace(/-/g, '');
+          req.file.filename = contentId;
+          req.file.contentId = contentId;
+          req.contentId = contentId;
+        }
+
+        next();
+      });
+    };
+  }
+}
+
+module.exports = MulterContentStorageResolver;


### PR DESCRIPTION
### Motivation
- `IContentStorageResolver` の具象実装として `multer()` を利用したアップロード処理を実装し、アップロードファイルに一意の `contentId` を付与する必要があったため。
- ファイル名とコンテンツIDを統一したフォーマット（UUIDのハイフン除去）にすることで後続処理の参照を簡素化する意図があるため。

### Description
- `src/infrastructure/MulterContentStorageResolver.js` を追加し、コンストラクタで `multer()` の戻り値を受け取り `resolveSingle(fieldName)` で Express ミドルウェアを返す実装を追加した。 
- ミドルウェアは `req.file` が存在する場合に `crypto.randomUUID()` で生成した UUID のハイフンを除去した文字列を `req.file.filename`、`req.file.contentId`、`req.contentId` に設定する仕様を実装した。 
- ドキュメントを `doc/7_infrastructure/MulterContentStorageResolver/readme.md` に追加し設計意図と振る舞いを明文化した。 
- テストケース仕様を `doc/7_infrastructure/MulterContentStorageResolver/testcase.md` に追加し、`__tests__/middle/infrastructure/MulterContentStorageResolver.test.js` に Express + `multer.memoryStorage()` + `supertest` を使った自動テストを追加した。 
- `package.json` の `test` スクリプトを `jest` に変更し、`multer`/`jest`/`supertest` を依存に追加した。 

### Testing
- `node --check src/infrastructure/MulterContentStorageResolver.js` を実行し構文チェックは成功した。 
- `node --check __tests__/middle/infrastructure/MulterContentStorageResolver.test.js` を実行し構文チェックは成功した。 
- `npm install` はレジストリアクセス制限により `403 Forbidden` となり依存取得に失敗したため自動テストフレームワークの実行はできなかった。 
- `npm test` は `jest: not found` により実行できなかった（上記依存取得失敗が原因）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b406d4ee24832b89daafd9342d32fb)