### PR TITLE
feat: 共通エラーページ用ルートとビューを追加

### DIFF
--- a/__tests__/small/app/createApp.test.js
+++ b/__tests__/small/app/createApp.test.js
@@ -39,13 +39,18 @@ describe('createApp', () => {
     app = undefined;
   });
 
-  test('構築した app は /api/media を提供し、未知のルートでは404を返す', async () => {
+  test('構築した app は /screen/error と /api/media を提供し、未知のルートでは404を返す', async () => {
     app = createApp({
       databaseStoragePath: databasePath,
       contentRootDirectory,
     });
 
     await app.locals.ready;
+
+    const errorScreenResponse = await request(app).get('/screen/error');
+    expect(errorScreenResponse.status).toBe(200);
+    expect(errorScreenResponse.type).toBe('text/html');
+    expect(errorScreenResponse.text).toContain('<title>エラーが発生しました</title>');
 
     const notFoundResponse = await request(app).get('/unknown');
     expect(notFoundResponse.status).toBe(404);

--- a/__tests__/small/controller/router/screen/setRouterScreenErrorGet.test.js
+++ b/__tests__/small/controller/router/screen/setRouterScreenErrorGet.test.js
@@ -1,0 +1,38 @@
+const setRouterScreenErrorGet = require('../../../../../src/controller/router/screen/setRouterScreenErrorGet');
+
+describe('setRouterScreenErrorGet', () => {
+  const createRes = () => {
+    const res = {
+      status: jest.fn(),
+      render: jest.fn(),
+    };
+    res.status.mockReturnValue(res);
+    return res;
+  };
+
+  it('GET /screen/error に描画ハンドラーを登録できる', () => {
+    const router = {
+      get: jest.fn(),
+    };
+
+    setRouterScreenErrorGet({ router });
+
+    expect(router.get).toHaveBeenCalledTimes(1);
+    const [path, handler] = router.get.mock.calls[0];
+    expect(path).toBe('/screen/error');
+    expect(handler).toEqual(expect.any(Function));
+
+    const res = createRes();
+    handler({}, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.render).toHaveBeenCalledWith('screen/error', expect.objectContaining({
+      pageTitle: 'エラーが発生しました',
+      errorTitle: 'ページを表示できませんでした',
+      navigationLinks: expect.arrayContaining([
+        expect.objectContaining({ href: '/screen/login' }),
+        expect.objectContaining({ href: '/screen/summary' }),
+      ]),
+    }));
+  });
+});

--- a/src/app/createDependencies.js
+++ b/src/app/createDependencies.js
@@ -5,6 +5,7 @@ const { Sequelize } = require('sequelize');
 
 const setRouterApiMediaPost = require('../controller/router/media/setRouterApiMediaPost');
 const setRouterScreenEntryGet = require('../controller/router/screen/setRouterScreenEntryGet');
+const setRouterScreenErrorGet = require('../controller/router/screen/setRouterScreenErrorGet');
 const InMemorySessionStateStore = require('../infrastructure/InMemorySessionStateStore');
 const MulterDiskStorageContentUploadAdapter = require('../infrastructure/MulterDiskStorageContentUploadAdapter');
 const SequelizeMediaRepository = require('../infrastructure/SequelizeMediaRepository');
@@ -62,6 +63,7 @@ const createDependencies = (env = {}) => {
     routeSetters: {
       setRouterApiMediaPost,
       setRouterScreenEntryGet,
+      setRouterScreenErrorGet,
     },
   };
 

--- a/src/app/setupRoutes.js
+++ b/src/app/setupRoutes.js
@@ -8,6 +8,10 @@ const setupRoutes = (app, { env: _env, dependencies } = {}) => {
     authResolver: dependencies.authResolver,
   });
 
+  dependencies.routeSetters.setRouterScreenErrorGet({
+    router,
+  });
+
   dependencies.routeSetters.setRouterApiMediaPost({
     router,
     authResolver: dependencies.authResolver,

--- a/src/controller/router/screen/setRouterScreenErrorGet.js
+++ b/src/controller/router/screen/setRouterScreenErrorGet.js
@@ -1,0 +1,27 @@
+const setRouterScreenErrorGet = ({
+  router,
+}) => {
+  router.get('/screen/error', (_req, res) => {
+    res.status(200).render('screen/error', {
+      pageTitle: 'エラーが発生しました',
+      errorTitle: 'ページを表示できませんでした',
+      errorMessage: '認証情報の確認が必要な場合や、対象のデータが見つからない場合、あるいは一時的な問題が発生した場合にこの画面が表示されます。時間をおいて再度お試しいただくか、別の画面へお戻りください。',
+      navigationLinks: [
+        {
+          href: '/screen/login',
+          label: 'ログイン画面へ戻る',
+        },
+        {
+          href: '/screen/summary',
+          label: '一覧・サマリー画面へ戻る',
+        },
+        {
+          href: '/screen/entry',
+          label: '登録画面へ戻る',
+        },
+      ],
+    });
+  });
+};
+
+module.exports = setRouterScreenErrorGet;

--- a/src/views/screen/error.ejs
+++ b/src/views/screen/error.ejs
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title><%= pageTitle %></title>
+    <style>
+      :root {
+        color-scheme: light;
+        font-family: "Hiragino Sans", "Yu Gothic UI", sans-serif;
+        background: #f5f6f8;
+        color: #1f2937;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 24px;
+        background: linear-gradient(180deg, #f8fafc 0%, #e2e8f0 100%);
+      }
+      .card {
+        width: min(100%, 720px);
+        background: #ffffff;
+        border: 1px solid #d1d5db;
+        border-radius: 20px;
+        padding: 40px 32px;
+        box-shadow: 0 18px 48px rgba(15, 23, 42, 0.1);
+      }
+      .eyebrow {
+        display: inline-flex;
+        align-items: center;
+        padding: 6px 12px;
+        border-radius: 9999px;
+        background: #fee2e2;
+        color: #b91c1c;
+        font-size: 13px;
+        font-weight: 700;
+      }
+      h1 {
+        margin: 16px 0 12px;
+        font-size: clamp(30px, 4vw, 40px);
+      }
+      p {
+        margin: 0;
+        font-size: 16px;
+        line-height: 1.8;
+        color: #475569;
+      }
+      .navigation {
+        margin-top: 28px;
+        display: grid;
+        gap: 12px;
+      }
+      .navigation a {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 100%;
+        min-height: 48px;
+        padding: 12px 16px;
+        border-radius: 12px;
+        text-decoration: none;
+        font-weight: 700;
+        color: #1d4ed8;
+        background: #eff6ff;
+        border: 1px solid #bfdbfe;
+      }
+      .navigation a:hover {
+        background: #dbeafe;
+      }
+      .subtext {
+        margin-top: 20px;
+        font-size: 14px;
+        color: #64748b;
+      }
+    </style>
+  </head>
+  <body>
+    <main class="card">
+      <span class="eyebrow">Error</span>
+      <h1><%= errorTitle %></h1>
+      <p><%= errorMessage %></p>
+      <nav class="navigation" aria-label="戻り先の候補">
+        <% navigationLinks.forEach((link) => { %>
+          <a href="<%= link.href %>"><%= link.label %></a>
+        <% }) %>
+      </nav>
+      <p class="subtext">認証失敗、対象データ未存在、予期しないエラーのいずれでも利用できる共通の案内ページです。</p>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
### Motivation
- 認証失敗の `301` リダイレクト先や対象未存在・一般エラー時に使い回せる、包括的なエラーページが必要なため。\

### Description
- `GET /screen/error` を描画するルーターを `src/controller/router/screen/setRouterScreenErrorGet.js` として追加し、タイトル・汎用メッセージ・戻り先リンクをビューへ渡すようにした。\
- 共通エラービュー `src/views/screen/error.ejs` を新規作成し、エラーページのタイトル・汎用メッセージ・`/screen/login`・`/screen/summary`・`/screen/entry` などへの導線を表示する UI を実装した。\
- 依存登録にルーターを追加するため `src/app/createDependencies.js` の `routeSetters` に `setRouterScreenErrorGet` を登録し、`src/app/setupRoutes.js` でルートを組み込むようにした。\
- ルーター単体テスト `__tests__/small/controller/router/screen/setRouterScreenErrorGet.test.js` を追加し、`__tests__/small/app/createApp.test.js` を更新してアプリ経由で `/screen/error` へ到達できることを確認するようにした。\

### Testing
- 追加したユニット/統合寄りテスト（`__tests__/small/controller/router/screen/setRouterScreenErrorGet.test.js` および更新済みの `__tests__/small/app/createApp.test.js`）をリポジトリに追加したが、実行は試行済みで失敗した。\
- `npm test ...` 実行はこの環境で `jest: not found` のため実行不可となり失敗した。\
- `node -e "require('./src/controller/router/screen/setRouterScreenErrorGet'); require('./src/app/createDependencies'); require('./src/app/setupRoutes');"` の実行は `sequelize` が見つからず完走できなかった。\
- コード変更はコミット済み（コミット: `feat: エラー画面ルートと共通エラービューを追加する`）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69befc58f770832b8900de6abb04c4ca)