### PR TITLE
feat: 検索画面を追加してサマリー画面への検索遷移を実現

### DIFF
--- a/__tests__/medium/controller/router/screen/setRouterScreenSearchGet.test.js
+++ b/__tests__/medium/controller/router/screen/setRouterScreenSearchGet.test.js
@@ -1,0 +1,103 @@
+const express = require('express');
+const path = require('path');
+
+const setRouterScreenSearchGet = require('../../../../../src/controller/router/screen/setRouterScreenSearchGet');
+const SessionStateAuthAdapter = require('../../../../../src/infrastructure/SessionStateAuthAdapter');
+
+class InMemorySessionStateStore {
+  constructor(entries = []) {
+    this.tokenToUserId = new Map(entries);
+  }
+
+  findUserIdBySessionToken(sessionToken) {
+    return this.tokenToUserId.get(sessionToken) ?? null;
+  }
+}
+
+const requestApp = async ({ app, method, targetPath, headers = {} } = {}) => {
+  const server = app.listen(0);
+
+  try {
+    await new Promise((resolve, reject) => {
+      server.once('listening', resolve);
+      server.once('error', reject);
+    });
+
+    const address = server.address();
+    const response = await fetch(`http://127.0.0.1:${address.port}${targetPath}`, {
+      method,
+      headers,
+    });
+
+    return {
+      status: response.status,
+      headers: response.headers,
+      bodyText: await response.text(),
+    };
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close(error => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    });
+  }
+};
+
+describe('setRouterScreenSearchGet (middle)', () => {
+  const createApp = () => {
+    const app = express();
+    const router = express.Router();
+
+    app.set('views', path.join(process.cwd(), 'src', 'views'));
+    app.set('view engine', 'ejs');
+    app.engine('ejs', (filePath, options, callback) => {
+      callback(
+        null,
+        `<!DOCTYPE html><html lang="ja"><head><title>${options.pageTitle}</title></head><body>${filePath}</body></html>`
+      );
+    });
+
+    app.use((req, _res, next) => {
+      req.session = {
+        session_token: req.header('x-session-token'),
+      };
+      req.context = {};
+      next();
+    });
+
+    setRouterScreenSearchGet({
+      router,
+      authResolver: new SessionStateAuthAdapter({
+        sessionStateStore: new InMemorySessionStateStore([
+          ['valid-token', 'user-001'],
+        ]),
+      }),
+    });
+
+    app.use(router);
+    return app;
+  };
+
+  test('GET /screen/search で HTML を返す', async () => {
+    const app = createApp();
+
+    const response = await requestApp({
+      app,
+      method: 'GET',
+      targetPath: '/screen/search',
+      headers: {
+        'x-session-token': 'valid-token',
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toContain('text/html');
+    expect(response.bodyText).toContain('<!DOCTYPE html>');
+    expect(response.bodyText).toContain('<title>メディア検索</title>');
+    expect(response.bodyText).toContain(path.join('src', 'views', 'screen', 'search.ejs'));
+  });
+});

--- a/__tests__/small/app/createApp.test.js
+++ b/__tests__/small/app/createApp.test.js
@@ -72,14 +72,14 @@ describe('createApp', () => {
     });
   });
 
-  test('固定セッション設定がある場合は /screen/entry と /api/media で認証を補完し、/screen/login を表示できる', async () => {
+  test('固定セッション設定がある場合は /screen/entry と /screen/search と /api/media で認証を補完し、/screen/login を表示できる', async () => {
     app = createApp({
       databaseStoragePath: databasePath,
       contentRootDirectory,
       devSessionToken: 'dev-token',
       devSessionUserId: 'admin-dev',
       devSessionTtlMs: 60_000,
-      devSessionPaths: ['/screen/entry', '/api/media'],
+      devSessionPaths: ['/screen/entry', '/screen/search', '/api/media'],
     });
 
     await app.locals.ready;
@@ -88,6 +88,11 @@ describe('createApp', () => {
     expect(screenResponse.status).toBe(200);
     expect(screenResponse.type).toBe('text/html');
     expect(screenResponse.text).toContain('<title>メディア登録</title>');
+
+    const searchResponse = await request(app).get('/screen/search');
+    expect(searchResponse.status).toBe(200);
+    expect(searchResponse.type).toBe('text/html');
+    expect(searchResponse.text).toContain('<title>メディア検索</title>');
 
     const loginResponse = await request(app).get('/screen/login');
     expect(loginResponse.status).toBe(200);

--- a/src/app/createDependencies.js
+++ b/src/app/createDependencies.js
@@ -7,6 +7,7 @@ const setRouterApiMediaPost = require('../controller/router/media/setRouterApiMe
 const setRouterScreenEntryGet = require('../controller/router/screen/setRouterScreenEntryGet');
 const setRouterScreenErrorGet = require('../controller/router/screen/setRouterScreenErrorGet');
 const setRouterScreenLoginGet = require('../controller/router/screen/setRouterScreenLoginGet');
+const setRouterScreenSearchGet = require('../controller/router/screen/setRouterScreenSearchGet');
 const InMemorySessionStateStore = require('../infrastructure/InMemorySessionStateStore');
 const MulterDiskStorageContentUploadAdapter = require('../infrastructure/MulterDiskStorageContentUploadAdapter');
 const SequelizeMediaRepository = require('../infrastructure/SequelizeMediaRepository');
@@ -66,6 +67,7 @@ const createDependencies = (env = {}) => {
       setRouterScreenEntryGet,
       setRouterScreenErrorGet,
       setRouterScreenLoginGet,
+      setRouterScreenSearchGet,
     },
   };
 

--- a/src/app/setupRoutes.js
+++ b/src/app/setupRoutes.js
@@ -14,6 +14,10 @@ const setupRoutes = (app, { env: _env, dependencies } = {}) => {
   dependencies.routeSetters.setRouterScreenLoginGet({
     router,
   });
+  dependencies.routeSetters.setRouterScreenSearchGet({
+    router,
+    authResolver: dependencies.authResolver,
+  });
 
   dependencies.routeSetters.setRouterApiMediaPost({
     router,

--- a/src/controller/router/screen/setRouterScreenSearchGet.js
+++ b/src/controller/router/screen/setRouterScreenSearchGet.js
@@ -1,0 +1,33 @@
+const SessionAuthMiddleware = require('../../middleware/SessionAuthMiddleware');
+
+const setRouterScreenSearchGet = ({
+  router,
+  authResolver,
+}) => {
+  const auth = new SessionAuthMiddleware(authResolver);
+
+  router.get('/screen/search', ...[
+    auth.execute.bind(auth),
+    (_req, res) => {
+      res.status(200).render('screen/search', {
+        pageTitle: 'メディア検索',
+        summaryPage: 1,
+        categoryOptions: ['作者', 'ジャンル', 'シリーズ'],
+        tagsByCategory: {
+          作者: ['山田', '佐藤', '鈴木'],
+          ジャンル: ['バトル', '恋愛', '日常'],
+          シリーズ: ['第1部', '短編集'],
+        },
+        sortOptions: [
+          { value: 'date_asc', label: '登録の新しい順' },
+          { value: 'date_desc', label: '登録の古い順' },
+          { value: 'title_asc', label: 'タイトル名の昇順' },
+          { value: 'title_desc', label: 'タイトル名の降順' },
+          { value: 'random', label: 'ランダム' },
+        ],
+      });
+    },
+  ]);
+};
+
+module.exports = setRouterScreenSearchGet;

--- a/src/views/screen/search.ejs
+++ b/src/views/screen/search.ejs
@@ -1,0 +1,207 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title><%= pageTitle %></title>
+    <style>
+      :root {
+        color-scheme: light;
+        font-family: "Hiragino Sans", "Yu Gothic UI", sans-serif;
+        background: #f5f6f8;
+        color: #1f2937;
+      }
+      * { box-sizing: border-box; }
+      body { margin: 0; background: #f5f6f8; }
+      .page {
+        max-width: 960px;
+        margin: 0 auto;
+        padding: 32px 16px 64px;
+      }
+      .card {
+        background: #fff;
+        border: 1px solid #d1d5db;
+        border-radius: 16px;
+        padding: 24px;
+        box-shadow: 0 10px 30px rgba(15, 23, 42, 0.06);
+      }
+      h1 { margin: 0 0 24px; font-size: 32px; }
+      .section { margin-top: 24px; }
+      .field-label, .section-title { display:block; font-weight:700; margin-bottom:8px; }
+      .text-input, .select-input {
+        width: 100%; border: 1px solid #cbd5e1; border-radius: 10px;
+        padding: 12px 14px; font-size: 16px; background: #fff;
+      }
+      .divider { border: 0; border-top: 1px solid #e5e7eb; margin: 16px 0 0; }
+      .tag-inputs { display: grid; grid-template-columns: 1fr 1fr auto; gap: 12px; align-items: end; }
+      .button {
+        border: 0; border-radius: 10px; padding: 12px 18px; font-size: 14px; font-weight: 700;
+        cursor: pointer; background: #2563eb; color: #fff;
+      }
+      .button.secondary { background: #e5e7eb; color: #111827; }
+      .button.danger { background: #dc2626; }
+      .tag-list { display: grid; gap: 12px; margin-top: 16px; }
+      .tag-item {
+        border: 1px solid #dbe3f0; border-radius: 12px; background: #f8fafc; padding: 16px;
+      }
+      .tag-item-header { display:flex; justify-content:space-between; gap:12px; align-items:center; }
+      .tag-category { font-size: 12px; color: #475569; }
+      .tag-label { font-size: 16px; font-weight: 700; }
+      .actions { display:flex; justify-content:flex-end; margin-top:24px; }
+      .message { margin-top: 16px; font-size: 14px; }
+      .message.error { color: #b91c1c; }
+      @media (max-width: 640px) {
+        .tag-inputs { grid-template-columns: 1fr; }
+        .button { width: 100%; }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="page">
+      <div class="card">
+        <h1><%= pageTitle %></h1>
+        <form id="search-form" action="/screen/summary" method="get">
+          <input type="hidden" id="summary-page" name="summaryPage" value="<%= summaryPage %>" />
+
+          <section>
+            <label class="field-label" for="title">タイトル部分一致</label>
+            <input id="title" name="title" class="text-input" type="text" />
+            <hr class="divider" />
+          </section>
+
+          <section class="section">
+            <span class="section-title">タグ</span>
+            <div id="tag-list" class="tag-list" aria-live="polite"></div>
+            <hr class="divider" />
+            <div class="tag-inputs">
+              <div>
+                <label class="field-label" for="category-input">カテゴリー</label>
+                <input id="category-input" class="text-input" list="category-options" autocomplete="off" />
+                <datalist id="category-options">
+                  <% categoryOptions.forEach((category) => { %>
+                    <option value="<%= category %>"></option>
+                  <% }) %>
+                </datalist>
+              </div>
+              <div>
+                <label class="field-label" for="tag-input">ラベル</label>
+                <input id="tag-input" class="text-input" list="tag-options" autocomplete="off" />
+                <datalist id="tag-options"></datalist>
+              </div>
+              <button id="add-tag-button" class="button secondary" type="button">タグ追加</button>
+            </div>
+            <div id="form-message" class="message" aria-live="polite"></div>
+            <hr class="divider" />
+          </section>
+
+          <section class="section">
+            <label class="field-label" for="sort">並び順</label>
+            <select id="sort" name="sort" class="select-input">
+              <% sortOptions.forEach((option) => { %>
+                <option value="<%= option.value %>"><%= option.label %></option>
+              <% }) %>
+            </select>
+            <hr class="divider" />
+          </section>
+
+          <div class="actions">
+            <button class="button" type="submit">検索実行</button>
+          </div>
+        </form>
+      </div>
+    </div>
+
+    <script>
+      (() => {
+        const tagsByCategory = <%- JSON.stringify(tagsByCategory) %>;
+        const form = document.getElementById('search-form');
+        const summaryPageInput = document.getElementById('summary-page');
+        const titleInput = document.getElementById('title');
+        const sortInput = document.getElementById('sort');
+        const categoryInput = document.getElementById('category-input');
+        const tagInput = document.getElementById('tag-input');
+        const tagOptions = document.getElementById('tag-options');
+        const tagList = document.getElementById('tag-list');
+        const addTagButton = document.getElementById('add-tag-button');
+        const formMessage = document.getElementById('form-message');
+
+        const selectedTags = [];
+
+        const updateTagOptions = () => {
+          const category = categoryInput.value.trim();
+          const candidates = Array.isArray(tagsByCategory[category]) ? tagsByCategory[category] : [];
+          tagOptions.innerHTML = candidates
+            .map(label => `<option value="${label}"></option>`)
+            .join('');
+        };
+
+        const renderTags = () => {
+          tagList.innerHTML = '';
+          selectedTags.forEach((tag, index) => {
+            const item = document.createElement('div');
+            item.className = 'tag-item';
+            item.innerHTML = `
+              <div class="tag-item-header">
+                <div>
+                  <div class="tag-category">${tag.category}</div>
+                  <div class="tag-label">${tag.label}</div>
+                </div>
+                <button class="button danger" type="button" data-remove-tag="${index}">削除</button>
+              </div>
+            `;
+            tagList.appendChild(item);
+          });
+        };
+
+        categoryInput.addEventListener('change', updateTagOptions);
+        categoryInput.addEventListener('input', updateTagOptions);
+
+        addTagButton.addEventListener('click', () => {
+          const category = categoryInput.value.trim();
+          const label = tagInput.value.trim();
+          if (!category || !label) {
+            formMessage.className = 'message error';
+            formMessage.textContent = 'カテゴリーとラベルを入力してください。';
+            return;
+          }
+
+          selectedTags.push({ category, label });
+          categoryInput.value = '';
+          tagInput.value = '';
+          updateTagOptions();
+          renderTags();
+          formMessage.className = 'message';
+          formMessage.textContent = '';
+        });
+
+        tagList.addEventListener('click', event => {
+          const { removeTag } = event.target.dataset;
+          if (removeTag === undefined) {
+            return;
+          }
+          selectedTags.splice(Number(removeTag), 1);
+          renderTags();
+        });
+
+        form.addEventListener('submit', event => {
+          event.preventDefault();
+          const params = new URLSearchParams();
+          const title = titleInput.value.trim();
+          if (title.length > 0) {
+            params.set('title', title);
+          }
+          params.set('summaryPage', summaryPageInput.value);
+          params.set('sort', sortInput.value);
+          selectedTags.forEach(tag => {
+            params.append('tags', `${tag.category}:${tag.label}`);
+          });
+
+          window.location.assign(`${form.action}?${params.toString()}`);
+        });
+
+        updateTagOptions();
+        renderTags();
+      })();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
### Motivation
- OpenAPI に沿った一覧検索の入力画面が未実装で、ユーザーがタイトル・タグ・並び順を指定して `/screen/summary` に遷移する起点が不足していたため。 

### Description
- 認証ミドルウェア付きの `GET /screen/search` ルートを `src/controller/router/screen/setRouterScreenSearchGet.js` に追加した。 
- 検索画面テンプレートを `src/views/screen/search.ejs` として新規作成し、タイトル部分一致入力・タグのカテゴリー/ラベル入力（暫定候補による入力補助）・並び順選択・検索実行ボタンを実装し、送信時に `title` `tags` `sort` `summaryPage` を query string として `/screen/summary` に詰め替えて GET 遷移する処理を組み込んだ。 
- 依存登録に新しい routeSetter を追加して `src/app/createDependencies.js` に登録し、`src/app/setupRoutes.js` でルーティングに組み込むことで起動時に画面遷移が有効になるよう変更した。 
- 画面ルーター単体テスト `__tests__/medium/controller/router/screen/setRouterScreenSearchGet.test.js` を追加し、アプリ初期化テスト `__tests__/small/app/createApp.test.js` を更新して開発用固定セッション経由で `/screen/search` が表示されることを確認するケースを追加した。 

### Testing
- `node --check` による構文チェックで `src/controller/router/screen/setRouterScreenSearchGet.js`、`src/app/createDependencies.js`、`src/app/setupRoutes.js` のチェックは成功した。 
- 追加したテスト群（`__tests__/medium/...` および更新した `__tests__/small/app/createApp.test.js`）について `npx jest` を実行して検証を試みたが、環境から `jest` を取得できず（`403 Forbidden`）、自動テストはこの環境で実行できなかった。 
- テストファイルはリポジトリに追加済みで、CI/ローカル環境で `jest` が利用できる状態で実行すれば成功する想定である。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf05236618832b829061765df35bae)