### PR TITLE
feat: メディア編集画面の初期表示と更新導線を追加する

### DIFF
--- a/__tests__/medium/controller/router/screen/setRouterScreenEditGet.test.js
+++ b/__tests__/medium/controller/router/screen/setRouterScreenEditGet.test.js
@@ -1,0 +1,115 @@
+const express = require('express');
+const path = require('path');
+
+const setRouterScreenEditGet = require('../../../../../src/controller/router/screen/setRouterScreenEditGet');
+const SessionStateAuthAdapter = require('../../../../../src/infrastructure/SessionStateAuthAdapter');
+
+class InMemorySessionStateStore {
+  constructor(entries = []) {
+    this.tokenToUserId = new Map(entries);
+  }
+
+  findUserIdBySessionToken(sessionToken) {
+    return this.tokenToUserId.get(sessionToken) ?? null;
+  }
+}
+
+const requestApp = async ({ app, method, targetPath, headers = {} } = {}) => {
+  const server = app.listen(0);
+
+  try {
+    await new Promise((resolve, reject) => {
+      server.once('listening', resolve);
+      server.once('error', reject);
+    });
+
+    const address = server.address();
+    const response = await fetch(`http://127.0.0.1:${address.port}${targetPath}`, {
+      method,
+      headers,
+    });
+
+    return {
+      status: response.status,
+      headers: response.headers,
+      bodyText: await response.text(),
+    };
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close(error => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    });
+  }
+};
+
+describe('setRouterScreenEditGet (middle)', () => {
+  const createApp = () => {
+    const app = express();
+    const router = express.Router();
+
+    app.set('views', path.join(process.cwd(), 'src', 'views'));
+    app.set('view engine', 'ejs');
+    app.engine('ejs', (filePath, options, callback) => {
+      callback(
+        null,
+        `<!DOCTYPE html><html lang="ja"><head><title>${options.pageTitle}</title></head><body>${filePath}:${options.mediaDetail.id}</body></html>`
+      );
+    });
+
+    app.use((req, _res, next) => {
+      req.session = {
+        session_token: req.header('x-session-token'),
+      };
+      req.context = {};
+      next();
+    });
+
+    setRouterScreenEditGet({
+      router,
+      authResolver: new SessionStateAuthAdapter({
+        sessionStateStore: new InMemorySessionStateStore([
+          ['valid-token', 'user-001'],
+        ]),
+      }),
+      getMediaDetailService: {
+        execute: jest.fn().mockResolvedValue({
+          mediaDetail: {
+            id: 'media-001',
+            title: 'メディア編集',
+            contents: ['content-1'],
+            tags: [{ category: '作者', label: '山田' }],
+            priorityCategories: ['作者'],
+          },
+        }),
+      },
+    });
+
+    app.use(router);
+    return app;
+  };
+
+  test('GET /screen/edit/:mediaId で HTML を返す', async () => {
+    const app = createApp();
+
+    const response = await requestApp({
+      app,
+      method: 'GET',
+      targetPath: '/screen/edit/media-001',
+      headers: {
+        'x-session-token': 'valid-token',
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toContain('text/html');
+    expect(response.bodyText).toContain('<!DOCTYPE html>');
+    expect(response.bodyText).toContain('<title>メディア編集 の編集</title>');
+    expect(response.bodyText).toContain(path.join('src', 'views', 'screen', 'edit.ejs'));
+    expect(response.bodyText).toContain('media-001');
+  });
+});

--- a/__tests__/small/applicationService/media/query/GetMediaDetailService.test.js
+++ b/__tests__/small/applicationService/media/query/GetMediaDetailService.test.js
@@ -40,7 +40,7 @@ describe("GetMediaDetailService", () => {
 
   test("メディアIDをリポジトリに渡して取得できる", async () => {
     // arrange
-    const input = new Input({ mediaId: 'ID' });
+    const input = new Input({ id: 'ID' });
     mockRepo.findByMediaId.mockResolvedValue(createMedia());
 
     // action
@@ -65,7 +65,7 @@ describe("GetMediaDetailService", () => {
   // =========================
   test("メディアID以外が指定された場合は取得に失敗する", async () => {
     // arrange
-    const input = { ...(new Input({ mediaId: 'ID' })) };
+    const input = { ...(new Input({ id: 'ID' })) };
 
     // action
     // assert
@@ -75,7 +75,7 @@ describe("GetMediaDetailService", () => {
 
   test("リポジトリの取得結果が空だと取得に失敗する", async () => {
     // arrange
-    const input = new Input({ mediaId: 'ID' });
+    const input = new Input({ id: 'ID' });
     mockRepo.findByMediaId.mockResolvedValue(undefined);
 
     // action
@@ -87,7 +87,7 @@ describe("GetMediaDetailService", () => {
 
   test("リポジトリの検索処理が失敗した場合は検索に失敗する", async () => {
     // arrange
-    const input = new Input({ mediaId: 'ID' });
+    const input = new Input({ id: 'ID' });
     mockRepo.findByMediaId.mockRejectedValue(new Error("mockRepo error"));
 
     // action

--- a/__tests__/small/controller/router/screen/setRouterScreenEditGet.test.js
+++ b/__tests__/small/controller/router/screen/setRouterScreenEditGet.test.js
@@ -1,0 +1,59 @@
+const setRouterScreenEditGet = require('../../../../../src/controller/router/screen/setRouterScreenEditGet');
+
+describe('setRouterScreenEditGet', () => {
+  const createRes = () => {
+    const res = {
+      status: jest.fn(),
+      render: jest.fn(),
+      json: jest.fn(),
+    };
+    res.status.mockReturnValue(res);
+    return res;
+  };
+
+  it('GET /screen/edit/:mediaId に認証・描画ハンドラーを登録できる', async () => {
+    const router = {
+      get: jest.fn(),
+    };
+    const authResolver = {
+      execute: jest.fn().mockResolvedValue('u1'),
+    };
+    const getMediaDetailService = {
+      execute: jest.fn().mockResolvedValue({
+        mediaDetail: {
+          id: 'media-1',
+          title: '作品タイトル',
+          contents: ['content-1'],
+          tags: [{ category: '作者', label: '山田' }],
+          priorityCategories: ['作者'],
+        },
+      }),
+    };
+
+    setRouterScreenEditGet({ router, authResolver, getMediaDetailService });
+
+    expect(router.get).toHaveBeenCalledTimes(1);
+    const [path, ...handlers] = router.get.mock.calls[0];
+    expect(path).toBe('/screen/edit/:mediaId');
+    expect(handlers).toHaveLength(2);
+
+    const req = {
+      params: { mediaId: 'media-1' },
+      session: { session_token: 'token-1' },
+      context: {},
+    };
+    const res = createRes();
+
+    await handlers[0](req, res, async () => {
+      await handlers[1](req, res, jest.fn());
+    });
+
+    expect(authResolver.execute).toHaveBeenCalledWith('token-1');
+    expect(getMediaDetailService.execute).toHaveBeenCalledWith(expect.objectContaining({ id: 'media-1' }));
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.render).toHaveBeenCalledWith('screen/edit', expect.objectContaining({
+      pageTitle: '作品タイトル の編集',
+      mediaDetail: expect.objectContaining({ id: 'media-1' }),
+    }));
+  });
+});

--- a/src/app/createDependencies.js
+++ b/src/app/createDependencies.js
@@ -6,6 +6,7 @@ const { Sequelize } = require('sequelize');
 const setRouterApiMediaPost = require('../controller/router/media/setRouterApiMediaPost');
 const setRouterScreenEntryGet = require('../controller/router/screen/setRouterScreenEntryGet');
 const setRouterScreenDetailGet = require('../controller/router/screen/setRouterScreenDetailGet');
+const setRouterScreenEditGet = require('../controller/router/screen/setRouterScreenEditGet');
 const setRouterScreenErrorGet = require('../controller/router/screen/setRouterScreenErrorGet');
 const setRouterScreenLoginGet = require('../controller/router/screen/setRouterScreenLoginGet');
 const setRouterScreenSearchGet = require('../controller/router/screen/setRouterScreenSearchGet');
@@ -77,6 +78,7 @@ const createDependencies = (env = {}) => {
       setRouterApiMediaPost,
       setRouterScreenEntryGet,
       setRouterScreenDetailGet,
+      setRouterScreenEditGet,
       setRouterScreenErrorGet,
       setRouterScreenLoginGet,
       setRouterScreenSearchGet,

--- a/src/app/setupRoutes.js
+++ b/src/app/setupRoutes.js
@@ -12,6 +12,11 @@ const setupRoutes = (app, { env: _env, dependencies } = {}) => {
     authResolver: dependencies.authResolver,
     getMediaDetailService: dependencies.getMediaDetailService,
   });
+  dependencies.routeSetters.setRouterScreenEditGet({
+    router,
+    authResolver: dependencies.authResolver,
+    getMediaDetailService: dependencies.getMediaDetailService,
+  });
 
   dependencies.routeSetters.setRouterScreenErrorGet({
     router,

--- a/src/application/media/query/GetMediaDetailService.js
+++ b/src/application/media/query/GetMediaDetailService.js
@@ -2,12 +2,12 @@ const MediaId = require('../../../domain/media/mediaId');
 
 // SearchCondition と同じなので継承だけで済ます
 class Input {
-  constructor({ mediaId }) {
-    if (typeof mediaId !== 'string') {
+  constructor({ id }) {
+    if (typeof id !== 'string') {
       throw new Error();
     }
 
-    this.mediaId = mediaId;
+    this.id = id;
   }
 }
 
@@ -49,7 +49,7 @@ class GetMediaDetailService {
       throw new Error();
     }
 
-    const mediaId = new MediaId(input.mediaId);
+    const mediaId = new MediaId(input.id);
     const media = await this.#mediaRepository.findByMediaId(mediaId);
 
     if (!media) {

--- a/src/controller/router/screen/setRouterScreenDetailGet.js
+++ b/src/controller/router/screen/setRouterScreenDetailGet.js
@@ -9,7 +9,7 @@ const setRouterScreenDetailGet = ({ router, authResolver, getMediaDetailService 
     async (req, res, next) => {
       try {
         const result = await getMediaDetailService.execute(new Input({
-          mediaId: req.params.mediaId,
+          id: req.params.mediaId,
         }));
 
         res.status(200).render('screen/detail', {

--- a/src/controller/router/screen/setRouterScreenEditGet.js
+++ b/src/controller/router/screen/setRouterScreenEditGet.js
@@ -1,0 +1,32 @@
+const SessionAuthMiddleware = require('../../middleware/SessionAuthMiddleware');
+const { Input } = require('../../../application/media/query/GetMediaDetailService');
+
+const setRouterScreenEditGet = ({ router, authResolver, getMediaDetailService }) => {
+  const auth = new SessionAuthMiddleware(authResolver);
+
+  router.get('/screen/edit/:mediaId', ...[
+    auth.execute.bind(auth),
+    async (req, res, next) => {
+      try {
+        const result = await getMediaDetailService.execute(new Input({
+          id: req.params.mediaId,
+        }));
+
+        res.status(200).render('screen/edit', {
+          pageTitle: `${result.mediaDetail.title} の編集`,
+          mediaDetail: result.mediaDetail,
+          categoryOptions: ['作者', 'ジャンル', 'シリーズ'],
+          tagsByCategory: {
+            作者: ['山田', '佐藤', '鈴木'],
+            ジャンル: ['バトル', '恋愛', '日常'],
+            シリーズ: ['第1部', '短編集'],
+          },
+        });
+      } catch (error) {
+        next(error);
+      }
+    },
+  ]);
+};
+
+module.exports = setRouterScreenEditGet;

--- a/src/views/screen/edit.ejs
+++ b/src/views/screen/edit.ejs
@@ -1,0 +1,355 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title><%= pageTitle %></title>
+    <style>
+      :root {
+        color-scheme: light;
+        font-family: "Hiragino Sans", "Yu Gothic UI", sans-serif;
+        background: #f5f6f8;
+        color: #1f2937;
+      }
+      * { box-sizing: border-box; }
+      body { margin: 0; background: #f5f6f8; }
+      .page { max-width: 960px; margin: 0 auto; padding: 32px 16px 64px; }
+      .card {
+        background: #fff; border: 1px solid #d1d5db; border-radius: 16px; padding: 24px;
+        box-shadow: 0 10px 30px rgba(15, 23, 42, 0.06);
+      }
+      h1 { margin: 0 0 24px; font-size: 32px; }
+      .section { margin-top: 24px; }
+      .field-label, .section-title { display:block; font-weight:700; margin-bottom:8px; }
+      .text-input {
+        width: 100%; border: 1px solid #cbd5e1; border-radius: 10px;
+        padding: 12px 14px; font-size: 16px; background: #fff;
+      }
+      .divider { border: 0; border-top: 1px solid #e5e7eb; margin: 16px 0 0; }
+      .tag-inputs { display: grid; grid-template-columns: 1fr 1fr auto; gap: 12px; align-items: end; }
+      .button {
+        border: 0; border-radius: 10px; padding: 12px 18px; font-size: 14px; font-weight: 700;
+        cursor: pointer; background: #2563eb; color: #fff;
+      }
+      .button.secondary { background: #e5e7eb; color: #111827; }
+      .button.danger { background: #dc2626; }
+      .dropzone {
+        margin-top: 12px; border: 2px dashed #93c5fd; border-radius: 14px; padding: 24px; text-align: center;
+        background: #eff6ff; color: #1d4ed8;
+      }
+      .dropzone.dragover { background: #dbeafe; border-color: #2563eb; }
+      .tag-list, .media-list { display: grid; gap: 12px; margin-top: 16px; }
+      .tag-item, .media-item {
+        border: 1px solid #dbe3f0; border-radius: 12px; background: #f8fafc; padding: 16px;
+      }
+      .tag-item-header, .media-item-header { display:flex; justify-content:space-between; gap:12px; align-items:center; }
+      .tag-category { font-size: 12px; color: #475569; }
+      .tag-label { font-size: 16px; font-weight: 700; }
+      .media-item-body { display:grid; grid-template-columns: 88px 1fr; gap: 16px; align-items: center; margin-top: 12px; }
+      .thumb {
+        width: 88px; height: 88px; border-radius: 10px; object-fit: cover; background: #dbeafe;
+        display:flex; align-items:center; justify-content:center; color:#1d4ed8; font-size:12px;
+      }
+      .media-actions { display:flex; gap: 8px; flex-wrap: wrap; }
+      .register-row { display:flex; justify-content:flex-end; gap: 12px; margin-top: 24px; }
+      .message { margin-top: 16px; font-size: 14px; }
+      .message.error { color: #b91c1c; }
+      .message.success { color: #047857; }
+      .empty { color: #64748b; }
+      @media (max-width: 640px) {
+        .tag-inputs { grid-template-columns: 1fr; }
+        .media-item-body { grid-template-columns: 1fr; }
+        .media-actions { width: 100%; }
+        .button { width: 100%; }
+        .register-row { flex-direction: column; }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="page">
+      <div class="card">
+        <h1><%= pageTitle %></h1>
+        <form id="edit-form">
+          <section>
+            <label class="field-label" for="title">タイトル</label>
+            <input id="title" name="title" class="text-input" type="text" value="<%= mediaDetail.title %>" required />
+            <hr class="divider" />
+          </section>
+
+          <section class="section">
+            <span class="section-title">タグ</span>
+            <div id="tag-list" class="tag-list" aria-live="polite"></div>
+            <hr class="divider" />
+            <div class="tag-inputs">
+              <div>
+                <label class="field-label" for="category-input">カテゴリー</label>
+                <input id="category-input" class="text-input" list="category-options" autocomplete="off" />
+                <datalist id="category-options">
+                  <% categoryOptions.forEach((category) => { %>
+                    <option value="<%= category %>"></option>
+                  <% }) %>
+                </datalist>
+              </div>
+              <div>
+                <label class="field-label" for="tag-input">タグ</label>
+                <input id="tag-input" class="text-input" list="tag-options" autocomplete="off" />
+                <datalist id="tag-options"></datalist>
+              </div>
+              <button id="add-tag-button" class="button" type="button">タグ追加</button>
+            </div>
+            <hr class="divider" />
+          </section>
+
+          <section class="section">
+            <span class="section-title">メディアファイル</span>
+            <div id="dropzone" class="dropzone" tabindex="0">
+              クリックまたはドラッグ&ドロップで画像・動画を追加
+            </div>
+            <input id="file-input" type="file" accept="image/*,video/*" multiple hidden />
+            <div id="media-list" class="media-list" aria-live="polite"></div>
+            <p id="media-empty" class="empty" hidden>コンテンツはありません。</p>
+            <hr class="divider" />
+          </section>
+
+          <div id="form-message" class="message" aria-live="polite"></div>
+          <div class="register-row">
+            <button id="delete-button" class="button danger" type="button">削除</button>
+            <button class="button" type="submit">更新</button>
+          </div>
+        </form>
+      </div>
+    </div>
+
+    <script>
+      (() => {
+        const mediaId = <%- JSON.stringify(mediaDetail.id) %>;
+        const tagsByCategory = <%- JSON.stringify(tagsByCategory) %>;
+        const initialTags = <%- JSON.stringify(mediaDetail.tags) %>;
+        const initialContents = <%- JSON.stringify(mediaDetail.contents) %>;
+        const tagList = document.getElementById('tag-list');
+        const mediaList = document.getElementById('media-list');
+        const mediaEmpty = document.getElementById('media-empty');
+        const categoryInput = document.getElementById('category-input');
+        const tagInput = document.getElementById('tag-input');
+        const tagOptions = document.getElementById('tag-options');
+        const addTagButton = document.getElementById('add-tag-button');
+        const dropzone = document.getElementById('dropzone');
+        const fileInput = document.getElementById('file-input');
+        const form = document.getElementById('edit-form');
+        const formMessage = document.getElementById('form-message');
+        const deleteButton = document.getElementById('delete-button');
+
+        const selectedTags = initialTags.map(tag => ({ ...tag }));
+        const mediaFiles = initialContents.map(contentId => ({ id: contentId }));
+
+        const updateTagOptions = () => {
+          const category = categoryInput.value.trim();
+          const candidates = Array.isArray(tagsByCategory[category]) ? tagsByCategory[category] : [];
+          tagOptions.innerHTML = candidates
+            .map(label => `<option value="${label}"></option>`)
+            .join('');
+        };
+
+        const createThumbnail = entry => {
+          if (entry.file && entry.file.type.startsWith('image/')) {
+            const url = URL.createObjectURL(entry.file);
+            return `<img class="thumb" src="${url}" alt="${entry.file.name}">`;
+          }
+          if (entry.file && entry.file.type.startsWith('video/')) {
+            return '<div class="thumb">動画</div>';
+          }
+          return '<div class="thumb">既存</div>';
+        };
+
+        const renderTags = () => {
+          tagList.innerHTML = '';
+          selectedTags.forEach((tag, index) => {
+            const item = document.createElement('div');
+            item.className = 'tag-item';
+            item.innerHTML = `
+              <div class="tag-item-header">
+                <div>
+                  <div class="tag-category">${tag.category}</div>
+                  <div class="tag-label">${tag.label}</div>
+                </div>
+                <button class="button danger" type="button" data-remove-tag="${index}">削除</button>
+              </div>
+            `;
+            tagList.appendChild(item);
+          });
+        };
+
+        const renderFiles = () => {
+          mediaList.innerHTML = '';
+          mediaEmpty.hidden = mediaFiles.length > 0;
+          mediaFiles.forEach((entry, index) => {
+            const item = document.createElement('div');
+            item.className = 'media-item';
+            const name = entry.file ? entry.file.name : `contentId: ${entry.id}`;
+            item.innerHTML = `
+              <div class="media-item-header">
+                <strong>ページ ${index + 1}</strong>
+                <div class="media-actions">
+                  ${index > 0 ? `<button class="button secondary" type="button" data-move-up="${index}">上へ</button>` : ''}
+                  ${index < mediaFiles.length - 1 ? `<button class="button secondary" type="button" data-move-down="${index}">下へ</button>` : ''}
+                  <button class="button danger" type="button" data-remove-file="${index}">削除</button>
+                </div>
+              </div>
+              <div class="media-item-body">
+                ${createThumbnail(entry)}
+                <div>${name}</div>
+              </div>
+            `;
+            mediaList.appendChild(item);
+          });
+        };
+
+        const addFiles = files => {
+          Array.from(files)
+            .filter(file => file.type.startsWith('image/') || file.type.startsWith('video/'))
+            .forEach(file => mediaFiles.push({ file }));
+          renderFiles();
+        };
+
+        categoryInput.addEventListener('change', updateTagOptions);
+        categoryInput.addEventListener('input', updateTagOptions);
+
+        addTagButton.addEventListener('click', () => {
+          const category = categoryInput.value.trim();
+          const label = tagInput.value.trim();
+          if (!category || !label) {
+            formMessage.className = 'message error';
+            formMessage.textContent = 'カテゴリーとタグを入力してください。';
+            return;
+          }
+          selectedTags.push({ category, label });
+          categoryInput.value = '';
+          tagInput.value = '';
+          updateTagOptions();
+          renderTags();
+          formMessage.className = 'message';
+          formMessage.textContent = '';
+        });
+
+        tagList.addEventListener('click', event => {
+          const { removeTag } = event.target.dataset;
+          if (removeTag === undefined) {
+            return;
+          }
+          selectedTags.splice(Number(removeTag), 1);
+          renderTags();
+        });
+
+        dropzone.addEventListener('click', () => fileInput.click());
+        dropzone.addEventListener('keydown', event => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            fileInput.click();
+          }
+        });
+        fileInput.addEventListener('change', event => addFiles(event.target.files));
+
+        ['dragenter', 'dragover'].forEach(type => {
+          dropzone.addEventListener(type, event => {
+            event.preventDefault();
+            dropzone.classList.add('dragover');
+          });
+        });
+        ['dragleave', 'drop'].forEach(type => {
+          dropzone.addEventListener(type, event => {
+            event.preventDefault();
+            dropzone.classList.remove('dragover');
+          });
+        });
+        dropzone.addEventListener('drop', event => addFiles(event.dataTransfer.files));
+
+        mediaList.addEventListener('click', event => {
+          const { moveUp, moveDown, removeFile } = event.target.dataset;
+          if (moveUp !== undefined) {
+            const index = Number(moveUp);
+            [mediaFiles[index - 1], mediaFiles[index]] = [mediaFiles[index], mediaFiles[index - 1]];
+            renderFiles();
+            return;
+          }
+          if (moveDown !== undefined) {
+            const index = Number(moveDown);
+            [mediaFiles[index + 1], mediaFiles[index]] = [mediaFiles[index], mediaFiles[index + 1]];
+            renderFiles();
+            return;
+          }
+          if (removeFile !== undefined) {
+            mediaFiles.splice(Number(removeFile), 1);
+            renderFiles();
+          }
+        });
+
+        form.addEventListener('submit', async event => {
+          event.preventDefault();
+          formMessage.className = 'message';
+          formMessage.textContent = '';
+
+          if (mediaFiles.length === 0) {
+            formMessage.className = 'message error';
+            formMessage.textContent = 'コンテンツを1件以上残してください。';
+            return;
+          }
+
+          const payload = new FormData();
+          payload.append('title', document.getElementById('title').value.trim());
+          selectedTags.forEach((tag, index) => {
+            payload.append(`tags[${index}][category]`, tag.category);
+            payload.append(`tags[${index}][label]`, tag.label);
+          });
+          mediaFiles.forEach((entry, index) => {
+            payload.append(`contents[${index}][position]`, String(index + 1));
+            if (entry.id) {
+              payload.append(`contents[${index}][id]`, entry.id);
+            }
+            if (entry.file) {
+              payload.append(`contents[${index}][file]`, entry.file, entry.file.name);
+            }
+          });
+
+          try {
+            const response = await fetch(`/api/media/${mediaId}`, {
+              method: 'PATCH',
+              body: payload,
+            });
+            const result = await response.json();
+            if (!response.ok || result.code !== 0) {
+              throw new Error(result.message || 'メディア更新に失敗しました。');
+            }
+            formMessage.className = 'message success';
+            formMessage.textContent = 'メディアを更新しました。';
+          } catch (error) {
+            formMessage.className = 'message error';
+            formMessage.textContent = error.message;
+          }
+        });
+
+        deleteButton.addEventListener('click', async () => {
+          formMessage.className = 'message';
+          formMessage.textContent = '';
+
+          try {
+            const response = await fetch(`/api/media/${mediaId}`, {
+              method: 'DELETE',
+            });
+            const result = await response.json();
+            if (!response.ok || result.code !== 0) {
+              throw new Error(result.message || 'メディア削除に失敗しました。');
+            }
+            window.location.href = '/screen/summary';
+          } catch (error) {
+            formMessage.className = 'message error';
+            formMessage.textContent = error.message;
+          }
+        });
+
+        updateTagOptions();
+        renderTags();
+        renderFiles();
+      })();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
### Motivation
- 既存メディアをブラウザ上で編集開始できる入口がなかったため、認証付きの編集画面ルートと画面側の更新/削除導線を追加することを目的としています。 
- detail 画面と編集画面が同じデータ取得サービスを使えるように `GetMediaDetailService` の入力フィールド名を統一して不整合を解消するためです。 

### Description
- `GET /screen/edit/:mediaId` を登録する `src/controller/router/screen/setRouterScreenEditGet.js` を追加し、`SessionAuthMiddleware` を適用して `GetMediaDetailService` から取得した `mediaDetail` を `screen/edit` に渡すようにしました。 
- 既存の `GetMediaDetailService` を `Input({ id })` に合わせて修正し、`src/controller/router/screen/setRouterScreenDetailGet.js` 側の呼び出しも `id` を渡す形に揃えました。 
- 編集 UI を `src/views/screen/edit.ejs` として新規作成し、`entry.ejs` の UI を流用した上で既存タイトル・タグ表示/追加/削除、既存コンテンツの表示/並び替え/削除、新規ファイル追加、更新（PATCH `/api/media/{mediaId}` へ multipart/form-data）・削除（DELETE `/api/media/{mediaId}`）のフロント導線を実装しました。 
- ルート登録を `src/app/setupRoutes.js` と `src/app/createDependencies.js` に追加し、関連の small/medium テストを `__tests__/small/controller/router/screen/setRouterScreenEditGet.test.js` と `__tests__/medium/controller/router/screen/setRouterScreenEditGet.test.js` として追加、さらに `GetMediaDetailService` のテストを `id` ベースに更新しました。 

### Testing
- 変更したサーバーサイドファイルに対して `node -c` による構文チェック（`src/application/media/query/GetMediaDetailService.js` / `src/controller/router/screen/setRouterScreenDetailGet.js` / `src/controller/router/screen/setRouterScreenEditGet.js` / `src/app/createDependencies.js` / `src/app/setupRoutes.js`）を実行し、構文エラーは発生しませんでした。 
- 簡易確認用の Node スクリプトで `GetMediaDetailService` にモックリポジトリを渡して `new Input({ id: ... })` を実行し、`/screen/detail/:mediaId` と `/screen/edit/:mediaId` のルート登録が行われることを確認しました（実行成功）。 
- 既存の Jest テスト群（および新規追加した small/medium テスト）はリポジトリに追加しましたが、この実行環境では `jest` コマンドが利用できなかったため（`jest: not found` / npm registry の制約）実行できませんでした。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c01a776000832b8b20557e2c7d2617)