### PR TITLE
feat: メディア一覧検索用Repositoryと /screen/summary 画面を追加

### DIFF
--- a/__tests__/medium/infrastructure/SequelizeMediaQueryRepository.test.js
+++ b/__tests__/medium/infrastructure/SequelizeMediaQueryRepository.test.js
@@ -1,0 +1,86 @@
+const { Sequelize } = require('sequelize');
+
+const SequelizeMediaRepository = require('../../../src/infrastructure/SequelizeMediaRepository');
+const SequelizeMediaQueryRepository = require('../../../src/infrastructure/SequelizeMediaQueryRepository');
+const SequelizeUnitOfWork = require('../../../src/infrastructure/SequelizeUnitOfWork');
+const Media = require('../../../src/domain/media/media');
+const MediaId = require('../../../src/domain/media/mediaId');
+const MediaTitle = require('../../../src/domain/media/mediaTitle');
+const ContentId = require('../../../src/domain/media/contentId');
+const Tag = require('../../../src/domain/media/tag');
+const Category = require('../../../src/domain/media/category');
+const Label = require('../../../src/domain/media/label');
+const { SearchCondition, SearchConditionTag, SortType } = require('../../../src/application/media/port/SearchCondition');
+
+const createMedia = ({ mediaId, title, contents, tags, priorityCategories }) => new Media(
+  new MediaId(mediaId),
+  new MediaTitle(title),
+  contents.map(content => new ContentId(content)),
+  tags.map(tag => new Tag(new Category(tag.category), new Label(tag.label))),
+  priorityCategories.map(category => new Category(category))
+);
+
+describe('SequelizeMediaQueryRepository', () => {
+  let sequelize;
+  let mediaRepository;
+  let queryRepository;
+  let unitOfWork;
+
+  beforeEach(async () => {
+    sequelize = new Sequelize('sqlite::memory:', { logging: false });
+    unitOfWork = new SequelizeUnitOfWork({ sequelize });
+    mediaRepository = new SequelizeMediaRepository({ sequelize, unitOfWorkContext: unitOfWork });
+    queryRepository = new SequelizeMediaQueryRepository({ sequelize });
+    await mediaRepository.sync();
+
+    await mediaRepository.save(createMedia({
+      mediaId: 'media-001',
+      title: '山田太郎の冒険',
+      contents: ['/contents/a-1.jpg', '/contents/a-2.jpg'],
+      tags: [
+        { category: '作者', label: '山田太郎' },
+        { category: 'ジャンル', label: 'バトル' },
+      ],
+      priorityCategories: ['作者', 'ジャンル'],
+    }));
+
+    await mediaRepository.save(createMedia({
+      mediaId: 'media-002',
+      title: '佐藤花子の日常',
+      contents: ['/contents/b-1.jpg'],
+      tags: [
+        { category: '作者', label: '佐藤花子' },
+        { category: 'ジャンル', label: '日常' },
+      ],
+      priorityCategories: ['ジャンル', '作者'],
+    }));
+  });
+
+  afterEach(async () => {
+    await sequelize.close();
+  });
+
+  test('search は一覧表示に必要な概要情報と totalCount を返す', async () => {
+    const result = await queryRepository.search(new SearchCondition({
+      title: '山田',
+      tags: [new SearchConditionTag({ category: 'ジャンル', label: 'バトル' })],
+      sortType: SortType.TITLE_ASC,
+      start: 1,
+      size: 20,
+    }));
+
+    expect(result.totalCount).toBe(1);
+    expect(result.mediaOverviews).toEqual([
+      expect.objectContaining({
+        mediaId: 'media-001',
+        title: '山田太郎の冒険',
+        thumbnail: '/contents/a-1.jpg',
+        priorityCategories: ['作者', 'ジャンル'],
+        tags: [
+          expect.objectContaining({ category: '作者', label: '山田太郎' }),
+          expect.objectContaining({ category: 'ジャンル', label: 'バトル' }),
+        ],
+      }),
+    ]);
+  });
+});

--- a/__tests__/small/app/createApp.test.js
+++ b/__tests__/small/app/createApp.test.js
@@ -72,14 +72,14 @@ describe('createApp', () => {
     });
   });
 
-  test('固定セッション設定がある場合は /screen/entry と /screen/search と /api/media で認証を補完し、/screen/login を表示できる', async () => {
+  test('固定セッション設定がある場合は /screen/entry と /screen/search と /screen/summary と /api/media で認証を補完し、/screen/login を表示できる', async () => {
     app = createApp({
       databaseStoragePath: databasePath,
       contentRootDirectory,
       devSessionToken: 'dev-token',
       devSessionUserId: 'admin-dev',
       devSessionTtlMs: 60_000,
-      devSessionPaths: ['/screen/entry', '/screen/search', '/api/media'],
+      devSessionPaths: ['/screen/entry', '/screen/search', '/screen/summary', '/api/media'],
     });
 
     await app.locals.ready;
@@ -93,6 +93,12 @@ describe('createApp', () => {
     expect(searchResponse.status).toBe(200);
     expect(searchResponse.type).toBe('text/html');
     expect(searchResponse.text).toContain('<title>メディア検索</title>');
+
+
+    const summaryResponse = await request(app).get('/screen/summary');
+    expect(summaryResponse.status).toBe(200);
+    expect(summaryResponse.type).toBe('text/html');
+    expect(summaryResponse.text).toContain('<title>メディア一覧</title>');
 
     const loginResponse = await request(app).get('/screen/login');
     expect(loginResponse.status).toBe(200);

--- a/__tests__/small/applicationService/media/query/SearchMediaService.test.js
+++ b/__tests__/small/applicationService/media/query/SearchMediaService.test.js
@@ -47,6 +47,7 @@ describe("SearchMediaService", () => {
     mockRepo.search.mockResolvedValue(new SearchResult({
       mediaOverviews: [
         new MediaOverview({
+          mediaId: 'media-001',
           title: 'Title',
           thumbnail: 'ID',
           tags: [new MediaOverviewTag({ category: 'C', label: 'L' })],
@@ -62,6 +63,7 @@ describe("SearchMediaService", () => {
     // assert
     expect(result).toEqual(new Output({
       mediaOverviews: [{
+        mediaId: 'media-001',
         title: 'Title',
         thumbnail: 'ID',
         tags: [{ category: 'C', label: 'L' }],

--- a/__tests__/small/controller/router/screen/setRouterScreenSummaryGet.test.js
+++ b/__tests__/small/controller/router/screen/setRouterScreenSummaryGet.test.js
@@ -1,0 +1,80 @@
+const express = require('express');
+const path = require('path');
+
+const setRouterScreenSummaryGet = require('../../../../../src/controller/router/screen/setRouterScreenSummaryGet');
+const SessionStateAuthAdapter = require('../../../../../src/infrastructure/SessionStateAuthAdapter');
+const { Output } = require('../../../../../src/application/media/query/SearchMediaService');
+
+class InMemorySessionStateStore {
+  constructor(entries = []) {
+    this.tokenToUserId = new Map(entries);
+  }
+
+  findUserIdBySessionToken(sessionToken) {
+    return this.tokenToUserId.get(sessionToken) ?? null;
+  }
+}
+
+describe('setRouterScreenSummaryGet', () => {
+  const createApp = ({ output } = {}) => {
+    const app = express();
+    const router = express.Router();
+    const searchMediaService = {
+      execute: jest.fn().mockResolvedValue(output ?? new Output({ mediaOverviews: [], totalCount: 0 })),
+    };
+
+    app.set('views', path.join(process.cwd(), 'src', 'views'));
+    app.set('view engine', 'ejs');
+    app.use((req, _res, next) => {
+      req.session = { session_token: req.header('x-session-token') };
+      req.context = {};
+      next();
+    });
+
+    setRouterScreenSummaryGet({
+      router,
+      authResolver: new SessionStateAuthAdapter({
+        sessionStateStore: new InMemorySessionStateStore([['valid-token', 'user-001']]),
+      }),
+      searchMediaService,
+    });
+
+    app.use(router);
+    return { app, searchMediaService };
+  };
+
+  test('GET /screen/summary で検索結果HTMLを返す', async () => {
+    const { app, searchMediaService } = createApp({
+      output: new Output({
+        mediaOverviews: [{
+          mediaId: 'media-001',
+          title: 'タイトル1',
+          thumbnail: '/contents/1.jpg',
+          tags: [{ category: '作者', label: '山田' }],
+          priorityCategories: ['作者'],
+        }],
+        totalCount: 1,
+      }),
+    });
+
+    const server = app.listen(0);
+    await new Promise(resolve => server.once('listening', resolve));
+    const { port } = server.address();
+    const response = await fetch(`http://127.0.0.1:${port}/screen/summary?summaryPage=2&title=太郎&tags=%E4%BD%9C%E8%80%85%3A%E5%B1%B1%E7%94%B0&sort=title_desc`, {
+      headers: { 'x-session-token': 'valid-token' },
+    });
+    const bodyText = await response.text();
+    await new Promise(resolve => server.close(resolve));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toContain('text/html');
+    expect(bodyText).toContain('<title>メディア一覧</title>');
+    expect(bodyText).toContain('タイトル1');
+    expect(bodyText).toContain('/screen/detail/media-001');
+    expect(searchMediaService.execute).toHaveBeenCalledWith(expect.objectContaining({
+      title: '太郎',
+      tags: [{ category: '作者', label: '山田' }],
+      start: 21,
+    }));
+  });
+});

--- a/src/app/createDependencies.js
+++ b/src/app/createDependencies.js
@@ -8,12 +8,15 @@ const setRouterScreenEntryGet = require('../controller/router/screen/setRouterSc
 const setRouterScreenErrorGet = require('../controller/router/screen/setRouterScreenErrorGet');
 const setRouterScreenLoginGet = require('../controller/router/screen/setRouterScreenLoginGet');
 const setRouterScreenSearchGet = require('../controller/router/screen/setRouterScreenSearchGet');
+const setRouterScreenSummaryGet = require('../controller/router/screen/setRouterScreenSummaryGet');
 const InMemorySessionStateStore = require('../infrastructure/InMemorySessionStateStore');
 const MulterDiskStorageContentUploadAdapter = require('../infrastructure/MulterDiskStorageContentUploadAdapter');
 const SequelizeMediaRepository = require('../infrastructure/SequelizeMediaRepository');
+const SequelizeMediaQueryRepository = require('../infrastructure/SequelizeMediaQueryRepository');
 const SequelizeUnitOfWork = require('../infrastructure/SequelizeUnitOfWork');
 const SessionStateAuthAdapter = require('../infrastructure/SessionStateAuthAdapter');
 const UUIDMediaIdValueGenerator = require('../infrastructure/UUIDMediaIdValueGenerator');
+const { SearchMediaService } = require('../application/media/query/SearchMediaService');
 const { hasDevelopmentSession } = require('./developmentSession');
 
 const ensureParentDirectory = targetPath => {
@@ -41,6 +44,8 @@ const createDependencies = (env = {}) => {
     unitOfWorkContext: unitOfWork,
   });
   const sessionStateStore = new InMemorySessionStateStore();
+  const mediaQueryRepository = new SequelizeMediaQueryRepository({ sequelize });
+  const searchMediaService = new SearchMediaService({ mediaQueryRepository });
 
   if (hasDevelopmentSession(env)) {
     sessionStateStore.save({
@@ -54,6 +59,8 @@ const createDependencies = (env = {}) => {
     sequelize,
     unitOfWork,
     mediaRepository,
+    mediaQueryRepository,
+    searchMediaService,
     sessionStateStore,
     authResolver: new SessionStateAuthAdapter({
       sessionStateStore,
@@ -68,6 +75,7 @@ const createDependencies = (env = {}) => {
       setRouterScreenErrorGet,
       setRouterScreenLoginGet,
       setRouterScreenSearchGet,
+      setRouterScreenSummaryGet,
     },
   };
 

--- a/src/app/setupRoutes.js
+++ b/src/app/setupRoutes.js
@@ -18,6 +18,11 @@ const setupRoutes = (app, { env: _env, dependencies } = {}) => {
     router,
     authResolver: dependencies.authResolver,
   });
+  dependencies.routeSetters.setRouterScreenSummaryGet({
+    router,
+    authResolver: dependencies.authResolver,
+    searchMediaService: dependencies.searchMediaService,
+  });
 
   dependencies.routeSetters.setRouterApiMediaPost({
     router,

--- a/src/application/media/port/SearchResult.js
+++ b/src/application/media/port/SearchResult.js
@@ -1,3 +1,5 @@
+const isMediaOverviewTagLike = tag => typeof tag?.category === 'string' && typeof tag?.label === 'string';
+
 class MediaOverviewTag {
   constructor({ category, label }) {
     if (typeof category !== 'string') {
@@ -12,6 +14,14 @@ class MediaOverviewTag {
   }
 }
 
+const isMediaOverviewLike = mediaOverview => typeof mediaOverview?.mediaId === 'string'
+  && typeof mediaOverview?.title === 'string'
+  && typeof mediaOverview?.thumbnail === 'string'
+  && Array.isArray(mediaOverview?.tags)
+  && mediaOverview.tags.every(isMediaOverviewTagLike)
+  && Array.isArray(mediaOverview?.priorityCategories)
+  && mediaOverview.priorityCategories.every(priorityCategory => typeof priorityCategory === 'string');
+
 class MediaOverview {
   constructor({ mediaId, title, thumbnail, tags, priorityCategories }) {
     if (typeof mediaId !== 'string') {
@@ -23,7 +33,7 @@ class MediaOverview {
     if (typeof thumbnail !== 'string') {
       throw new Error();
     }
-    if (!(tags instanceof Array) || !tags.every(tag => tag instanceof MediaOverviewTag)) {
+    if (!(tags instanceof Array) || !tags.every(isMediaOverviewTagLike)) {
       throw new Error();
     }
     if (!(priorityCategories instanceof Array) || !priorityCategories.every(pc => typeof pc === 'string')) {
@@ -40,14 +50,17 @@ class MediaOverview {
 
 class SearchResult {
   constructor({ mediaOverviews, totalCount }) {
-    if (!(mediaOverviews instanceof Array) || !mediaOverviews.every(mov => mov instanceof MediaOverview)) {
+    if (!(mediaOverviews instanceof Array) || !mediaOverviews.every(isMediaOverviewLike)) {
       throw new Error();
     }
     if (typeof totalCount !== 'number' || totalCount < 0 || !Number.isInteger(totalCount)) {
       throw new Error();
     }
 
-    this.mediaOverviews = mediaOverviews;
+    this.mediaOverviews = mediaOverviews.map(mediaOverview => new MediaOverview({
+      ...mediaOverview,
+      tags: mediaOverview.tags.map(tag => new MediaOverviewTag(tag)),
+    }));
     this.totalCount = totalCount;
   }
 }

--- a/src/application/media/port/SearchResult.js
+++ b/src/application/media/port/SearchResult.js
@@ -50,7 +50,7 @@ class MediaOverview {
 
 class SearchResult {
   constructor({ mediaOverviews, totalCount }) {
-    if (!(mediaOverviews instanceof Array) || !mediaOverviews.every(isMediaOverviewLike)) {
+    if (!Array.isArray(mediaOverviews) || !mediaOverviews.every(isMediaOverviewLike)) {
       throw new Error();
     }
     if (typeof totalCount !== 'number' || totalCount < 0 || !Number.isInteger(totalCount)) {

--- a/src/application/media/port/SearchResult.js
+++ b/src/application/media/port/SearchResult.js
@@ -13,7 +13,10 @@ class MediaOverviewTag {
 }
 
 class MediaOverview {
-  constructor({ title, thumbnail, tags, priorityCategories }) {
+  constructor({ mediaId, title, thumbnail, tags, priorityCategories }) {
+    if (typeof mediaId !== 'string') {
+      throw new Error();
+    }
     if (typeof title !== 'string') {
       throw new Error();
     }
@@ -27,6 +30,7 @@ class MediaOverview {
       throw new Error();
     }
 
+    this.mediaId = mediaId;
     this.title = title;
     this.thumbnail = thumbnail;
     this.tags = tags;

--- a/src/application/media/query/SearchMediaService.js
+++ b/src/application/media/query/SearchMediaService.js
@@ -30,6 +30,9 @@ class Input {
 }
 
 const isMediaOverviewLike = (obj) => {
+  if (typeof obj.mediaId !== 'string') {
+    return false;
+  }
   if (typeof obj.title !== 'string') {
     return false;
   }
@@ -54,6 +57,9 @@ const isMediaOverviewLike = (obj) => {
 class Output {
   constructor({ mediaOverviews, totalCount }) {
     if (!(mediaOverviews instanceof Array) || !mediaOverviews.every(isMediaOverviewLike)) {
+      throw new Error();
+    }
+    if (typeof totalCount !== 'number' || totalCount < 0 || !Number.isInteger(totalCount)) {
       throw new Error();
     }
 

--- a/src/controller/router/screen/setRouterScreenSummaryGet.js
+++ b/src/controller/router/screen/setRouterScreenSummaryGet.js
@@ -1,0 +1,116 @@
+const SessionAuthMiddleware = require('../../middleware/SessionAuthMiddleware');
+const {
+  Input,
+  InputSortType,
+} = require('../../../application/media/query/SearchMediaService');
+
+const SORT_TYPES_BY_QUERY = Object.freeze({
+  date_asc: InputSortType.DATE_ASC,
+  date_desc: InputSortType.DATE_DESC,
+  title_asc: InputSortType.TITLE_ASC,
+  title_desc: InputSortType.TITLE_DESC,
+  random: InputSortType.RANDOM,
+});
+
+const normalizeTags = (rawTags) => {
+  const values = rawTags === undefined ? [] : (Array.isArray(rawTags) ? rawTags : [rawTags]);
+
+  return values
+    .filter(value => typeof value === 'string')
+    .map(value => value.trim())
+    .filter(value => value.length > 0)
+    .map(value => {
+      const separatorIndex = value.indexOf(':');
+      if (separatorIndex <= 0 || separatorIndex >= value.length - 1) {
+        return null;
+      }
+
+      return {
+        category: value.slice(0, separatorIndex).trim(),
+        label: value.slice(separatorIndex + 1).trim(),
+      };
+    })
+    .filter(tag => tag && tag.category.length > 0 && tag.label.length > 0);
+};
+
+const createPagination = ({ totalCount, summaryPage, pageSize }) => {
+  const totalPages = Math.max(1, Math.ceil(totalCount / pageSize));
+  const currentPage = Math.min(Math.max(summaryPage, 1), totalPages);
+  const pages = [];
+
+  for (let page = 1; page <= totalPages; page += 1) {
+    const isEdge = page === 1 || page === totalPages;
+    const isNearCurrent = Math.abs(page - currentPage) <= 1;
+    if (isEdge || isNearCurrent || totalPages <= 7) {
+      pages.push(page);
+    }
+  }
+
+  const items = [];
+  pages.forEach(page => {
+    if (items.length > 0 && page - items[items.length - 1] > 1) {
+      items.push('ellipsis');
+    }
+    items.push(page);
+  });
+
+  return { totalPages, currentPage, items };
+};
+
+const setRouterScreenSummaryGet = ({ router, authResolver, searchMediaService }) => {
+  const auth = new SessionAuthMiddleware(authResolver);
+
+  router.get('/screen/summary', ...[
+    auth.execute.bind(auth),
+    async (req, res, next) => {
+      try {
+        const summaryPage = Math.max(Number.parseInt(req.query.summaryPage ?? '1', 10) || 1, 1);
+        const title = typeof req.query.title === 'string' ? req.query.title : '';
+        const tags = normalizeTags(req.query.tags);
+        const sort = typeof req.query.sort === 'string' && SORT_TYPES_BY_QUERY[req.query.sort]
+          ? req.query.sort
+          : 'date_asc';
+
+        const result = await searchMediaService.execute(new Input({
+          title,
+          tags,
+          sortType: SORT_TYPES_BY_QUERY[sort],
+          start: ((summaryPage - 1) * 20) + 1,
+        }));
+
+        const pagination = createPagination({
+          totalCount: result.totalCount,
+          summaryPage,
+          pageSize: 20,
+        });
+
+        res.status(200).render('screen/summary', {
+          pageTitle: 'メディア一覧',
+          currentConditions: {
+            summaryPage: pagination.currentPage,
+            title,
+            tags,
+            sort,
+          },
+          mediaOverviews: result.mediaOverviews,
+          totalCount: result.totalCount,
+          pagination,
+          sortOptions: [
+            { value: 'date_asc', label: '登録の新しい順' },
+            { value: 'date_desc', label: '登録の古い順' },
+            { value: 'title_asc', label: 'タイトル名の昇順' },
+            { value: 'title_desc', label: 'タイトル名の降順' },
+            { value: 'random', label: 'ランダム' },
+          ],
+        });
+      } catch (error) {
+        next(error);
+      }
+    },
+  ]);
+};
+
+module.exports = setRouterScreenSummaryGet;
+module.exports.SORT_TYPES_BY_QUERY = SORT_TYPES_BY_QUERY;
+module.exports.normalizeTags = normalizeTags;
+module.exports.createPagination = createPagination;

--- a/src/infrastructure/SequelizeMediaQueryRepository.js
+++ b/src/infrastructure/SequelizeMediaQueryRepository.js
@@ -1,0 +1,219 @@
+const { Op } = require('sequelize');
+
+const IMediaQueryRepository = require('../application/media/port/IMediaQueryRepository');
+const { SearchCondition, SortType } = require('../application/media/port/SearchCondition');
+const {
+  SearchResult,
+  MediaOverview,
+  MediaOverviewTag,
+} = require('../application/media/port/SearchResult');
+const { defineModels } = require('./SequelizeMediaRepository');
+
+const buildSortOrder = (sortType) => {
+  switch (sortType) {
+    case SortType.DATE_ASC:
+      return [['createdAtProxy', 'DESC'], ['media_id', 'ASC']];
+    case SortType.DATE_DESC:
+      return [['createdAtProxy', 'ASC'], ['media_id', 'ASC']];
+    case SortType.TITLE_ASC:
+      return [['title', 'ASC'], ['media_id', 'ASC']];
+    case SortType.TITLE_DESC:
+      return [['title', 'DESC'], ['media_id', 'ASC']];
+    case SortType.RANDOM:
+      return null;
+    default:
+      throw new Error();
+  }
+};
+
+module.exports = class SequelizeMediaQueryRepository extends IMediaQueryRepository {
+  #models;
+
+  constructor({ sequelize, models } = {}) {
+    super();
+
+    if (!sequelize || typeof sequelize.random !== 'function') {
+      throw new Error();
+    }
+
+    this.sequelize = sequelize;
+    this.#models = models || defineModels(sequelize);
+  }
+
+  async search(condition) {
+    if (!(condition instanceof SearchCondition)) {
+      throw new Error();
+    }
+
+    const { MediaModel, ContentModel, TagModel, CategoryModel, MediaTagModel, MediaCategoryModel } = this.#models;
+
+    const mediaIds = await this.#findMatchedMediaIds({
+      condition,
+      MediaModel,
+      CategoryModel,
+      TagModel,
+      MediaTagModel,
+    });
+
+    if (mediaIds.length === 0) {
+      return new SearchResult({ mediaOverviews: [], totalCount: 0 });
+    }
+
+    const totalCount = mediaIds.length;
+    const pagedIds = await this.#paginateMediaIds({
+      mediaIds,
+      condition,
+      MediaModel,
+    });
+
+    if (pagedIds.length === 0) {
+      return new SearchResult({ mediaOverviews: [], totalCount });
+    }
+
+    const [contentRows, tagRows, categoryRows, mediaRows] = await Promise.all([
+      ContentModel.findAll({
+        where: { media_id: pagedIds },
+        order: [['media_id', 'ASC'], ['position', 'ASC']],
+      }),
+      MediaTagModel.findAll({
+        where: { media_id: pagedIds },
+        include: [{
+          model: TagModel,
+          as: 'tag',
+          include: [{ model: CategoryModel, as: 'category' }],
+        }],
+      }),
+      MediaCategoryModel.findAll({
+        where: { media_id: pagedIds },
+        include: [{ model: CategoryModel, as: 'category' }],
+        order: [['media_id', 'ASC'], ['priority', 'ASC']],
+      }),
+      MediaModel.findAll({ where: { media_id: pagedIds } }),
+    ]);
+
+    const mediaRowMap = new Map(mediaRows.map(row => [row.media_id, row]));
+    const thumbnailMap = new Map();
+    contentRows.forEach(row => {
+      if (!thumbnailMap.has(row.media_id)) {
+        thumbnailMap.set(row.media_id, row.content_id);
+      }
+    });
+
+    const tagsMap = new Map();
+    tagRows.forEach(row => {
+      const items = tagsMap.get(row.media_id) ?? [];
+      items.push(new MediaOverviewTag({
+        category: row.tag.category.name,
+        label: row.tag.name,
+      }));
+      tagsMap.set(row.media_id, items);
+    });
+
+    const priorityCategoriesMap = new Map();
+    categoryRows.forEach(row => {
+      const items = priorityCategoriesMap.get(row.media_id) ?? [];
+      items.push(row.category.name);
+      priorityCategoriesMap.set(row.media_id, items);
+    });
+
+    const mediaOverviews = pagedIds
+      .map(mediaId => mediaRowMap.get(mediaId))
+      .filter(Boolean)
+      .map(row => new MediaOverview({
+        mediaId: row.media_id,
+        title: row.title,
+        thumbnail: thumbnailMap.get(row.media_id) ?? '',
+        tags: this.#sortTags({
+          tags: tagsMap.get(row.media_id) ?? [],
+          priorityCategories: priorityCategoriesMap.get(row.media_id) ?? [],
+        }),
+        priorityCategories: priorityCategoriesMap.get(row.media_id) ?? [],
+      }));
+
+    return new SearchResult({ mediaOverviews, totalCount });
+  }
+
+  #sortTags({ tags, priorityCategories }) {
+    const priorityMap = new Map(priorityCategories.map((category, index) => [category, index]));
+
+    return [...tags].sort((a, b) => {
+      const aPriority = priorityMap.has(a.category) ? priorityMap.get(a.category) : Number.MAX_SAFE_INTEGER;
+      const bPriority = priorityMap.has(b.category) ? priorityMap.get(b.category) : Number.MAX_SAFE_INTEGER;
+      if (aPriority !== bPriority) {
+        return aPriority - bPriority;
+      }
+      if (a.category !== b.category) {
+        return a.category.localeCompare(b.category, 'ja');
+      }
+      return a.label.localeCompare(b.label, 'ja');
+    });
+  }
+
+  async #findMatchedMediaIds({ condition, MediaModel, CategoryModel, TagModel, MediaTagModel }) {
+    const where = {};
+    if (condition.title.length > 0) {
+      where.title = { [Op.like]: `%${condition.title}%` };
+    }
+
+    const mediaRows = await MediaModel.findAll({
+      where,
+      attributes: ['media_id'],
+    });
+    let matchedMediaIds = mediaRows.map(row => row.media_id);
+
+    for (const tag of condition.tags) {
+      if (matchedMediaIds.length === 0) {
+        return [];
+      }
+
+      const categoryRow = await CategoryModel.findOne({ where: { name: tag.category } });
+      if (!categoryRow) {
+        return [];
+      }
+
+      const tagRow = await TagModel.findOne({
+        where: {
+          category_id: categoryRow.category_id,
+          name: tag.label,
+        },
+      });
+      if (!tagRow) {
+        return [];
+      }
+
+      const mediaTagRows = await MediaTagModel.findAll({
+        where: {
+          media_id: matchedMediaIds,
+          tag_id: tagRow.tag_id,
+        },
+        attributes: ['media_id'],
+      });
+
+      matchedMediaIds = mediaTagRows.map(row => row.media_id);
+    }
+
+    return matchedMediaIds;
+  }
+
+  async #paginateMediaIds({ mediaIds, condition, MediaModel }) {
+    const order = buildSortOrder(condition.sortType);
+    const query = {
+      where: { media_id: mediaIds },
+      attributes: [
+        'media_id',
+        [this.sequelize.literal('rowid'), 'createdAtProxy'],
+      ],
+      offset: condition.start - 1,
+      limit: condition.size,
+    };
+
+    if (order) {
+      query.order = order;
+    } else {
+      query.order = this.sequelize.random();
+    }
+
+    const rows = await MediaModel.findAll(query);
+    return rows.map(row => row.media_id);
+  }
+};

--- a/src/views/screen/summary.ejs
+++ b/src/views/screen/summary.ejs
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title><%= pageTitle %></title>
+    <style>
+      :root {
+        color-scheme: light;
+        font-family: "Hiragino Sans", "Yu Gothic UI", sans-serif;
+        background: #f5f6f8;
+        color: #1f2937;
+      }
+      * { box-sizing: border-box; }
+      body { margin: 0; background: #f5f6f8; }
+      a { color: #2563eb; text-decoration: none; }
+      a:hover { text-decoration: underline; }
+      .page { max-width: 1080px; margin: 0 auto; padding: 32px 16px 64px; }
+      .stack { display: grid; gap: 24px; }
+      .card {
+        background: #fff; border: 1px solid #d1d5db; border-radius: 16px; padding: 24px;
+        box-shadow: 0 10px 30px rgba(15, 23, 42, 0.06);
+      }
+      h1 { margin: 0 0 12px; font-size: 32px; }
+      .condition-list, .tag-list { display: flex; gap: 8px; flex-wrap: wrap; }
+      .chip { background: #eff6ff; color: #1d4ed8; border-radius: 999px; padding: 6px 12px; font-size: 14px; }
+      .summary-header { display:flex; justify-content:space-between; gap:16px; align-items:center; flex-wrap:wrap; }
+      .media-grid { display: grid; gap: 16px; }
+      .media-card { border: 1px solid #dbe3f0; border-radius: 16px; background: #f8fafc; padding: 16px; }
+      .media-body { display: grid; grid-template-columns: 160px 1fr; gap: 16px; }
+      .thumbnail {
+        width: 160px; height: 120px; border-radius: 12px; background: #dbeafe; overflow: hidden;
+        display:flex; align-items:center; justify-content:center; color:#1d4ed8; font-size:12px;
+      }
+      .thumbnail img { width:100%; height:100%; object-fit:cover; }
+      .meta { display:grid; gap: 12px; }
+      .actions { display:flex; gap:12px; flex-wrap:wrap; }
+      .priority { font-size: 14px; color: #475569; }
+      .pagination { display:flex; gap:8px; flex-wrap:wrap; align-items:center; }
+      .page-link, .page-current, .ellipsis {
+        min-width: 40px; height: 40px; border-radius: 999px; display:inline-flex; align-items:center; justify-content:center;
+        border: 1px solid #cbd5e1; background: #fff; padding: 0 12px;
+      }
+      .page-current { background: #2563eb; color: #fff; border-color: #2563eb; }
+      .empty { color: #64748b; }
+      .sort-form { display:flex; gap:12px; align-items:center; flex-wrap:wrap; }
+      .select-input { border: 1px solid #cbd5e1; border-radius: 10px; padding: 10px 14px; background:#fff; }
+      .button { border: 0; border-radius: 10px; padding: 10px 16px; background:#2563eb; color:#fff; cursor:pointer; }
+      @media (max-width: 720px) {
+        .media-body { grid-template-columns: 1fr; }
+        .thumbnail { width: 100%; height: 200px; }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="page">
+      <div class="stack">
+        <section class="card">
+          <h1><%= pageTitle %></h1>
+          <p>現在の検索条件</p>
+          <div class="condition-list">
+            <% if (currentConditions.title) { %>
+              <span class="chip">タイトル: <%= currentConditions.title %></span>
+            <% } %>
+            <% currentConditions.tags.forEach((tag) => { %>
+              <span class="chip"><%= tag.category %>:<%= tag.label %></span>
+            <% }) %>
+            <% if (!currentConditions.title && currentConditions.tags.length === 0) { %>
+              <span class="chip">条件なし</span>
+            <% } %>
+          </div>
+        </section>
+
+        <section class="card">
+          <div class="summary-header">
+            <p><strong><%= totalCount %></strong> 件</p>
+            <form class="sort-form" method="get" action="/screen/summary">
+              <input type="hidden" name="summaryPage" value="1" />
+              <% if (currentConditions.title) { %><input type="hidden" name="title" value="<%= currentConditions.title %>" /><% } %>
+              <% currentConditions.tags.forEach((tag) => { %>
+                <input type="hidden" name="tags" value="<%= `${tag.category}:${tag.label}` %>" />
+              <% }) %>
+              <label for="sort">並び順</label>
+              <select id="sort" name="sort" class="select-input" onchange="this.form.submit()">
+                <% sortOptions.forEach((option) => { %>
+                  <option value="<%= option.value %>" <%= currentConditions.sort === option.value ? 'selected' : '' %>><%= option.label %></option>
+                <% }) %>
+              </select>
+              <noscript><button class="button" type="submit">更新</button></noscript>
+            </form>
+          </div>
+
+          <% if (mediaOverviews.length === 0) { %>
+            <p class="empty">検索結果0件ラベル</p>
+          <% } else { %>
+            <div class="media-grid">
+              <% mediaOverviews.forEach((media) => { %>
+                <article class="media-card">
+                  <div class="media-body">
+                    <a class="thumbnail" href="/screen/detail/<%= media.mediaId %>">
+                      <% if (media.thumbnail) { %>
+                        <img src="<%= media.thumbnail %>" alt="<%= media.title %> のサムネイル" />
+                      <% } else { %>
+                        <span>NO IMAGE</span>
+                      <% } %>
+                    </a>
+                    <div class="meta">
+                      <div>
+                        <h2><a href="/screen/detail/<%= media.mediaId %>"><%= media.title %></a></h2>
+                        <% if (media.priorityCategories.length > 0) { %>
+                          <p class="priority">優先カテゴリ: <%= media.priorityCategories.join(' / ') %></p>
+                        <% } %>
+                      </div>
+                      <div class="tag-list">
+                        <% media.tags.forEach((tag) => { %>
+                          <a class="chip" href="/screen/summary?summaryPage=1&sort=<%= currentConditions.sort %>&tags=<%= encodeURIComponent(`${tag.category}:${tag.label}`) %>"><%= tag.category %>:<%= tag.label %></a>
+                        <% }) %>
+                      </div>
+                      <div class="actions">
+                        <a href="/screen/detail/<%= media.mediaId %>">詳細画面へ</a>
+                        <a href="/screen/viewer/<%= media.mediaId %>/1">ビューアー先頭ページへ</a>
+                      </div>
+                    </div>
+                  </div>
+                </article>
+              <% }) %>
+            </div>
+          <% } %>
+        </section>
+
+        <nav class="card">
+          <div class="pagination">
+            <% pagination.items.forEach((item) => { %>
+              <% if (item === 'ellipsis') { %>
+                <span class="ellipsis">...</span>
+              <% } else if (item === pagination.currentPage) { %>
+                <span class="page-current"><%= item %></span>
+              <% } else { %>
+                <% const params = new URLSearchParams(); %>
+                <% params.set('summaryPage', String(item)); %>
+                <% params.set('sort', currentConditions.sort); %>
+                <% if (currentConditions.title) { params.set('title', currentConditions.title); } %>
+                <% currentConditions.tags.forEach((tag) => params.append('tags', `${tag.category}:${tag.label}`)); %>
+                <a class="page-link" href="/screen/summary?<%= params.toString() %>"><%= item %></a>
+              <% } %>
+            <% }) %>
+          </div>
+        </nav>
+      </div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
### Motivation
- メディア一覧画面で表示に必要な単位（サムネイル、タグ、優先カテゴリ、`mediaId`）と検索結果の `totalCount` を永続層から取得できるようにするため。 
- 画面から渡される検索条件（`summaryPage` / `title` / `tags` / `sort`）を `SearchMediaService` に渡して一覧を描画するコントローラとビューが必要だったため。 

### Description
- 永続化層に `SequelizeMediaQueryRepository` を追加し、タイトル/タグで絞り込み、ソート・ページングを行って `SearchResult`（`mediaOverviews` と `totalCount`）を返すよう実装しました (`src/infrastructure/SequelizeMediaQueryRepository.js`)。 
- `SearchResult` と `SearchMediaService` を拡張して `mediaId` を扱えるようにし、出力のバリデーションを強化しました (`src/application/media/port/SearchResult.js`, `src/application/media/query/SearchMediaService.js`)。 
- 認証ミドルウェア付きの画面ルート `GET /screen/summary` 用コントローラを追加し、クエリ文字列を解釈して `SearchMediaService` に渡しページネーションを組み立てるようにしました (`src/controller/router/screen/setRouterScreenSummaryGet.js`)。 
- 一覧表示用のテンプレート `src/views/screen/summary.ejs` を追加し、現在の検索条件カード、件数、サムネイル、タイトル、タグ、詳細/ビューアーへの導線、ページネーションを描画します。 
- 依存の配線を `createDependencies` と `setupRoutes` に追加して `mediaQueryRepository` / `searchMediaService` / ルートセッタを登録し、開発用固定セッションで `summary` が有効になるようにしました (`src/app/createDependencies.js`, `src/app/setupRoutes.js`)。 
- 小/中規模の自動テストを追加・更新し、`SearchMediaService` と `SequelizeMediaQueryRepository`、および `setRouterScreenSummaryGet` のルート周りのテストを追加しました（`__tests__/...`）。 

### Testing
- `node --check` による変更ファイルの構文チェック（`src/infrastructure/SequelizeMediaQueryRepository.js`、`src/controller/router/screen/setRouterScreenSummaryGet.js`、`src/app/createDependencies.js`、`src/app/setupRoutes.js` 等）は問題なく通過しました。 
- 追加した Jest テスト群（`__tests__/small/...` と `__tests__/medium/...`）はプロジェクトにインストールされたテストランナー環境での実行を想定していますが、今回の実行環境では `jest` が見つからずテスト実行ができませんでした（`jest: not found`）。 
- アプリ起動による統合確認を試みましたが、実行環境に `sequelize` が存在しないため起動できませんでした（`Cannot find module 'sequelize'`）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf0df174ac832bbc702e4753ef5e49)