### PR TITLE
Add session state infrastructure (InMemory store, registrar, auth resolver) with unit tests

### DIFF
--- a/__tests__/small/infrastructure/InMemorySessionStateStore.test.js
+++ b/__tests__/small/infrastructure/InMemorySessionStateStore.test.js
@@ -1,0 +1,73 @@
+const InMemorySessionStateStore = require('../../../src/infrastructure/InMemorySessionStateStore');
+
+describe('InMemorySessionStateStore', () => {
+  let now;
+  let store;
+
+  beforeEach(() => {
+    now = 1700000000000;
+    store = new InMemorySessionStateStore({
+      clock: () => now,
+    });
+  });
+
+  test('save したセッショントークンから userId を取得できる', () => {
+    store.save({
+      sessionToken: 'token-1',
+      userId: 'u1',
+      ttlMs: 30000,
+    });
+
+    expect(store.findUserIdBySessionToken('token-1')).toBe('u1');
+  });
+
+  test('TTL を過ぎたセッションは取得時に自動削除される', () => {
+    store.save({
+      sessionToken: 'token-1',
+      userId: 'u1',
+      ttlMs: 1000,
+    });
+
+    now += 1000;
+
+    expect(store.findUserIdBySessionToken('token-1')).toBeUndefined();
+  });
+
+  test('delete は対象セッションを削除できる', () => {
+    store.save({
+      sessionToken: 'token-1',
+      userId: 'u1',
+      ttlMs: 30000,
+    });
+
+    expect(store.delete('token-1')).toBe(true);
+    expect(store.findUserIdBySessionToken('token-1')).toBeUndefined();
+  });
+
+  test('purgeExpired は期限切れセッションのみ削除する', () => {
+    store.save({
+      sessionToken: 'token-1',
+      userId: 'u1',
+      ttlMs: 1000,
+    });
+    store.save({
+      sessionToken: 'token-2',
+      userId: 'u2',
+      ttlMs: 5000,
+    });
+
+    now += 1001;
+    store.purgeExpired();
+
+    expect(store.findUserIdBySessionToken('token-1')).toBeUndefined();
+    expect(store.findUserIdBySessionToken('token-2')).toBe('u2');
+  });
+
+  test.each([
+    [{ sessionToken: '', userId: 'u1', ttlMs: 1000 }, 'sessionToken'],
+    [{ sessionToken: 'token-1', userId: '', ttlMs: 1000 }, 'userId'],
+    [{ sessionToken: 'token-1', userId: 'u1', ttlMs: 0 }, 'ttlMs'],
+  ])('save の入力が不正な場合は例外となる: %s', (payload, expectedMessage) => {
+    expect(() => store.save(payload)).toThrow(expectedMessage);
+  });
+});

--- a/__tests__/small/infrastructure/SessionStateAuthResolver.test.js
+++ b/__tests__/small/infrastructure/SessionStateAuthResolver.test.js
@@ -1,0 +1,23 @@
+const SessionStateAuthResolver = require('../../../src/infrastructure/SessionStateAuthResolver');
+
+describe('SessionStateAuthResolver', () => {
+  test('execute は sessionToken に紐づく userId を返す', async () => {
+    const sessionStateStore = {
+      findUserIdBySessionToken: jest.fn().mockReturnValue('u1'),
+    };
+    const resolver = new SessionStateAuthResolver({
+      sessionStateStore,
+    });
+
+    await expect(resolver.execute('token-1')).resolves.toBe('u1');
+    expect(sessionStateStore.findUserIdBySessionToken).toHaveBeenCalledWith('token-1');
+  });
+
+  test('sessionStateStore が不正な場合は初期化時に例外となる', () => {
+    expect(() => {
+      new SessionStateAuthResolver({
+        sessionStateStore: {},
+      });
+    }).toThrow('sessionStateStore.findUserIdBySessionToken');
+  });
+});

--- a/__tests__/small/infrastructure/SessionStateRegistrar.test.js
+++ b/__tests__/small/infrastructure/SessionStateRegistrar.test.js
@@ -1,7 +1,7 @@
 const SessionStateRegistrar = require('../../../src/infrastructure/SessionStateRegistrar');
 
 describe('SessionStateRegistrar', () => {
-  test('ログイン成功時に session へ session_token を保存しストア登録できる', () => {
+  test('ログイン成功時に session へ session_token を保存しストア登録できる', async () => {
     const sessionStateStore = {
       save: jest.fn().mockReturnValue({
         sessionToken: 'token-1',
@@ -15,7 +15,7 @@ describe('SessionStateRegistrar', () => {
     });
     const session = {};
 
-    const actual = registrar.execute({
+    const actual = await registrar.execute({
       session,
       userId: 'u1',
       ttlMs: 30000,
@@ -37,7 +37,7 @@ describe('SessionStateRegistrar', () => {
   test.each([
     [{ session: null, userId: 'u1', ttlMs: 30000 }, 'session must be an object'],
     [{ session: {}, userId: '', ttlMs: 30000 }, 'userId must be a non-empty string'],
-  ])('execute の入力が不正な場合は例外となる: %s', (payload, expectedMessage) => {
+  ])('execute の入力が不正な場合は例外となる: %s', async (payload, expectedMessage) => {
     const registrar = new SessionStateRegistrar({
       sessionStateStore: {
         save: jest.fn(),
@@ -45,10 +45,10 @@ describe('SessionStateRegistrar', () => {
       sessionTokenGenerator: jest.fn().mockReturnValue('token-1'),
     });
 
-    expect(() => registrar.execute(payload)).toThrow(expectedMessage);
+    await expect(registrar.execute(payload)).rejects.toThrow(expectedMessage);
   });
 
-  test('sessionTokenGenerator が空文字を返す場合は例外となる', () => {
+  test('sessionTokenGenerator が空文字を返す場合は例外となる', async () => {
     const registrar = new SessionStateRegistrar({
       sessionStateStore: {
         save: jest.fn(),
@@ -56,12 +56,64 @@ describe('SessionStateRegistrar', () => {
       sessionTokenGenerator: jest.fn().mockReturnValue(''),
     });
 
-    expect(() => {
-      registrar.execute({
-        session: {},
-        userId: 'u1',
-        ttlMs: 30000,
-      });
-    }).toThrow('sessionToken must be a non-empty string');
+    await expect(registrar.execute({
+      session: {},
+      userId: 'u1',
+      ttlMs: 30000,
+    })).rejects.toThrow('sessionToken must be a non-empty string');
+  });
+
+  test('非同期ストア保存の完了後に session_token を更新する', async () => {
+    let resolveSave;
+    const savePromise = new Promise((resolve) => {
+      resolveSave = resolve;
+    });
+    const sessionStateStore = {
+      save: jest.fn().mockReturnValue(savePromise),
+    };
+    const registrar = new SessionStateRegistrar({
+      sessionStateStore,
+      sessionTokenGenerator: jest.fn().mockReturnValue('token-async'),
+    });
+    const session = {};
+
+    const executePromise = registrar.execute({
+      session,
+      userId: 'u1',
+      ttlMs: 30000,
+    });
+
+    expect(session.session_token).toBeUndefined();
+
+    resolveSave({
+      sessionToken: 'token-async',
+      userId: 'u1',
+      expiresAt: 1700000030000,
+    });
+
+    await expect(executePromise).resolves.toEqual({
+      sessionToken: 'token-async',
+      userId: 'u1',
+      expiresAt: 1700000030000,
+    });
+    expect(session.session_token).toBe('token-async');
+  });
+
+  test('非同期ストア保存が失敗した場合は session_token を更新しない', async () => {
+    const sessionStateStore = {
+      save: jest.fn().mockRejectedValue(new Error('save failed')),
+    };
+    const registrar = new SessionStateRegistrar({
+      sessionStateStore,
+      sessionTokenGenerator: jest.fn().mockReturnValue('token-async'),
+    });
+    const session = {};
+
+    await expect(registrar.execute({
+      session,
+      userId: 'u1',
+      ttlMs: 30000,
+    })).rejects.toThrow('save failed');
+    expect(session.session_token).toBeUndefined();
   });
 });

--- a/__tests__/small/infrastructure/SessionStateRegistrar.test.js
+++ b/__tests__/small/infrastructure/SessionStateRegistrar.test.js
@@ -108,6 +108,48 @@ describe('SessionStateRegistrar', () => {
     expect(session.session_token).toBe('token-async');
   });
 
+
+  test('express-session のように regenerate 後に req.session が差し替わる場合は新しい session に session_token を保存する', async () => {
+    const newSession = {};
+    let regenerateSession;
+    const session = {
+      req: {
+        session: null,
+      },
+      regenerate: jest.fn((callback) => {
+        regenerateSession = callback;
+      }),
+    };
+    const sessionStateStore = {
+      save: jest.fn().mockResolvedValue({
+        sessionToken: 'token-rotated',
+        userId: 'u1',
+        expiresAt: 1700000030000,
+      }),
+    };
+    const registrar = new SessionStateRegistrar({
+      sessionStateStore,
+      sessionTokenGenerator: jest.fn().mockReturnValue('token-rotated'),
+    });
+
+    const executePromise = registrar.execute({
+      session,
+      userId: 'u1',
+      ttlMs: 30000,
+    });
+
+    session.req.session = newSession;
+    regenerateSession();
+
+    await expect(executePromise).resolves.toEqual({
+      sessionToken: 'token-rotated',
+      userId: 'u1',
+      expiresAt: 1700000030000,
+    });
+    expect(newSession.session_token).toBe('token-rotated');
+    expect(session.session_token).toBeUndefined();
+  });
+
   test('セッション再生成が失敗した場合はストア保存と session_token 更新を行わない', async () => {
     const sessionStateStore = {
       save: jest.fn(),

--- a/__tests__/small/infrastructure/SessionStateRegistrar.test.js
+++ b/__tests__/small/infrastructure/SessionStateRegistrar.test.js
@@ -1,7 +1,11 @@
 const SessionStateRegistrar = require('../../../src/infrastructure/SessionStateRegistrar');
 
 describe('SessionStateRegistrar', () => {
-  test('ログイン成功時に session へ session_token を保存しストア登録できる', async () => {
+  const createSession = () => ({
+    regenerate: jest.fn((callback) => callback()),
+  });
+
+  test('ログイン成功時にセッションIDをローテーションして session へ session_token を保存しストア登録できる', async () => {
     const sessionStateStore = {
       save: jest.fn().mockReturnValue({
         sessionToken: 'token-1',
@@ -13,7 +17,7 @@ describe('SessionStateRegistrar', () => {
       sessionStateStore,
       sessionTokenGenerator: jest.fn().mockReturnValue('token-1'),
     });
-    const session = {};
+    const session = createSession();
 
     const actual = await registrar.execute({
       session,
@@ -21,6 +25,7 @@ describe('SessionStateRegistrar', () => {
       ttlMs: 30000,
     });
 
+    expect(session.regenerate).toHaveBeenCalledTimes(1);
     expect(sessionStateStore.save).toHaveBeenCalledWith({
       sessionToken: 'token-1',
       userId: 'u1',
@@ -36,7 +41,8 @@ describe('SessionStateRegistrar', () => {
 
   test.each([
     [{ session: null, userId: 'u1', ttlMs: 30000 }, 'session must be an object'],
-    [{ session: {}, userId: '', ttlMs: 30000 }, 'userId must be a non-empty string'],
+    [{ session: {}, userId: 'u1', ttlMs: 30000 }, 'session.regenerate must be a function'],
+    [{ session: createSession(), userId: '', ttlMs: 30000 }, 'userId must be a non-empty string'],
   ])('execute の入力が不正な場合は例外となる: %s', async (payload, expectedMessage) => {
     const registrar = new SessionStateRegistrar({
       sessionStateStore: {
@@ -57,25 +63,30 @@ describe('SessionStateRegistrar', () => {
     });
 
     await expect(registrar.execute({
-      session: {},
+      session: createSession(),
       userId: 'u1',
       ttlMs: 30000,
     })).rejects.toThrow('sessionToken must be a non-empty string');
   });
 
-  test('非同期ストア保存の完了後に session_token を更新する', async () => {
-    let resolveSave;
-    const savePromise = new Promise((resolve) => {
-      resolveSave = resolve;
-    });
+  test('セッション再生成の完了後にストア保存と session_token 更新を行う', async () => {
+    let regenerateSession;
+    const session = {
+      regenerate: jest.fn((callback) => {
+        regenerateSession = callback;
+      }),
+    };
     const sessionStateStore = {
-      save: jest.fn().mockReturnValue(savePromise),
+      save: jest.fn().mockResolvedValue({
+        sessionToken: 'token-async',
+        userId: 'u1',
+        expiresAt: 1700000030000,
+      }),
     };
     const registrar = new SessionStateRegistrar({
       sessionStateStore,
       sessionTokenGenerator: jest.fn().mockReturnValue('token-async'),
     });
-    const session = {};
 
     const executePromise = registrar.execute({
       session,
@@ -83,20 +94,39 @@ describe('SessionStateRegistrar', () => {
       ttlMs: 30000,
     });
 
+    expect(sessionStateStore.save).not.toHaveBeenCalled();
     expect(session.session_token).toBeUndefined();
 
-    resolveSave({
-      sessionToken: 'token-async',
-      userId: 'u1',
-      expiresAt: 1700000030000,
-    });
+    regenerateSession();
 
     await expect(executePromise).resolves.toEqual({
       sessionToken: 'token-async',
       userId: 'u1',
       expiresAt: 1700000030000,
     });
+    expect(sessionStateStore.save).toHaveBeenCalledTimes(1);
     expect(session.session_token).toBe('token-async');
+  });
+
+  test('セッション再生成が失敗した場合はストア保存と session_token 更新を行わない', async () => {
+    const sessionStateStore = {
+      save: jest.fn(),
+    };
+    const registrar = new SessionStateRegistrar({
+      sessionStateStore,
+      sessionTokenGenerator: jest.fn().mockReturnValue('token-async'),
+    });
+    const session = {
+      regenerate: jest.fn((callback) => callback(new Error('regenerate failed'))),
+    };
+
+    await expect(registrar.execute({
+      session,
+      userId: 'u1',
+      ttlMs: 30000,
+    })).rejects.toThrow('regenerate failed');
+    expect(sessionStateStore.save).not.toHaveBeenCalled();
+    expect(session.session_token).toBeUndefined();
   });
 
   test('非同期ストア保存が失敗した場合は session_token を更新しない', async () => {
@@ -107,7 +137,7 @@ describe('SessionStateRegistrar', () => {
       sessionStateStore,
       sessionTokenGenerator: jest.fn().mockReturnValue('token-async'),
     });
-    const session = {};
+    const session = createSession();
 
     await expect(registrar.execute({
       session,

--- a/__tests__/small/infrastructure/SessionStateRegistrar.test.js
+++ b/__tests__/small/infrastructure/SessionStateRegistrar.test.js
@@ -1,0 +1,67 @@
+const SessionStateRegistrar = require('../../../src/infrastructure/SessionStateRegistrar');
+
+describe('SessionStateRegistrar', () => {
+  test('ログイン成功時に session へ session_token を保存しストア登録できる', () => {
+    const sessionStateStore = {
+      save: jest.fn().mockReturnValue({
+        sessionToken: 'token-1',
+        userId: 'u1',
+        expiresAt: 1700000030000,
+      }),
+    };
+    const registrar = new SessionStateRegistrar({
+      sessionStateStore,
+      sessionTokenGenerator: jest.fn().mockReturnValue('token-1'),
+    });
+    const session = {};
+
+    const actual = registrar.execute({
+      session,
+      userId: 'u1',
+      ttlMs: 30000,
+    });
+
+    expect(sessionStateStore.save).toHaveBeenCalledWith({
+      sessionToken: 'token-1',
+      userId: 'u1',
+      ttlMs: 30000,
+    });
+    expect(session.session_token).toBe('token-1');
+    expect(actual).toEqual({
+      sessionToken: 'token-1',
+      userId: 'u1',
+      expiresAt: 1700000030000,
+    });
+  });
+
+  test.each([
+    [{ session: null, userId: 'u1', ttlMs: 30000 }, 'session must be an object'],
+    [{ session: {}, userId: '', ttlMs: 30000 }, 'userId must be a non-empty string'],
+  ])('execute の入力が不正な場合は例外となる: %s', (payload, expectedMessage) => {
+    const registrar = new SessionStateRegistrar({
+      sessionStateStore: {
+        save: jest.fn(),
+      },
+      sessionTokenGenerator: jest.fn().mockReturnValue('token-1'),
+    });
+
+    expect(() => registrar.execute(payload)).toThrow(expectedMessage);
+  });
+
+  test('sessionTokenGenerator が空文字を返す場合は例外となる', () => {
+    const registrar = new SessionStateRegistrar({
+      sessionStateStore: {
+        save: jest.fn(),
+      },
+      sessionTokenGenerator: jest.fn().mockReturnValue(''),
+    });
+
+    expect(() => {
+      registrar.execute({
+        session: {},
+        userId: 'u1',
+        ttlMs: 30000,
+      });
+    }).toThrow('sessionToken must be a non-empty string');
+  });
+});

--- a/src/infrastructure/InMemorySessionStateStore.js
+++ b/src/infrastructure/InMemorySessionStateStore.js
@@ -1,0 +1,80 @@
+class InMemorySessionStateStore {
+  #clock;
+
+  #sessions;
+
+  constructor({
+    clock = () => Date.now(),
+  } = {}) {
+    this.#clock = clock;
+    this.#sessions = new Map();
+  }
+
+  save({
+    sessionToken,
+    userId,
+    ttlMs,
+  }) {
+    this.#validateSessionToken(sessionToken);
+    this.#validateUserId(userId);
+    this.#validateTtlMs(ttlMs);
+
+    const expiresAt = this.#clock() + ttlMs;
+    this.#sessions.set(sessionToken, {
+      userId,
+      expiresAt,
+    });
+
+    return {
+      sessionToken,
+      userId,
+      expiresAt,
+    };
+  }
+
+  findUserIdBySessionToken(sessionToken) {
+    this.#validateSessionToken(sessionToken);
+    this.purgeExpired();
+
+    return this.#sessions.get(sessionToken)?.userId;
+  }
+
+  delete(sessionToken) {
+    this.#validateSessionToken(sessionToken);
+
+    return this.#sessions.delete(sessionToken);
+  }
+
+  purgeExpired() {
+    const now = this.#clock();
+    for (const [sessionToken, sessionState] of this.#sessions.entries()) {
+      if (sessionState.expiresAt <= now) {
+        this.#sessions.delete(sessionToken);
+      }
+    }
+  }
+
+  #validateSessionToken(sessionToken) {
+    if (!this.#isNonEmptyString(sessionToken)) {
+      throw new Error('sessionToken must be a non-empty string');
+    }
+  }
+
+  #validateUserId(userId) {
+    if (!this.#isNonEmptyString(userId)) {
+      throw new Error('userId must be a non-empty string');
+    }
+  }
+
+  #validateTtlMs(ttlMs) {
+    if (!Number.isInteger(ttlMs) || ttlMs <= 0) {
+      throw new Error('ttlMs must be a positive integer');
+    }
+  }
+
+  #isNonEmptyString(value) {
+    return typeof value === 'string' && value.length > 0;
+  }
+}
+
+module.exports = InMemorySessionStateStore;

--- a/src/infrastructure/SessionStateAuthResolver.js
+++ b/src/infrastructure/SessionStateAuthResolver.js
@@ -1,0 +1,19 @@
+class SessionStateAuthResolver {
+  #sessionStateStore;
+
+  constructor({
+    sessionStateStore,
+  } = {}) {
+    if (!sessionStateStore || typeof sessionStateStore.findUserIdBySessionToken !== 'function') {
+      throw new Error('sessionStateStore.findUserIdBySessionToken must be a function');
+    }
+
+    this.#sessionStateStore = sessionStateStore;
+  }
+
+  async execute(sessionToken) {
+    return this.#sessionStateStore.findUserIdBySessionToken(sessionToken);
+  }
+}
+
+module.exports = SessionStateAuthResolver;

--- a/src/infrastructure/SessionStateRegistrar.js
+++ b/src/infrastructure/SessionStateRegistrar.js
@@ -30,6 +30,10 @@ class SessionStateRegistrar {
       throw new Error('session must be an object');
     }
 
+    if (typeof session.regenerate !== 'function') {
+      throw new Error('session.regenerate must be a function');
+    }
+
     if (!this.#isNonEmptyString(userId)) {
       throw new Error('userId must be a non-empty string');
     }
@@ -38,6 +42,8 @@ class SessionStateRegistrar {
     if (!this.#isNonEmptyString(sessionToken)) {
       throw new Error('sessionToken must be a non-empty string');
     }
+
+    await this.#regenerateSession(session);
 
     const sessionState = await this.#sessionStateStore.save({
       sessionToken,
@@ -48,6 +54,19 @@ class SessionStateRegistrar {
     session.session_token = sessionToken;
 
     return sessionState;
+  }
+
+  #regenerateSession(session) {
+    return new Promise((resolve, reject) => {
+      session.regenerate((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+
+        resolve();
+      });
+    });
   }
 
   #isNonEmptyString(value) {

--- a/src/infrastructure/SessionStateRegistrar.js
+++ b/src/infrastructure/SessionStateRegistrar.js
@@ -21,7 +21,7 @@ class SessionStateRegistrar {
     this.#sessionTokenGenerator = sessionTokenGenerator;
   }
 
-  execute({
+  async execute({
     session,
     userId,
     ttlMs,
@@ -39,7 +39,7 @@ class SessionStateRegistrar {
       throw new Error('sessionToken must be a non-empty string');
     }
 
-    const sessionState = this.#sessionStateStore.save({
+    const sessionState = await this.#sessionStateStore.save({
       sessionToken,
       userId,
       ttlMs,

--- a/src/infrastructure/SessionStateRegistrar.js
+++ b/src/infrastructure/SessionStateRegistrar.js
@@ -43,7 +43,7 @@ class SessionStateRegistrar {
       throw new Error('sessionToken must be a non-empty string');
     }
 
-    await this.#regenerateSession(session);
+    const activeSession = await this.#regenerateSession(session);
 
     const sessionState = await this.#sessionStateStore.save({
       sessionToken,
@@ -51,7 +51,7 @@ class SessionStateRegistrar {
       ttlMs,
     });
 
-    session.session_token = sessionToken;
+    activeSession.session_token = sessionToken;
 
     return sessionState;
   }
@@ -64,9 +64,18 @@ class SessionStateRegistrar {
           return;
         }
 
-        resolve();
+        resolve(this.#resolveActiveSession(session));
       });
     });
+  }
+
+  #resolveActiveSession(session) {
+    const regeneratedSession = session.req?.session;
+    if (regeneratedSession && typeof regeneratedSession === 'object') {
+      return regeneratedSession;
+    }
+
+    return session;
   }
 
   #isNonEmptyString(value) {

--- a/src/infrastructure/SessionStateRegistrar.js
+++ b/src/infrastructure/SessionStateRegistrar.js
@@ -1,0 +1,58 @@
+const { randomUUID } = require('crypto');
+
+class SessionStateRegistrar {
+  #sessionStateStore;
+
+  #sessionTokenGenerator;
+
+  constructor({
+    sessionStateStore,
+    sessionTokenGenerator = () => randomUUID().replace(/-/g, ''),
+  } = {}) {
+    if (!sessionStateStore || typeof sessionStateStore.save !== 'function') {
+      throw new Error('sessionStateStore.save must be a function');
+    }
+
+    if (typeof sessionTokenGenerator !== 'function') {
+      throw new Error('sessionTokenGenerator must be a function');
+    }
+
+    this.#sessionStateStore = sessionStateStore;
+    this.#sessionTokenGenerator = sessionTokenGenerator;
+  }
+
+  execute({
+    session,
+    userId,
+    ttlMs,
+  }) {
+    if (!session || typeof session !== 'object') {
+      throw new Error('session must be an object');
+    }
+
+    if (!this.#isNonEmptyString(userId)) {
+      throw new Error('userId must be a non-empty string');
+    }
+
+    const sessionToken = this.#sessionTokenGenerator();
+    if (!this.#isNonEmptyString(sessionToken)) {
+      throw new Error('sessionToken must be a non-empty string');
+    }
+
+    const sessionState = this.#sessionStateStore.save({
+      sessionToken,
+      userId,
+      ttlMs,
+    });
+
+    session.session_token = sessionToken;
+
+    return sessionState;
+  }
+
+  #isNonEmptyString(value) {
+    return typeof value === 'string' && value.length > 0;
+  }
+}
+
+module.exports = SessionStateRegistrar;


### PR DESCRIPTION
### Motivation

- Provide a simple in-memory session state implementation to manage session tokens, TTLs, and lookup for authentication.
- Add a registrar to create and persist session tokens and attach them to the HTTP session object.
- Add an auth resolver to map a `sessionToken` to a `userId` for authorization flows.

### Description

- Introduce `InMemorySessionStateStore` with `save`, `findUserIdBySessionToken`, `delete`, and `purgeExpired` methods, plus input validation for `sessionToken`, `userId`, and `ttlMs`.
- Add `SessionStateRegistrar` that generates a session token (default using `randomUUID`), validates inputs, stores the session state via the store, and sets `session.session_token`.
- Add `SessionStateAuthResolver` that validates the provided store and exposes `execute(sessionToken)` to return the associated `userId`.
- Add unit tests covering behavior and validation in `__tests__/small/infrastructure`: `InMemorySessionStateStore.test.js`, `SessionStateRegistrar.test.js`, and `SessionStateAuthResolver.test.js`.

### Testing

- Ran the unit tests with `npm test` (Jest) for the new test files and all added tests passed.
- The tests cover saving and retrieval, TTL expiration and purging, deletion, registrar behavior including session mutation and invalid inputs, and auth resolver input validation and lookup.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb827cc9f0832ba7c21e696a12bcde)