### PR TITLE
refactor: Expressアプリの起動責務と構築責務を分離する

### DIFF
--- a/__tests__/small/app/createApp.test.js
+++ b/__tests__/small/app/createApp.test.js
@@ -1,0 +1,66 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const request = require('supertest');
+
+const createApp = require('../../../src/app');
+
+const createTempPath = (prefix, leaf) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  return {
+    root,
+    target: path.join(root, leaf),
+  };
+};
+
+describe('createApp', () => {
+  let databasePath;
+  let contentRootDirectory;
+  let cleanupRoots;
+
+  beforeEach(() => {
+    cleanupRoots = [];
+
+    const database = createTempPath('app-db-', 'data.sqlite');
+    const contents = createTempPath('app-content-', 'contents');
+
+    cleanupRoots.push(database.root, contents.root);
+    databasePath = database.target;
+    contentRootDirectory = contents.target;
+  });
+
+  afterEach(() => {
+    for (const root of cleanupRoots) {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('構築した app は /api/media を提供し、未知のルートでは404を返す', async () => {
+    const app = createApp({
+      databaseStoragePath: databasePath,
+      contentRootDirectory,
+    });
+
+    await app.locals.ready;
+
+    const notFoundResponse = await request(app).get('/unknown');
+    expect(notFoundResponse.status).toBe(404);
+    expect(notFoundResponse.body).toEqual({
+      message: 'Not Found',
+    });
+
+    const unauthorizedResponse = await request(app)
+      .post('/api/media')
+      .field('title', 'sample title')
+      .field('tags[0][category]', '作者')
+      .field('tags[0][label]', '山田')
+      .field('contents[0][position]', '1')
+      .attach('contents[0][file]', Buffer.from('a'), 'first.jpg');
+
+    expect(unauthorizedResponse.status).toBe(401);
+    expect(unauthorizedResponse.body).toEqual({
+      message: '認証に失敗しました',
+    });
+  });
+});

--- a/src/app.js
+++ b/src/app.js
@@ -1,0 +1,21 @@
+const express = require('express');
+
+const createDependencies = require('./app/createDependencies');
+const setupMiddleware = require('./app/setupMiddleware');
+const setupRoutes = require('./app/setupRoutes');
+
+const createApp = (env = {}) => {
+  const app = express();
+  const dependencies = createDependencies(env);
+
+  app.locals.env = env;
+  app.locals.dependencies = dependencies;
+  app.locals.ready = dependencies.ready;
+
+  setupMiddleware(app, { env, dependencies });
+  setupRoutes(app, { env, dependencies });
+
+  return app;
+};
+
+module.exports = createApp;

--- a/src/app/createDependencies.js
+++ b/src/app/createDependencies.js
@@ -1,0 +1,62 @@
+const fs = require('fs');
+const path = require('path');
+
+const { Sequelize } = require('sequelize');
+
+const setRouterApiMediaPost = require('../controller/router/media/setRouterApiMediaPost');
+const InMemorySessionStateStore = require('../infrastructure/InMemorySessionStateStore');
+const MulterDiskStorageContentUploadAdapter = require('../infrastructure/MulterDiskStorageContentUploadAdapter');
+const SequelizeMediaRepository = require('../infrastructure/SequelizeMediaRepository');
+const SequelizeUnitOfWork = require('../infrastructure/SequelizeUnitOfWork');
+const SessionStateAuthAdapter = require('../infrastructure/SessionStateAuthAdapter');
+const UUIDMediaIdValueGenerator = require('../infrastructure/UUIDMediaIdValueGenerator');
+
+const ensureParentDirectory = targetPath => {
+  const directory = path.dirname(targetPath);
+  fs.mkdirSync(directory, { recursive: true });
+};
+
+const ensureDirectory = targetPath => {
+  fs.mkdirSync(targetPath, { recursive: true });
+};
+
+const createDependencies = (env = {}) => {
+  ensureParentDirectory(env.databaseStoragePath);
+  ensureDirectory(env.contentRootDirectory);
+
+  const sequelize = new Sequelize({
+    dialect: 'sqlite',
+    storage: env.databaseStoragePath,
+    logging: false,
+  });
+
+  const unitOfWork = new SequelizeUnitOfWork({ sequelize });
+  const mediaRepository = new SequelizeMediaRepository({
+    sequelize,
+    unitOfWorkContext: unitOfWork,
+  });
+  const sessionStateStore = new InMemorySessionStateStore();
+
+  const dependencies = {
+    sequelize,
+    unitOfWork,
+    mediaRepository,
+    sessionStateStore,
+    authResolver: new SessionStateAuthAdapter({
+      sessionStateStore,
+    }),
+    saveAdapter: new MulterDiskStorageContentUploadAdapter({
+      rootDirectory: env.contentRootDirectory,
+    }),
+    mediaIdValueGenerator: new UUIDMediaIdValueGenerator(),
+    routeSetters: {
+      setRouterApiMediaPost,
+    },
+  };
+
+  dependencies.ready = mediaRepository.sync();
+
+  return dependencies;
+};
+
+module.exports = createDependencies;

--- a/src/app/setupMiddleware.js
+++ b/src/app/setupMiddleware.js
@@ -1,0 +1,20 @@
+const express = require('express');
+
+const setupMiddleware = (app, { env: _env, dependencies: _dependencies } = {}) => {
+  app.use(express.json());
+  app.use(express.urlencoded({ extended: true }));
+
+  app.use((req, _res, next) => {
+    req.context = req.context ?? {};
+    req.session = req.session ?? {};
+
+    const sessionToken = req.header('x-session-token');
+    if (typeof sessionToken === 'string' && sessionToken.length > 0) {
+      req.session.session_token = sessionToken;
+    }
+
+    next();
+  });
+};
+
+module.exports = setupMiddleware;

--- a/src/app/setupRoutes.js
+++ b/src/app/setupRoutes.js
@@ -1,0 +1,24 @@
+const express = require('express');
+
+const setupRoutes = (app, { env: _env, dependencies } = {}) => {
+  const router = express.Router();
+
+  dependencies.routeSetters.setRouterApiMediaPost({
+    router,
+    authResolver: dependencies.authResolver,
+    saveAdapter: dependencies.saveAdapter,
+    mediaIdValueGenerator: dependencies.mediaIdValueGenerator,
+    mediaRepository: dependencies.mediaRepository,
+    unitOfWork: dependencies.unitOfWork,
+  });
+
+  app.use(router);
+
+  app.use((_req, res) => {
+    res.status(404).json({
+      message: 'Not Found',
+    });
+  });
+};
+
+module.exports = setupRoutes;

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,40 @@
+const path = require('path');
+
+const createApp = require('./app');
+
+const createEnv = source => ({
+  port: Number.parseInt(source.PORT, 10) || 3000,
+  databaseStoragePath: source.DATABASE_STORAGE_PATH
+    || path.join(process.cwd(), 'var', 'data', 'mangaviewer.sqlite'),
+  contentRootDirectory: source.CONTENT_ROOT_DIRECTORY
+    || path.join(process.cwd(), 'var', 'contents'),
+});
+
+const startServer = async () => {
+  const env = createEnv(process.env);
+  const app = createApp(env);
+
+  try {
+    await app.locals.ready;
+  } catch (error) {
+    console.error('アプリケーションの初期化に失敗しました', error);
+    process.exit(1);
+    return;
+  }
+
+  const server = app.listen(env.port, () => {
+    console.log(`サーバーを起動しました: port=${env.port}`);
+  });
+
+  server.on('error', error => {
+    console.error('サーバーの起動に失敗しました', error);
+    process.exit(1);
+  });
+};
+
+startServer();
+
+module.exports = {
+  createEnv,
+  startServer,
+};


### PR DESCRIPTION
### Motivation

- 起動処理とアプリ構築処理の責務を明確に分離して可読性・保守性を高めるため。 
- 依存生成やルート登録が増えた際に `app.js` の肥大化を防ぎ将来的な拡張を容易にするため。

### Description

- `src/server.js` を追加し、`process.env` から必要な値だけを抽出して `createApp(env)` を呼び、`app.listen(...)` で起動・成功時は `console.log`、失敗時は `console.error` と `process.exit(1)` を行う起動専用エントリにした。 
- `src/app.js` を追加し `express()` でアプリを生成し `createDependencies(env)`、`setupMiddleware(...)`、`setupRoutes(...)` を順に呼んでアプリを構築して `app` を返すようにした（`listen` は持たせない）。
- `src/app/createDependencies.js` を追加して Sequelize やリポジトリ、セッションストア、アップロードアダプタ、ID生成器などの依存を集約し、`setRouterApiMediaPost` に必要な依存を供給するようにした（`mediaRepository.sync()` の Promise を `dependencies.ready` として公開）。
- `src/app/setupMiddleware.js` を追加し `express.json()` と `express.urlencoded(...)` を設定し、`x-session-token` ヘッダーから `req.session.session_token` を補完する共通ミドルウェアを実装した。 
- `src/app/setupRoutes.js` を追加し既存の `setRouterApiMediaPost` を組み込み、最後に 404 JSON 応答を返すハンドリングを追加した。 
- 最低限の統合確認用テスト `__tests__/small/app/createApp.test.js` を追加し、`/unknown` で 404 を返すことと未認証の `/api/media` が 401 を返すことを確認するようにした。 

### Testing

- 構文チェックとして `node --check src/server.js && node --check src/app.js && node --check src/app/createDependencies.js && node --check src/app/setupMiddleware.js && node --check src/app/setupRoutes.js && node --check __tests__/small/app/createApp.test.js` を実行して成功した。 
- `npm test -- --selectProjects small --runInBand` はこの環境で `jest: not found` のため実行できなかった。 
- 依存導入のために `npm install` / `npm ci` を試行したが、レジストリ制約や環境エラーにより依存解決が完了せず外部依存を伴う実行確認（実際の jest 実行やアプリのランタイム起動）は未完了である。 
- 変更はコミット済み（コミットメッセージは日本語ルールに従い `refactor: Expressアプリの起動責務と構築責務を分離する`）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be54b91c3c832bb918b71358c708c6)