### PR TITLE
fix: SQLite接続を安全にクリーンアップできるようにする

### DIFF
--- a/__tests__/small/app/createApp.test.js
+++ b/__tests__/small/app/createApp.test.js
@@ -15,29 +15,32 @@ const createTempPath = (prefix, leaf) => {
 };
 
 describe('createApp', () => {
+  let app;
   let databasePath;
   let contentRootDirectory;
-  let cleanupRoots;
+  let databaseRoot;
+  let contentRoot;
 
   beforeEach(() => {
-    cleanupRoots = [];
-
     const database = createTempPath('app-db-', 'data.sqlite');
     const contents = createTempPath('app-content-', 'contents');
 
-    cleanupRoots.push(database.root, contents.root);
+    databaseRoot = database.root;
+    contentRoot = contents.root;
     databasePath = database.target;
     contentRootDirectory = contents.target;
   });
 
-  afterEach(() => {
-    for (const root of cleanupRoots) {
-      fs.rmSync(root, { recursive: true, force: true });
-    }
+  afterEach(async () => {
+    if (app?.locals?.close) await app.locals.close();
+
+    fs.rmSync(databaseRoot, { recursive: true, force: true });
+    fs.rmSync(contentRoot, { recursive: true, force: true });
+    app = undefined;
   });
 
   test('構築した app は /api/media を提供し、未知のルートでは404を返す', async () => {
-    const app = createApp({
+    app = createApp({
       databaseStoragePath: databasePath,
       contentRootDirectory,
     });

--- a/src/app.js
+++ b/src/app.js
@@ -11,6 +11,7 @@ const createApp = (env = {}) => {
   app.locals.env = env;
   app.locals.dependencies = dependencies;
   app.locals.ready = dependencies.ready;
+  app.locals.close = dependencies.close;
 
   setupMiddleware(app, { env, dependencies });
   setupRoutes(app, { env, dependencies });

--- a/src/app/createDependencies.js
+++ b/src/app/createDependencies.js
@@ -55,6 +55,10 @@ const createDependencies = (env = {}) => {
   };
 
   dependencies.ready = mediaRepository.sync();
+  dependencies.close = async () => {
+    await dependencies.ready;
+    await sequelize.close();
+  };
 
   return dependencies;
 };


### PR DESCRIPTION
### Motivation
- SQLite のデータベース接続がテスト終了時に開いたままだと一時ディレクトリ削除時にファイルハンドルが残り、特に Windows 環境で削除に失敗するため。 
- テストや将来のサーバー終了処理から同一のクリーンアップ経路を再利用できるように `close` を公開するため。

### Description
- `src/app/createDependencies.js` に `dependencies.close = async () => { await dependencies.ready; await sequelize.close(); };` を追加して、呼び出し側が接続終了を `await` できるようにした。 
- `src/app.js` で `app.locals.close = dependencies.close;` を追加して、アプリインスタンス経由でクリーンアップ関数を参照できるようにした。 
- `__tests__/small/app/createApp.test.js` を修正し、`app` を `describe` スコープに移し、`afterEach` を `async` 化して `if (app?.locals?.close) await app.locals.close();` を呼んでから一時ディレクトリを削除するようにした。

### Testing
- `npm test -- --runInBand __tests__/small/app/createApp.test.js` を実行しましたが、環境内で `jest` バイナリが見つからず実行できなかったためテストは実行失敗となりました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be674547a4832ba30ce258769f3159)