### PR TITLE
feat: ログイン画面の表示ルートとビューを追加する

### DIFF
--- a/__tests__/medium/controller/router/screen/setRouterScreenLoginGet.test.js
+++ b/__tests__/medium/controller/router/screen/setRouterScreenLoginGet.test.js
@@ -1,0 +1,74 @@
+const express = require('express');
+const path = require('path');
+
+const setRouterScreenLoginGet = require('../../../../../src/controller/router/screen/setRouterScreenLoginGet');
+
+const requestApp = async ({ app, method, targetPath } = {}) => {
+  const server = app.listen(0);
+
+  try {
+    await new Promise((resolve, reject) => {
+      server.once('listening', resolve);
+      server.once('error', reject);
+    });
+
+    const address = server.address();
+    const response = await fetch(`http://127.0.0.1:${address.port}${targetPath}`, {
+      method,
+    });
+
+    return {
+      status: response.status,
+      headers: response.headers,
+      bodyText: await response.text(),
+    };
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close(error => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    });
+  }
+};
+
+describe('setRouterScreenLoginGet (middle)', () => {
+  const createApp = () => {
+    const app = express();
+    const router = express.Router();
+
+    app.set('views', path.join(process.cwd(), 'src', 'views'));
+    app.set('view engine', 'ejs');
+    app.engine('ejs', (filePath, options, callback) => {
+      callback(
+        null,
+        `<!DOCTYPE html><html lang="ja"><head><title>${options.pageTitle}</title></head><body>${filePath}:${options.formAction}</body></html>`
+      );
+    });
+
+    setRouterScreenLoginGet({ router });
+
+    app.use(router);
+    return app;
+  };
+
+  test('GET /screen/login で HTML を返す', async () => {
+    const app = createApp();
+
+    const response = await requestApp({
+      app,
+      method: 'GET',
+      targetPath: '/screen/login',
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toContain('text/html');
+    expect(response.bodyText).toContain('<!DOCTYPE html>');
+    expect(response.bodyText).toContain('<title>ログイン</title>');
+    expect(response.bodyText).toContain(path.join('src', 'views', 'screen', 'login.ejs'));
+    expect(response.bodyText).toContain(':/api/login');
+  });
+});

--- a/__tests__/small/app/createApp.test.js
+++ b/__tests__/small/app/createApp.test.js
@@ -67,7 +67,7 @@ describe('createApp', () => {
     });
   });
 
-  test('固定セッション設定がある場合は /screen/entry と /api/media で認証を補完する', async () => {
+  test('固定セッション設定がある場合は /screen/entry と /api/media で認証を補完し、/screen/login を表示できる', async () => {
     app = createApp({
       databaseStoragePath: databasePath,
       contentRootDirectory,
@@ -83,6 +83,12 @@ describe('createApp', () => {
     expect(screenResponse.status).toBe(200);
     expect(screenResponse.type).toBe('text/html');
     expect(screenResponse.text).toContain('<title>メディア登録</title>');
+
+    const loginResponse = await request(app).get('/screen/login');
+    expect(loginResponse.status).toBe(200);
+    expect(loginResponse.type).toBe('text/html');
+    expect(loginResponse.text).toContain('<title>ログイン</title>');
+    expect(loginResponse.text).toContain('action="/api/login"');
 
     const mediaResponse = await request(app)
       .post('/api/media')

--- a/__tests__/small/controller/router/screen/setRouterScreenLoginGet.test.js
+++ b/__tests__/small/controller/router/screen/setRouterScreenLoginGet.test.js
@@ -1,0 +1,37 @@
+const setRouterScreenLoginGet = require('../../../../../src/controller/router/screen/setRouterScreenLoginGet');
+
+describe('setRouterScreenLoginGet', () => {
+  const createRes = () => {
+    const res = {
+      status: jest.fn(),
+      render: jest.fn(),
+    };
+    res.status.mockReturnValue(res);
+    return res;
+  };
+
+  it('GET /screen/login に描画ハンドラーを登録できる', () => {
+    const router = {
+      get: jest.fn(),
+    };
+
+    setRouterScreenLoginGet({ router });
+
+    expect(router.get).toHaveBeenCalledTimes(1);
+    const [path, handler] = router.get.mock.calls[0];
+    expect(path).toBe('/screen/login');
+    expect(typeof handler).toBe('function');
+
+    const res = createRes();
+    handler({}, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.render).toHaveBeenCalledWith('screen/login', {
+      pageTitle: 'ログイン',
+      formAction: '/api/login',
+      usernameLabel: 'ユーザー名',
+      passwordLabel: 'パスワード',
+      submitLabel: 'ログイン',
+    });
+  });
+});

--- a/src/app/createDependencies.js
+++ b/src/app/createDependencies.js
@@ -5,6 +5,7 @@ const { Sequelize } = require('sequelize');
 
 const setRouterApiMediaPost = require('../controller/router/media/setRouterApiMediaPost');
 const setRouterScreenEntryGet = require('../controller/router/screen/setRouterScreenEntryGet');
+const setRouterScreenLoginGet = require('../controller/router/screen/setRouterScreenLoginGet');
 const InMemorySessionStateStore = require('../infrastructure/InMemorySessionStateStore');
 const MulterDiskStorageContentUploadAdapter = require('../infrastructure/MulterDiskStorageContentUploadAdapter');
 const SequelizeMediaRepository = require('../infrastructure/SequelizeMediaRepository');
@@ -62,6 +63,7 @@ const createDependencies = (env = {}) => {
     routeSetters: {
       setRouterApiMediaPost,
       setRouterScreenEntryGet,
+      setRouterScreenLoginGet,
     },
   };
 

--- a/src/app/setupRoutes.js
+++ b/src/app/setupRoutes.js
@@ -8,6 +8,10 @@ const setupRoutes = (app, { env: _env, dependencies } = {}) => {
     authResolver: dependencies.authResolver,
   });
 
+  dependencies.routeSetters.setRouterScreenLoginGet({
+    router,
+  });
+
   dependencies.routeSetters.setRouterApiMediaPost({
     router,
     authResolver: dependencies.authResolver,

--- a/src/controller/router/screen/setRouterScreenLoginGet.js
+++ b/src/controller/router/screen/setRouterScreenLoginGet.js
@@ -1,0 +1,15 @@
+const setRouterScreenLoginGet = ({
+  router,
+}) => {
+  router.get('/screen/login', (_req, res) => {
+    res.status(200).render('screen/login', {
+      pageTitle: 'ログイン',
+      formAction: '/api/login',
+      usernameLabel: 'ユーザー名',
+      passwordLabel: 'パスワード',
+      submitLabel: 'ログイン',
+    });
+  });
+};
+
+module.exports = setRouterScreenLoginGet;

--- a/src/views/screen/login.ejs
+++ b/src/views/screen/login.ejs
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title><%= pageTitle %></title>
+    <style>
+      :root {
+        color-scheme: light;
+        font-family: "Hiragino Sans", "Yu Gothic UI", sans-serif;
+        background: #f5f6f8;
+        color: #1f2937;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        background: linear-gradient(180deg, #eff6ff 0%, #f8fafc 100%);
+      }
+      .page {
+        width: min(100%, 440px);
+        padding: 24px 16px;
+      }
+      .card {
+        background: #fff;
+        border: 1px solid #dbe3f0;
+        border-radius: 16px;
+        padding: 32px 24px;
+        box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
+      }
+      h1 {
+        margin: 0 0 8px;
+        font-size: 32px;
+      }
+      .description {
+        margin: 0 0 24px;
+        color: #475569;
+        font-size: 14px;
+      }
+      .field {
+        margin-top: 16px;
+      }
+      .field-label {
+        display: block;
+        margin-bottom: 8px;
+        font-weight: 700;
+      }
+      .text-input {
+        width: 100%;
+        border: 1px solid #cbd5e1;
+        border-radius: 10px;
+        padding: 12px 14px;
+        font-size: 16px;
+        background: #fff;
+      }
+      .button {
+        width: 100%;
+        margin-top: 24px;
+        border: 0;
+        border-radius: 10px;
+        padding: 12px 18px;
+        font-size: 16px;
+        font-weight: 700;
+        cursor: pointer;
+        background: #2563eb;
+        color: #fff;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="page">
+      <div class="card">
+        <h1><%= pageTitle %></h1>
+        <p class="description">アカウント情報を入力してログインしてください。</p>
+        <form method="post" action="<%= formAction %>">
+          <div class="field">
+            <label class="field-label" for="username"><%= usernameLabel %></label>
+            <input id="username" name="username" class="text-input" type="text" autocomplete="username" required />
+          </div>
+          <div class="field">
+            <label class="field-label" for="password"><%= passwordLabel %></label>
+            <input id="password" name="password" class="text-input" type="password" autocomplete="current-password" required />
+          </div>
+          <button class="button" type="submit"><%= submitLabel %></button>
+        </form>
+      </div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
### Motivation
- ユーザーがログインできるように `GET /screen/login` でログイン画面を提供し、画面レンダリングに最低限の view model を渡すためのルートとビューを追加するため。

### Description
- `src/controller/router/screen/setRouterScreenLoginGet.js` を追加し `GET /screen/login` で `screen/login` をレンダリングするハンドラを実装しました。  
- 依存登録に `setRouterScreenLoginGet` を追加するために `src/app/createDependencies.js` の `routeSetters` を更新しました。  
- アプリ起動時にルートを登録するように `src/app/setupRoutes.js` に `setRouterScreenLoginGet` の呼び出しを追加しました。  
- `src/views/screen/login.ejs` を新規作成し、ページタイトル、ユーザー名入力、パスワード入力、送信ボタン、`/api/login` へ POST するフォームを実装しました。  
- ルーター単体テスト (`__tests__/small/controller/router/screen/setRouterScreenLoginGet.test.js`)、ルーター中間テスト (`__tests__/medium/controller/router/screen/setRouterScreenLoginGet.test.js`) を追加し、既存の `createApp` 統合テストに `/screen/login` 表示確認を追記しました (`__tests__/small/app/createApp.test.js`)。  

### Testing
- `node --check src/controller/router/screen/setRouterScreenLoginGet.js`、`node --check src/app/createDependencies.js`、`node --check src/app/setupRoutes.js`、および追加したテストファイルに対する `node --check` を実行し構文チェックは成功しました。  
- `npx jest __tests__/small/controller/router/screen/setRouterScreenLoginGet.test.js __tests__/medium/controller/router/screen/setRouterScreenLoginGet.test.js __tests__/small/app/createApp.test.js` を実行しようとしましたが、実行環境で `jest` の取得が失敗（npm レジストリへのアクセスで `403`）したためテスト実行はできませんでした。  
- テストファイルはリポジトリに追加済みで、ローカルまたは CI 環境で依存をインストール (`npm install`) すれば `jest` による自動テスト実行が可能です。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69befc575554832b856de35ad502e0f6)