### PR TITLE
ビューアー画面とコンテンツ配信ルートを追加

### DIFF
--- a/__tests__/small/app/createApp.test.js
+++ b/__tests__/small/app/createApp.test.js
@@ -72,14 +72,14 @@ describe('createApp', () => {
     });
   });
 
-  test('固定セッション設定がある場合は /screen/entry と /screen/search と /screen/summary と /api/media で認証を補完し、/screen/login を表示できる', async () => {
+  test('固定セッション設定がある場合は /screen/entry と /screen/search と /screen/summary と /screen/viewer と /api/media で認証を補完し、/screen/login を表示できる', async () => {
     app = createApp({
       databaseStoragePath: databasePath,
       contentRootDirectory,
       devSessionToken: 'dev-token',
       devSessionUserId: 'admin-dev',
       devSessionTtlMs: 60_000,
-      devSessionPaths: ['/screen/entry', '/screen/search', '/screen/summary', '/api/media'],
+      devSessionPaths: ['/screen/entry', '/screen/search', '/screen/summary', '/screen/viewer', '/api/media'],
     });
 
     await app.locals.ready;
@@ -100,24 +100,31 @@ describe('createApp', () => {
     expect(summaryResponse.type).toBe('text/html');
     expect(summaryResponse.text).toContain('<title>メディア一覧</title>');
 
-    const loginResponse = await request(app).get('/screen/login');
-    expect(loginResponse.status).toBe(200);
-    expect(loginResponse.type).toBe('text/html');
-    expect(loginResponse.text).toContain('<title>ログイン</title>');
-    expect(loginResponse.text).toContain('action="/api/login"');
-
     const mediaResponse = await request(app)
       .post('/api/media')
       .field('title', 'sample title')
       .field('tags[0][category]', '作者')
       .field('tags[0][label]', '山田')
       .field('contents[0][position]', '1')
-      .attach('contents[0][file]', Buffer.from('a'), 'first.jpg');
+      .attach('contents[0][file]', Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]), 'first.png');
 
     expect(mediaResponse.status).toBe(200);
     expect(mediaResponse.body).toEqual({
       code: 0,
       mediaId: expect.stringMatching(/^[0-9a-f]{32}$/),
     });
+
+    const viewerResponse = await request(app).get(`/screen/viewer/${mediaResponse.body.mediaId}/1`);
+    expect(viewerResponse.status).toBe(200);
+    expect(viewerResponse.type).toBe('text/html');
+    expect(viewerResponse.text).toContain(`/screen/detail/${mediaResponse.body.mediaId}`);
+    expect(viewerResponse.text).toContain('/content/');
+
+    const loginResponse = await request(app).get('/screen/login');
+    expect(loginResponse.status).toBe(200);
+    expect(loginResponse.type).toBe('text/html');
+    expect(loginResponse.text).toContain('<title>ログイン</title>');
+    expect(loginResponse.text).toContain('action="/api/login"');
+
   });
 });

--- a/__tests__/small/controller/router/content/setRouterContentGet.test.js
+++ b/__tests__/small/controller/router/content/setRouterContentGet.test.js
@@ -1,0 +1,38 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const express = require('express');
+const request = require('supertest');
+
+const setRouterContentGet = require('../../../../../src/controller/router/content/setRouterContentGet');
+const { createContentStoragePath } = require('../../../../../src/presentation/content/contentAssetPaths');
+
+describe('setRouterContentGet', () => {
+  let rootDirectory;
+
+  beforeEach(() => {
+    rootDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'content-route-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(rootDirectory, { recursive: true, force: true });
+  });
+
+  test('保存形式に従って contentId からコンテンツを配信できる', async () => {
+    const contentId = '0123456789abcdef0123456789abcdef';
+    const contentPath = createContentStoragePath({ rootDirectory, contentId });
+    fs.mkdirSync(path.dirname(contentPath), { recursive: true });
+    fs.writeFileSync(contentPath, Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]));
+
+    const app = express();
+    const router = express.Router();
+    setRouterContentGet({ router, contentRootDirectory: rootDirectory });
+    app.use(router);
+
+    const response = await request(app).get('/content/01/23/45/67/0123456789abcdef0123456789abcdef');
+
+    expect(response.status).toBe(200);
+    expect(response.headers['content-type']).toContain('image/png');
+    expect(response.body).toEqual(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]));
+  });
+});

--- a/__tests__/small/controller/router/screen/setRouterScreenViewerGet.test.js
+++ b/__tests__/small/controller/router/screen/setRouterScreenViewerGet.test.js
@@ -1,0 +1,75 @@
+const express = require('express');
+const path = require('path');
+
+const setRouterScreenViewerGet = require('../../../../../src/controller/router/screen/setRouterScreenViewerGet');
+const SessionStateAuthAdapter = require('../../../../../src/infrastructure/SessionStateAuthAdapter');
+const {
+  FoundResult,
+} = require('../../../../../src/application/media/query/GetMediaContentWithNavigationService');
+
+class InMemorySessionStateStore {
+  constructor(entries = []) {
+    this.tokenToUserId = new Map(entries);
+  }
+
+  findUserIdBySessionToken(sessionToken) {
+    return this.tokenToUserId.get(sessionToken) ?? null;
+  }
+}
+
+describe('setRouterScreenViewerGet', () => {
+  const createApp = ({ result } = {}) => {
+    const app = express();
+    const router = express.Router();
+    const getMediaContentWithNavigationService = {
+      execute: jest.fn().mockResolvedValue(result ?? new FoundResult({
+        contentId: '0123456789abcdef0123456789abcdef',
+        previousContentId: null,
+        nextContentId: 'fedcba9876543210fedcba9876543210',
+      })),
+    };
+
+    app.set('views', path.join(process.cwd(), 'src', 'views'));
+    app.set('view engine', 'ejs');
+    app.use((req, _res, next) => {
+      req.session = { session_token: req.header('x-session-token') };
+      req.context = {};
+      next();
+    });
+
+    setRouterScreenViewerGet({
+      router,
+      authResolver: new SessionStateAuthAdapter({
+        sessionStateStore: new InMemorySessionStateStore([['valid-token', 'user-001']]),
+      }),
+      getMediaContentWithNavigationService,
+    });
+
+    app.use(router);
+    return { app, getMediaContentWithNavigationService };
+  };
+
+  test('GET /screen/viewer/:mediaId/:mediaPage で viewer HTML を返す', async () => {
+    const { app, getMediaContentWithNavigationService } = createApp();
+
+    const server = app.listen(0);
+    await new Promise(resolve => server.once('listening', resolve));
+    const { port } = server.address();
+    const response = await fetch(`http://127.0.0.1:${port}/screen/viewer/media-001/2`, {
+      headers: { 'x-session-token': 'valid-token' },
+    });
+    const bodyText = await response.text();
+    await new Promise(resolve => server.close(resolve));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toContain('text/html');
+    expect(bodyText).toContain('<title>ビューアー media-001 - 2ページ</title>');
+    expect(bodyText).toContain('/screen/viewer/media-001/3');
+    expect(bodyText).toContain('/screen/detail/media-001');
+    expect(bodyText).toContain('/content/01/23/45/67/0123456789abcdef0123456789abcdef');
+    expect(getMediaContentWithNavigationService.execute).toHaveBeenCalledWith(expect.objectContaining({
+      mediaId: 'media-001',
+      contentPosition: 2,
+    }));
+  });
+});

--- a/src/app/createDependencies.js
+++ b/src/app/createDependencies.js
@@ -3,6 +3,7 @@ const path = require('path');
 
 const { Sequelize } = require('sequelize');
 
+const setRouterContentGet = require('../controller/router/content/setRouterContentGet');
 const setRouterApiMediaPost = require('../controller/router/media/setRouterApiMediaPost');
 const setRouterScreenEntryGet = require('../controller/router/screen/setRouterScreenEntryGet');
 const setRouterScreenDetailGet = require('../controller/router/screen/setRouterScreenDetailGet');
@@ -10,6 +11,7 @@ const setRouterScreenErrorGet = require('../controller/router/screen/setRouterSc
 const setRouterScreenLoginGet = require('../controller/router/screen/setRouterScreenLoginGet');
 const setRouterScreenSearchGet = require('../controller/router/screen/setRouterScreenSearchGet');
 const setRouterScreenSummaryGet = require('../controller/router/screen/setRouterScreenSummaryGet');
+const setRouterScreenViewerGet = require('../controller/router/screen/setRouterScreenViewerGet');
 const InMemorySessionStateStore = require('../infrastructure/InMemorySessionStateStore');
 const MulterDiskStorageContentUploadAdapter = require('../infrastructure/MulterDiskStorageContentUploadAdapter');
 const SequelizeMediaRepository = require('../infrastructure/SequelizeMediaRepository');
@@ -19,6 +21,7 @@ const SessionStateAuthAdapter = require('../infrastructure/SessionStateAuthAdapt
 const UUIDMediaIdValueGenerator = require('../infrastructure/UUIDMediaIdValueGenerator');
 const { SearchMediaService } = require('../application/media/query/SearchMediaService');
 const { GetMediaDetailService } = require('../application/media/query/GetMediaDetailService');
+const { GetMediaContentWithNavigationService } = require('../application/media/query/GetMediaContentWithNavigationService');
 const { hasDevelopmentSession } = require('./developmentSession');
 
 const ensureParentDirectory = targetPath => {
@@ -49,6 +52,7 @@ const createDependencies = (env = {}) => {
   const mediaQueryRepository = new SequelizeMediaQueryRepository({ sequelize });
   const searchMediaService = new SearchMediaService({ mediaQueryRepository });
   const getMediaDetailService = new GetMediaDetailService({ mediaRepository });
+  const getMediaContentWithNavigationService = new GetMediaContentWithNavigationService({ mediaRepository });
 
   if (hasDevelopmentSession(env)) {
     sessionStateStore.save({
@@ -65,6 +69,7 @@ const createDependencies = (env = {}) => {
     mediaQueryRepository,
     searchMediaService,
     getMediaDetailService,
+    getMediaContentWithNavigationService,
     sessionStateStore,
     authResolver: new SessionStateAuthAdapter({
       sessionStateStore,
@@ -74,6 +79,7 @@ const createDependencies = (env = {}) => {
     }),
     mediaIdValueGenerator: new UUIDMediaIdValueGenerator(),
     routeSetters: {
+      setRouterContentGet,
       setRouterApiMediaPost,
       setRouterScreenEntryGet,
       setRouterScreenDetailGet,
@@ -81,6 +87,7 @@ const createDependencies = (env = {}) => {
       setRouterScreenLoginGet,
       setRouterScreenSearchGet,
       setRouterScreenSummaryGet,
+      setRouterScreenViewerGet,
     },
   };
 

--- a/src/app/setupRoutes.js
+++ b/src/app/setupRoutes.js
@@ -3,6 +3,10 @@ const express = require('express');
 const setupRoutes = (app, { env: _env, dependencies } = {}) => {
   const router = express.Router();
 
+  dependencies.routeSetters.setRouterContentGet({
+    router,
+    contentRootDirectory: app.locals.env.contentRootDirectory,
+  });
   dependencies.routeSetters.setRouterScreenEntryGet({
     router,
     authResolver: dependencies.authResolver,
@@ -11,6 +15,11 @@ const setupRoutes = (app, { env: _env, dependencies } = {}) => {
     router,
     authResolver: dependencies.authResolver,
     getMediaDetailService: dependencies.getMediaDetailService,
+  });
+  dependencies.routeSetters.setRouterScreenViewerGet({
+    router,
+    authResolver: dependencies.authResolver,
+    getMediaContentWithNavigationService: dependencies.getMediaContentWithNavigationService,
   });
 
   dependencies.routeSetters.setRouterScreenErrorGet({

--- a/src/application/media/query/GetMediaContentWithNavigationService.js
+++ b/src/application/media/query/GetMediaContentWithNavigationService.js
@@ -69,7 +69,7 @@ class GetMediaContentWithNavigationService {
       throw new Error();
     }
 
-    const mediaId = new MediaId(input.id);
+    const mediaId = new MediaId(input.mediaId);
     const media = await this.#mediaRepository.findByMediaId(mediaId);
 
     if (!media) {

--- a/src/controller/router/content/setRouterContentGet.js
+++ b/src/controller/router/content/setRouterContentGet.js
@@ -1,0 +1,73 @@
+const fs = require('fs');
+
+const {
+  createContentStoragePath,
+} = require('../../../presentation/content/contentAssetPaths');
+
+const detectContentType = (buffer) => {
+  if (buffer.length >= 12
+    && buffer[0] === 0xff
+    && buffer[1] === 0xd8
+    && buffer[2] === 0xff) {
+    return 'image/jpeg';
+  }
+
+  if (buffer.length >= 8
+    && buffer[0] === 0x89
+    && buffer[1] === 0x50
+    && buffer[2] === 0x4e
+    && buffer[3] === 0x47
+    && buffer[4] === 0x0d
+    && buffer[5] === 0x0a
+    && buffer[6] === 0x1a
+    && buffer[7] === 0x0a) {
+    return 'image/png';
+  }
+
+  if (buffer.length >= 6) {
+    const signature = buffer.subarray(0, 6).toString('ascii');
+    if (signature === 'GIF87a' || signature === 'GIF89a') {
+      return 'image/gif';
+    }
+  }
+
+  if (buffer.length >= 12 && buffer.subarray(0, 4).toString('ascii') === 'RIFF' && buffer.subarray(8, 12).toString('ascii') === 'WEBP') {
+    return 'image/webp';
+  }
+
+  if (buffer.length >= 12 && buffer.subarray(4, 8).toString('ascii') === 'ftyp') {
+    return 'video/mp4';
+  }
+
+  return 'application/octet-stream';
+};
+
+const setRouterContentGet = ({ router, contentRootDirectory }) => {
+  router.get('/content/:segment1/:segment2/:segment3/:segment4/:contentId([0-9a-f]{32})', (req, res) => {
+    const { contentId } = req.params;
+    const contentPath = createContentStoragePath({
+      rootDirectory: contentRootDirectory,
+      contentId,
+    });
+
+    if (!fs.existsSync(contentPath)) {
+      res.status(404).json({ message: 'Not Found' });
+      return;
+    }
+
+    const descriptor = fs.openSync(contentPath, 'r');
+
+    try {
+      const header = Buffer.alloc(32);
+      const bytesRead = fs.readSync(descriptor, header, 0, header.length, 0);
+      res.type(detectContentType(header.subarray(0, bytesRead)));
+    } finally {
+      fs.closeSync(descriptor);
+    }
+
+    res.sendFile(contentPath);
+  });
+};
+
+module.exports = setRouterContentGet;
+module.exports.detectContentType = detectContentType;

--- a/src/controller/router/screen/setRouterScreenSummaryGet.js
+++ b/src/controller/router/screen/setRouterScreenSummaryGet.js
@@ -3,6 +3,7 @@ const {
   Input,
   InputSortType,
 } = require('../../../application/media/query/SearchMediaService');
+const { createContentPublicPath } = require('../../../presentation/content/contentAssetPaths');
 
 const SORT_TYPES_BY_QUERY = Object.freeze({
   date_asc: InputSortType.DATE_ASC,
@@ -92,7 +93,10 @@ const setRouterScreenSummaryGet = ({ router, authResolver, searchMediaService })
             tags,
             sort,
           },
-          mediaOverviews: result.mediaOverviews,
+          mediaOverviews: result.mediaOverviews.map(media => ({
+            ...media,
+            thumbnail: media.thumbnail ? createContentPublicPath(media.thumbnail) : '',
+          })),
           totalCount: result.totalCount,
           pagination,
           sortOptions: [

--- a/src/controller/router/screen/setRouterScreenViewerGet.js
+++ b/src/controller/router/screen/setRouterScreenViewerGet.js
@@ -1,0 +1,71 @@
+const SessionAuthMiddleware = require('../../middleware/SessionAuthMiddleware');
+const {
+  Input,
+  FoundResult,
+  MediaNotFoundResult,
+  ContentNotFoundResult,
+} = require('../../../application/media/query/GetMediaContentWithNavigationService');
+const {
+  createContentPublicPath,
+} = require('../../../presentation/content/contentAssetPaths');
+
+const parsePage = (value) => {
+  const parsed = Number.parseInt(value, 10);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+};
+
+const setRouterScreenViewerGet = ({
+  router,
+  authResolver,
+  getMediaContentWithNavigationService,
+}) => {
+  const auth = new SessionAuthMiddleware(authResolver);
+
+  router.get('/screen/viewer/:mediaId/:mediaPage', ...[
+    auth.execute.bind(auth),
+    async (req, res, next) => {
+      try {
+        const mediaPage = parsePage(req.params.mediaPage);
+        if (mediaPage === null) {
+          res.status(404).render('screen/error', {
+            pageTitle: 'エラーが発生しました',
+          });
+          return;
+        }
+
+        const result = await getMediaContentWithNavigationService.execute(new Input({
+          mediaId: req.params.mediaId,
+          contentPosition: mediaPage,
+        }));
+
+        if (result instanceof MediaNotFoundResult || result instanceof ContentNotFoundResult) {
+          res.status(404).render('screen/error', {
+            pageTitle: 'エラーが発生しました',
+          });
+          return;
+        }
+
+        if (!(result instanceof FoundResult)) {
+          throw new Error('viewer result is invalid');
+        }
+
+        res.status(200).render('screen/viewer', {
+          pageTitle: `ビューアー ${req.params.mediaId} - ${mediaPage}ページ`,
+          viewer: {
+            mediaId: req.params.mediaId,
+            mediaPage,
+            contentUrl: createContentPublicPath(result.contentId),
+            previousPageUrl: result.previousContentId ? `/screen/viewer/${req.params.mediaId}/${mediaPage - 1}` : null,
+            nextPageUrl: result.nextContentId ? `/screen/viewer/${req.params.mediaId}/${mediaPage + 1}` : null,
+            detailUrl: `/screen/detail/${req.params.mediaId}`,
+          },
+        });
+      } catch (error) {
+        next(error);
+      }
+    },
+  ]);
+};
+
+module.exports = setRouterScreenViewerGet;
+module.exports.parsePage = parsePage;

--- a/src/presentation/content/contentAssetPaths.js
+++ b/src/presentation/content/contentAssetPaths.js
@@ -1,0 +1,38 @@
+const path = require('path');
+
+const CONTENT_ID_PATTERN = /^[0-9a-f]{32}$/;
+
+const assertContentId = (contentId) => {
+  if (!(typeof contentId === 'string' && CONTENT_ID_PATTERN.test(contentId))) {
+    throw new Error('contentId is invalid');
+  }
+};
+
+const createContentPathSegments = (contentId) => {
+  assertContentId(contentId);
+
+  return [
+    contentId.slice(0, 2),
+    contentId.slice(2, 4),
+    contentId.slice(4, 6),
+    contentId.slice(6, 8),
+    contentId,
+  ];
+};
+
+const createContentPublicPath = (contentId) => `/content/${createContentPathSegments(contentId).join('/')}`;
+
+const createContentStoragePath = ({ rootDirectory, contentId }) => {
+  if (!(typeof rootDirectory === 'string' && rootDirectory.length > 0)) {
+    throw new Error('rootDirectory is required');
+  }
+
+  return path.join(rootDirectory, ...createContentPathSegments(contentId));
+};
+
+module.exports = {
+  CONTENT_ID_PATTERN,
+  createContentPathSegments,
+  createContentPublicPath,
+  createContentStoragePath,
+};

--- a/src/views/screen/viewer.ejs
+++ b/src/views/screen/viewer.ejs
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title><%= pageTitle %></title>
+    <style>
+      :root {
+        color-scheme: light;
+        font-family: "Hiragino Sans", "Yu Gothic UI", sans-serif;
+        background: #0f172a;
+        color: #e2e8f0;
+      }
+      * { box-sizing: border-box; }
+      body { margin: 0; background: #020617; }
+      a { color: #93c5fd; text-decoration: none; }
+      a:hover { text-decoration: underline; }
+      .page { max-width: 1200px; margin: 0 auto; padding: 24px 16px 48px; }
+      .stack { display: grid; gap: 20px; }
+      .card {
+        background: #0f172a;
+        border: 1px solid #1e293b;
+        border-radius: 16px;
+        padding: 20px;
+      }
+      .toolbar {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
+      .nav-list { display: flex; gap: 12px; flex-wrap: wrap; }
+      .nav-link, .nav-disabled {
+        min-width: 120px;
+        padding: 12px 16px;
+        border-radius: 12px;
+        text-align: center;
+        border: 1px solid #334155;
+        background: #1e293b;
+      }
+      .nav-disabled { color: #64748b; }
+      .page-label { font-size: 18px; font-weight: 700; }
+      .viewer-stage {
+        min-height: 70vh;
+        display: grid;
+        place-items: center;
+        background: #020617;
+        border-radius: 16px;
+        overflow: hidden;
+      }
+      .viewer-media {
+        display: block;
+        max-width: 100%;
+        max-height: 70vh;
+        width: auto;
+        height: auto;
+        background: #000;
+      }
+      .guide { color: #94a3b8; font-size: 14px; }
+    </style>
+  </head>
+  <body>
+    <div class="page">
+      <div class="stack">
+        <section class="card toolbar">
+          <div class="nav-list">
+            <% if (viewer.previousPageUrl) { %>
+              <a class="nav-link" href="<%= viewer.previousPageUrl %>">前へ</a>
+            <% } else { %>
+              <span class="nav-disabled">前へ</span>
+            <% } %>
+            <% if (viewer.nextPageUrl) { %>
+              <a class="nav-link" href="<%= viewer.nextPageUrl %>">次へ</a>
+            <% } else { %>
+              <span class="nav-disabled">次へ</span>
+            <% } %>
+          </div>
+          <div class="page-label">現在ページ: <%= viewer.mediaPage %></div>
+          <a class="nav-link" href="<%= viewer.detailUrl %>">詳細画面へ戻る</a>
+        </section>
+
+        <section class="card">
+          <div class="viewer-stage">
+            <picture>
+              <img class="viewer-media" src="<%= viewer.contentUrl %>" alt="<%= viewer.mediaPage %>ページ目のコンテンツ" />
+            </picture>
+            <video class="viewer-media" controls preload="metadata" src="<%= viewer.contentUrl %>">
+              お使いのブラウザは動画再生に対応していません。
+            </video>
+          </div>
+          <p class="guide">画像はそのまま表示され、動画コンテンツではブラウザが再生可能な場合に動画プレイヤーを利用できます。</p>
+        </section>
+      </div>
+    </div>
+
+    <script>
+      (() => {
+        const image = document.querySelector('img.viewer-media');
+        const video = document.querySelector('video.viewer-media');
+
+        const showImage = () => {
+          image.hidden = false;
+          video.hidden = true;
+        };
+
+        const showVideo = () => {
+          image.hidden = true;
+          video.hidden = false;
+        };
+
+        image.addEventListener('load', showImage, { once: true });
+        image.addEventListener('error', () => {
+          showVideo();
+          video.load();
+        }, { once: true });
+
+        video.addEventListener('loadeddata', showVideo, { once: true });
+        video.addEventListener('error', showImage, { once: true });
+
+        showImage();
+      })();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
### Motivation
- メディアの個別ページを認証付きで閲覧するため、`mediaId`/`mediaPage` を受け取る viewer 画面と、そのページに対応するコンテンツ（画像/動画）を配信するルートが必要だったため。
- `contentId` の保存形式に沿って表示用 URL を一元的に組み立てる責務を整理し、サムネイルや viewer の表示で整合させる必要があったため。
- `GetMediaContentWithNavigationService` の入力参照に不整合（`input.id`）が残っており、viewer 導線で正しく動作しなかったため修正した。 

### Description
- 認証ミドルウェア付きの `GET /screen/viewer/:mediaId/:mediaPage` を追加し、`GetMediaContentWithNavigationService` の `Input(mediaId, contentPosition)` を正しく渡す `controller` を実装した（`src/controller/router/screen/setRouterScreenViewerGet.js`）。
- `contentId` から公開用 URL を組み立てるヘルパーを `src/presentation/content/contentAssetPaths.js` に追加し、配信ルート `GET /content/<2>/<2>/<2>/<2>/<contentId>` を `src/controller/router/content/setRouterContentGet.js` で実装して先頭バイトから簡易に MIME タイプ判定するようにした。
- サマリー画面のサムネイル解決を `createContentPublicPath` に合わせて変更し、viewer と同じ保存形式を利用するようにした（`src/controller/router/screen/setRouterScreenSummaryGet.js` のサムネイルマッピング）。
- `GetMediaContentWithNavigationService` 内で `input.id` を参照していた不整合を `input.mediaId` に修正した（`src/application/media/query/GetMediaContentWithNavigationService.js`）。
- ルート登録と依存注入に viewer/content 配信を組み込み、関連する小さな単体テストを追加した（`__tests__/small/...` に `setRouterScreenViewerGet.test.js` と `setRouterContentGet.test.js` を追加）。

### Testing
- `node --check` による追加/変更ファイルの構文チェックを実行して問題がないことを確認した。
- `node -e "require('./src/application/media/query/GetMediaContentWithNavigationService'); require('./src/controller/router/screen/setRouterScreenViewerGet'); require('./src/controller/router/content/setRouterContentGet'); require('./src/presentation/content/contentAssetPaths');"` を実行してモジュール読み込みが成功することを確認した。
- プロジェクトの自動テスト（`jest`）は依存導入環境が不整合のため実行できず、`jest: not found` または `npm ci` の途中エラーによりスイートは未実行であることを確認した。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfda82ba70832b8fadad29a79fb4c2)