### PR TITLE
feat: お気に入り一覧画面と取得サービスを追加する

### DIFF
--- a/__tests__/medium/infrastructure/SequelizeUserRepository.test.js
+++ b/__tests__/medium/infrastructure/SequelizeUserRepository.test.js
@@ -1,0 +1,37 @@
+const { Sequelize } = require('sequelize');
+
+const SequelizeUnitOfWork = require('../../../src/infrastructure/SequelizeUnitOfWork');
+const SequelizeUserRepository = require('../../../src/infrastructure/SequelizeUserRepository');
+const User = require('../../../src/domain/user/user');
+const UserId = require('../../../src/domain/user/userId');
+const MediaId = require('../../../src/domain/media/mediaId');
+
+describe('SequelizeUserRepository', () => {
+  let sequelize;
+  let unitOfWork;
+  let userRepository;
+
+  beforeEach(async () => {
+    sequelize = new Sequelize('sqlite::memory:', { logging: false });
+    unitOfWork = new SequelizeUnitOfWork({ sequelize });
+    userRepository = new SequelizeUserRepository({ sequelize, unitOfWorkContext: unitOfWork });
+    await userRepository.sync();
+  });
+
+  afterEach(async () => {
+    await sequelize.close();
+  });
+
+  test('save / findByUserId で favorite と queue を永続化できる', async () => {
+    const user = new User(new UserId('user-001'));
+    user.addFavorite(new MediaId('media-001'));
+    user.addFavorite(new MediaId('media-002'));
+    user.addQueue(new MediaId('media-003'));
+
+    await userRepository.save(user);
+
+    const found = await userRepository.findByUserId(new UserId('user-001'));
+    expect(found.getFavorites().map(mediaId => mediaId.getId())).toEqual(['media-001', 'media-002']);
+    expect(found.getQueue().map(mediaId => mediaId.getId())).toEqual(['media-003']);
+  });
+});

--- a/__tests__/medium/infrastructure/SequelizeUserRepository.test.js
+++ b/__tests__/medium/infrastructure/SequelizeUserRepository.test.js
@@ -23,14 +23,14 @@ describe('SequelizeUserRepository', () => {
   });
 
   test('save / findByUserId で favorite と queue を永続化できる', async () => {
-    const user = new User(new UserId('user-001'));
+    const user = new User(new UserId('user001'));
     user.addFavorite(new MediaId('media-001'));
     user.addFavorite(new MediaId('media-002'));
     user.addQueue(new MediaId('media-003'));
 
     await userRepository.save(user);
 
-    const found = await userRepository.findByUserId(new UserId('user-001'));
+    const found = await userRepository.findByUserId(new UserId('user001'));
     expect(found.getFavorites().map(mediaId => mediaId.getId())).toEqual(['media-001', 'media-002']);
     expect(found.getQueue().map(mediaId => mediaId.getId())).toEqual(['media-003']);
   });

--- a/__tests__/small/applicationService/__mocks__/MockMediaQueryRepository.js
+++ b/__tests__/small/applicationService/__mocks__/MockMediaQueryRepository.js
@@ -6,6 +6,7 @@ module.exports = class MockMediaQueryRepository extends IMediaQueryRepository {
 
     [
       'search',
+      'findOverviewsByMediaIds',
     ].forEach(propertyName => {
       if (!(propertyName in this)) {
         throw new Error();

--- a/__tests__/small/applicationService/__mocks__/MockUserRepository.js
+++ b/__tests__/small/applicationService/__mocks__/MockUserRepository.js
@@ -7,7 +7,6 @@ module.exports = class MockUserRepository extends IUserRepository {
     [
       'save',
       'findByUserId',
-      'sync',
     ].forEach(propertyName => {
       if (!(propertyName in this)) {
         throw new Error();

--- a/__tests__/small/applicationService/__mocks__/MockUserRepository.js
+++ b/__tests__/small/applicationService/__mocks__/MockUserRepository.js
@@ -7,6 +7,7 @@ module.exports = class MockUserRepository extends IUserRepository {
     [
       'save',
       'findByUserId',
+      'sync',
     ].forEach(propertyName => {
       if (!(propertyName in this)) {
         throw new Error();

--- a/__tests__/small/applicationService/user/query/GetFavoriteSummariesService.test.js
+++ b/__tests__/small/applicationService/user/query/GetFavoriteSummariesService.test.js
@@ -1,0 +1,32 @@
+const MockUserRepository = require('../../../applicationService/__mocks__/MockUserRepository');
+const MockMediaQueryRepository = require('../../../applicationService/__mocks__/MockMediaQueryRepository');
+const User = require('../../../../../src/domain/user/user');
+const UserId = require('../../../../../src/domain/user/userId');
+const MediaId = require('../../../../../src/domain/media/mediaId');
+const {
+  Input,
+  GetFavoriteSummariesService,
+} = require('../../../../../src/application/user/query/GetFavoriteSummariesService');
+
+describe('GetFavoriteSummariesService', () => {
+  test('user の favorite を media overview 一覧へ変換して返す', async () => {
+    const userRepository = new MockUserRepository();
+    const mediaQueryRepository = new MockMediaQueryRepository();
+    const user = new User(new UserId('user-001'));
+    user.addFavorite(new MediaId('media-001'));
+    user.addFavorite(new MediaId('media-002'));
+
+    userRepository.findByUserId.mockResolvedValue(user);
+    mediaQueryRepository.findOverviewsByMediaIds.mockResolvedValue([
+      { mediaId: 'media-001', title: 'タイトル1', thumbnail: '/c1.jpg', tags: [], priorityCategories: [] },
+      { mediaId: 'media-002', title: 'タイトル2', thumbnail: '/c2.jpg', tags: [], priorityCategories: [] },
+    ]);
+
+    const service = new GetFavoriteSummariesService({ userRepository, mediaQueryRepository });
+    const result = await service.execute(new Input({ userId: 'user-001' }));
+
+    expect(userRepository.findByUserId).toHaveBeenCalledWith(expect.objectContaining({}));
+    expect(mediaQueryRepository.findOverviewsByMediaIds).toHaveBeenCalledWith(['media-001', 'media-002']);
+    expect(result.mediaOverviews).toHaveLength(2);
+  });
+});

--- a/__tests__/small/applicationService/user/query/GetFavoriteSummariesService.test.js
+++ b/__tests__/small/applicationService/user/query/GetFavoriteSummariesService.test.js
@@ -12,7 +12,7 @@ describe('GetFavoriteSummariesService', () => {
   test('user の favorite を media overview 一覧へ変換して返す', async () => {
     const userRepository = new MockUserRepository();
     const mediaQueryRepository = new MockMediaQueryRepository();
-    const user = new User(new UserId('user-001'));
+    const user = new User(new UserId('user001'));
     user.addFavorite(new MediaId('media-001'));
     user.addFavorite(new MediaId('media-002'));
 
@@ -23,7 +23,7 @@ describe('GetFavoriteSummariesService', () => {
     ]);
 
     const service = new GetFavoriteSummariesService({ userRepository, mediaQueryRepository });
-    const result = await service.execute(new Input({ userId: 'user-001' }));
+    const result = await service.execute(new Input({ userId: 'user001' }));
 
     expect(userRepository.findByUserId).toHaveBeenCalledWith(expect.objectContaining({}));
     expect(mediaQueryRepository.findOverviewsByMediaIds).toHaveBeenCalledWith(['media-001', 'media-002']);

--- a/__tests__/small/controller/router/screen/setRouterScreenFavoriteGet.test.js
+++ b/__tests__/small/controller/router/screen/setRouterScreenFavoriteGet.test.js
@@ -1,0 +1,66 @@
+const express = require('express');
+const path = require('path');
+
+const setRouterScreenFavoriteGet = require('../../../../../src/controller/router/screen/setRouterScreenFavoriteGet');
+const SessionStateAuthAdapter = require('../../../../../src/infrastructure/SessionStateAuthAdapter');
+const { Output } = require('../../../../../src/application/user/query/GetFavoriteSummariesService');
+
+class InMemorySessionStateStore {
+  constructor(entries = []) {
+    this.tokenToUserId = new Map(entries);
+  }
+  findUserIdBySessionToken(sessionToken) {
+    return this.tokenToUserId.get(sessionToken) ?? null;
+  }
+}
+
+describe('setRouterScreenFavoriteGet', () => {
+  test('GET /screen/favorite でお気に入り一覧HTMLを返す', async () => {
+    const app = express();
+    const router = express.Router();
+    const getFavoriteSummariesService = {
+      execute: jest.fn().mockResolvedValue(new Output({
+        mediaOverviews: [{
+          mediaId: 'media-001',
+          title: 'タイトル1',
+          thumbnail: '/contents/1.jpg',
+          tags: [{ category: '作者', label: '山田' }],
+          priorityCategories: ['作者'],
+        }],
+      })),
+    };
+
+    app.set('views', path.join(process.cwd(), 'src', 'views'));
+    app.set('view engine', 'ejs');
+    app.use((req, _res, next) => {
+      req.session = { session_token: req.header('x-session-token') };
+      req.context = {};
+      next();
+    });
+
+    setRouterScreenFavoriteGet({
+      router,
+      authResolver: new SessionStateAuthAdapter({
+        sessionStateStore: new InMemorySessionStateStore([['valid-token', 'user-001']]),
+      }),
+      getFavoriteSummariesService,
+    });
+    app.use(router);
+
+    const server = app.listen(0);
+    await new Promise(resolve => server.once('listening', resolve));
+    const { port } = server.address();
+    const response = await fetch(`http://127.0.0.1:${port}/screen/favorite`, {
+      headers: { 'x-session-token': 'valid-token' },
+    });
+    const bodyText = await response.text();
+    await new Promise(resolve => server.close(resolve));
+
+    expect(response.status).toBe(200);
+    expect(bodyText).toContain('<title>お気に入り一覧</title>');
+    expect(bodyText).toContain('タイトル1');
+    expect(bodyText).toContain('/api/favorite/media-001');
+    expect(bodyText).toContain('/api/queue/media-001');
+    expect(getFavoriteSummariesService.execute).toHaveBeenCalledWith(expect.objectContaining({ userId: 'user-001' }));
+  });
+});

--- a/src/app/createDependencies.js
+++ b/src/app/createDependencies.js
@@ -8,18 +8,26 @@ const setRouterScreenEntryGet = require('../controller/router/screen/setRouterSc
 const setRouterScreenDetailGet = require('../controller/router/screen/setRouterScreenDetailGet');
 const setRouterScreenEditGet = require('../controller/router/screen/setRouterScreenEditGet');
 const setRouterScreenErrorGet = require('../controller/router/screen/setRouterScreenErrorGet');
+const setRouterScreenFavoriteGet = require('../controller/router/screen/setRouterScreenFavoriteGet');
 const setRouterScreenLoginGet = require('../controller/router/screen/setRouterScreenLoginGet');
 const setRouterScreenSearchGet = require('../controller/router/screen/setRouterScreenSearchGet');
 const setRouterScreenSummaryGet = require('../controller/router/screen/setRouterScreenSummaryGet');
+const setRouterApiFavoriteAndQueue = require('../controller/router/user/setRouterApiFavoriteAndQueue');
 const InMemorySessionStateStore = require('../infrastructure/InMemorySessionStateStore');
 const MulterDiskStorageContentUploadAdapter = require('../infrastructure/MulterDiskStorageContentUploadAdapter');
 const SequelizeMediaRepository = require('../infrastructure/SequelizeMediaRepository');
 const SequelizeMediaQueryRepository = require('../infrastructure/SequelizeMediaQueryRepository');
+const SequelizeUserRepository = require('../infrastructure/SequelizeUserRepository');
 const SequelizeUnitOfWork = require('../infrastructure/SequelizeUnitOfWork');
 const SessionStateAuthAdapter = require('../infrastructure/SessionStateAuthAdapter');
 const UUIDMediaIdValueGenerator = require('../infrastructure/UUIDMediaIdValueGenerator');
 const { SearchMediaService } = require('../application/media/query/SearchMediaService');
 const { GetMediaDetailService } = require('../application/media/query/GetMediaDetailService');
+const { GetFavoriteSummariesService } = require('../application/user/query/GetFavoriteSummariesService');
+const { AddFavoriteService } = require('../application/user/command/AddFavoriteService');
+const { RemoveFavoriteService } = require('../application/user/command/RemoveFavoriteService');
+const { AddQueueService } = require('../application/user/command/AddQueueService');
+const { RemoveQueueService } = require('../application/user/command/RemoveQueueService');
 const { hasDevelopmentSession } = require('./developmentSession');
 
 const ensureParentDirectory = targetPath => {
@@ -48,8 +56,17 @@ const createDependencies = (env = {}) => {
   });
   const sessionStateStore = new InMemorySessionStateStore();
   const mediaQueryRepository = new SequelizeMediaQueryRepository({ sequelize });
+  const userRepository = new SequelizeUserRepository({
+    sequelize,
+    unitOfWorkContext: unitOfWork,
+  });
   const searchMediaService = new SearchMediaService({ mediaQueryRepository });
   const getMediaDetailService = new GetMediaDetailService({ mediaRepository });
+  const getFavoriteSummariesService = new GetFavoriteSummariesService({ userRepository, mediaQueryRepository });
+  const addFavoriteService = new AddFavoriteService({ mediaRepository, userRepository, unitOfWork });
+  const removeFavoriteService = new RemoveFavoriteService({ userRepository, unitOfWork });
+  const addQueueService = new AddQueueService({ mediaRepository, userRepository, unitOfWork });
+  const removeQueueService = new RemoveQueueService({ userRepository, unitOfWork });
 
   if (hasDevelopmentSession(env)) {
     sessionStateStore.save({
@@ -64,8 +81,14 @@ const createDependencies = (env = {}) => {
     unitOfWork,
     mediaRepository,
     mediaQueryRepository,
+    userRepository,
     searchMediaService,
     getMediaDetailService,
+    getFavoriteSummariesService,
+    addFavoriteService,
+    removeFavoriteService,
+    addQueueService,
+    removeQueueService,
     sessionStateStore,
     authResolver: new SessionStateAuthAdapter({
       sessionStateStore,
@@ -80,9 +103,11 @@ const createDependencies = (env = {}) => {
       setRouterScreenDetailGet,
       setRouterScreenEditGet,
       setRouterScreenErrorGet,
+      setRouterScreenFavoriteGet,
       setRouterScreenLoginGet,
       setRouterScreenSearchGet,
       setRouterScreenSummaryGet,
+      setRouterApiFavoriteAndQueue,
     },
   };
 

--- a/src/app/setupRoutes.js
+++ b/src/app/setupRoutes.js
@@ -21,6 +21,11 @@ const setupRoutes = (app, { env: _env, dependencies } = {}) => {
   dependencies.routeSetters.setRouterScreenErrorGet({
     router,
   });
+  dependencies.routeSetters.setRouterScreenFavoriteGet({
+    router,
+    authResolver: dependencies.authResolver,
+    getFavoriteSummariesService: dependencies.getFavoriteSummariesService,
+  });
   dependencies.routeSetters.setRouterScreenLoginGet({
     router,
   });
@@ -41,6 +46,14 @@ const setupRoutes = (app, { env: _env, dependencies } = {}) => {
     mediaIdValueGenerator: dependencies.mediaIdValueGenerator,
     mediaRepository: dependencies.mediaRepository,
     unitOfWork: dependencies.unitOfWork,
+  });
+  dependencies.routeSetters.setRouterApiFavoriteAndQueue({
+    router,
+    authResolver: dependencies.authResolver,
+    addFavoriteService: dependencies.addFavoriteService,
+    removeFavoriteService: dependencies.removeFavoriteService,
+    addQueueService: dependencies.addQueueService,
+    removeQueueService: dependencies.removeQueueService,
   });
 
   app.use(router);

--- a/src/application/media/port/IMediaQueryRepository.js
+++ b/src/application/media/port/IMediaQueryRepository.js
@@ -2,4 +2,7 @@ module.exports = class IMediaQueryRepository {
   async search() {
     throw new Error();
   }
+  async findOverviewsByMediaIds() {
+    throw new Error();
+  }
 };

--- a/src/application/user/query/GetFavoriteSummariesService.js
+++ b/src/application/user/query/GetFavoriteSummariesService.js
@@ -1,0 +1,74 @@
+const UserId = require('../../../domain/user/userId');
+
+class Input {
+  constructor({ userId }) {
+    if (typeof userId !== 'string' || userId.length === 0) {
+      throw new Error();
+    }
+
+    this.userId = userId;
+  }
+}
+
+const isMediaOverviewLike = (obj) => {
+  if (typeof obj?.mediaId !== 'string') return false;
+  if (typeof obj?.title !== 'string') return false;
+  if (typeof obj?.thumbnail !== 'string') return false;
+  if (!(obj?.tags instanceof Array)) return false;
+  if (!obj.tags.every(tag => ['category', 'label'].every(prop => prop in tag))) return false;
+  if (!(obj?.priorityCategories instanceof Array)) return false;
+  if (!obj.priorityCategories.every(category => typeof category === 'string')) return false;
+  return true;
+};
+
+class Output {
+  constructor({ mediaOverviews }) {
+    if (!(mediaOverviews instanceof Array) || !mediaOverviews.every(isMediaOverviewLike)) {
+      throw new Error();
+    }
+
+    this.mediaOverviews = mediaOverviews;
+  }
+}
+
+class GetFavoriteSummariesService {
+  #userRepository;
+  #mediaQueryRepository;
+
+  constructor({ userRepository, mediaQueryRepository }) {
+    if (!userRepository || typeof userRepository.findByUserId !== 'function') {
+      throw new Error();
+    }
+    if (!mediaQueryRepository || typeof mediaQueryRepository.findOverviewsByMediaIds !== 'function') {
+      throw new Error();
+    }
+
+    this.#userRepository = userRepository;
+    this.#mediaQueryRepository = mediaQueryRepository;
+  }
+
+  async execute(input) {
+    if (!(input instanceof Input)) {
+      throw new Error();
+    }
+
+    const user = await this.#userRepository.findByUserId(new UserId(input.userId));
+    if (!user) {
+      return new Output({ mediaOverviews: [] });
+    }
+
+    const mediaIds = user.getFavorites().map(mediaId => mediaId.getId());
+    if (mediaIds.length === 0) {
+      return new Output({ mediaOverviews: [] });
+    }
+
+    const mediaOverviews = await this.#mediaQueryRepository.findOverviewsByMediaIds(mediaIds);
+    return new Output({ mediaOverviews });
+  }
+}
+
+module.exports = {
+  Input,
+  Output,
+  GetFavoriteSummariesService,
+};

--- a/src/controller/router/screen/setRouterScreenFavoriteGet.js
+++ b/src/controller/router/screen/setRouterScreenFavoriteGet.js
@@ -1,0 +1,26 @@
+const SessionAuthMiddleware = require('../../middleware/SessionAuthMiddleware');
+const { Input } = require('../../../application/user/query/GetFavoriteSummariesService');
+
+const setRouterScreenFavoriteGet = ({ router, authResolver, getFavoriteSummariesService }) => {
+  const auth = new SessionAuthMiddleware(authResolver);
+
+  router.get('/screen/favorite', ...[
+    auth.execute.bind(auth),
+    async (req, res, next) => {
+      try {
+        const result = await getFavoriteSummariesService.execute(new Input({
+          userId: req.context.userId,
+        }));
+
+        res.status(200).render('screen/favorite', {
+          pageTitle: 'お気に入り一覧',
+          mediaOverviews: result.mediaOverviews,
+        });
+      } catch (error) {
+        next(error);
+      }
+    },
+  ]);
+};
+
+module.exports = setRouterScreenFavoriteGet;

--- a/src/controller/router/user/setRouterApiFavoriteAndQueue.js
+++ b/src/controller/router/user/setRouterApiFavoriteAndQueue.js
@@ -1,0 +1,64 @@
+const SessionAuthMiddleware = require('../../middleware/SessionAuthMiddleware');
+const { Query: AddFavoriteQuery } = require('../../../application/user/command/AddFavoriteService');
+const { Query: RemoveFavoriteQuery } = require('../../../application/user/command/RemoveFavoriteService');
+const { Query: AddQueueQuery } = require('../../../application/user/command/AddQueueService');
+const { Query: RemoveQueueQuery } = require('../../../application/user/command/RemoveQueueService');
+
+const setRouterApiFavoriteAndQueue = ({
+  router,
+  authResolver,
+  addFavoriteService,
+  removeFavoriteService,
+  addQueueService,
+  removeQueueService,
+}) => {
+  const auth = new SessionAuthMiddleware(authResolver);
+  const getUserId = req => req.context.userId;
+
+  router.post('/api/favorite/:mediaId', auth.execute.bind(auth), async (req, res, next) => {
+    try {
+      await addFavoriteService.execute(new AddFavoriteQuery({ mediaId: req.params.mediaId, userId: getUserId(req) }));
+      res.status(200).json({ code: 0 });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.delete('/api/favorite/:mediaId', auth.execute.bind(auth), async (req, res, next) => {
+    try {
+      await removeFavoriteService.execute(new RemoveFavoriteQuery({ mediaId: req.params.mediaId, userId: getUserId(req) }));
+      res.status(200).json({ code: 0 });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.put('/api/queue/:mediaId', auth.execute.bind(auth), async (req, res, next) => {
+    try {
+      await addQueueService.execute(new AddQueueQuery({ mediaId: req.params.mediaId, userId: getUserId(req) }));
+      res.status(200).json({ code: 0 });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.post('/api/queue/:mediaId', auth.execute.bind(auth), async (req, res, next) => {
+    try {
+      await addQueueService.execute(new AddQueueQuery({ mediaId: req.params.mediaId, userId: getUserId(req) }));
+      res.status(200).json({ code: 0 });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.delete('/api/queue/:mediaId', auth.execute.bind(auth), async (req, res, next) => {
+    try {
+      await removeQueueService.execute(new RemoveQueueQuery({ mediaId: req.params.mediaId, userId: getUserId(req) }));
+      res.status(200).json({ code: 0 });
+    } catch (error) {
+      next(error);
+    }
+  });
+};
+
+module.exports = setRouterApiFavoriteAndQueue;

--- a/src/infrastructure/SequelizeMediaQueryRepository.js
+++ b/src/infrastructure/SequelizeMediaQueryRepository.js
@@ -9,6 +9,23 @@ const {
 } = require('../application/media/port/SearchResult');
 const { defineModels } = require('./SequelizeMediaRepository');
 
+
+const extractMediaIdValue = mediaId => {
+  if (typeof mediaId === 'string') {
+    return mediaId;
+  }
+  if (mediaId && typeof mediaId.get === 'function') {
+    const value = mediaId.get('media_id');
+    if (typeof value === 'string') {
+      return value;
+    }
+  }
+  if (typeof mediaId?.media_id === 'string') {
+    return mediaId.media_id;
+  }
+  return null;
+};
+
 const buildSortOrder = (sortType) => {
   switch (sortType) {
     case SortType.DATE_ASC:
@@ -75,21 +92,29 @@ module.exports = class SequelizeMediaQueryRepository extends IMediaQueryReposito
   }
 
   async findOverviewsByMediaIds(mediaIds) {
-    if (!(mediaIds instanceof Array) || !mediaIds.every(mediaId => typeof mediaId === 'string')) {
+    if (!(mediaIds instanceof Array)) {
       throw new Error();
     }
-    if (mediaIds.length === 0) {
+
+    const normalizedMediaIds = mediaIds
+      .map(extractMediaIdValue)
+      .filter(mediaId => typeof mediaId === 'string');
+
+    if (normalizedMediaIds.length !== mediaIds.length) {
+      throw new Error();
+    }
+    if (normalizedMediaIds.length === 0) {
       return [];
     }
 
     const { MediaModel, ContentModel, TagModel, CategoryModel, MediaTagModel, MediaCategoryModel } = this.#models;
     const [contentRows, tagRows, categoryRows, mediaRows] = await Promise.all([
       ContentModel.findAll({
-        where: { media_id: mediaIds },
+        where: { media_id: normalizedMediaIds },
         order: [['media_id', 'ASC'], ['position', 'ASC']],
       }),
       MediaTagModel.findAll({
-        where: { media_id: mediaIds },
+        where: { media_id: normalizedMediaIds },
         include: [{
           model: TagModel,
           as: 'tag',
@@ -97,11 +122,11 @@ module.exports = class SequelizeMediaQueryRepository extends IMediaQueryReposito
         }],
       }),
       MediaCategoryModel.findAll({
-        where: { media_id: mediaIds },
+        where: { media_id: normalizedMediaIds },
         include: [{ model: CategoryModel, as: 'category' }],
         order: [['media_id', 'ASC'], ['priority', 'ASC']],
       }),
-      MediaModel.findAll({ where: { media_id: mediaIds } }),
+      MediaModel.findAll({ where: { media_id: normalizedMediaIds } }),
     ]);
 
     const mediaRowMap = new Map(mediaRows.map(row => [row.media_id, row]));
@@ -129,7 +154,7 @@ module.exports = class SequelizeMediaQueryRepository extends IMediaQueryReposito
       priorityCategoriesMap.set(row.media_id, items);
     });
 
-    return mediaIds
+    return normalizedMediaIds
       .map(mediaId => mediaRowMap.get(mediaId))
       .filter(Boolean)
       .map(row => new MediaOverview({
@@ -225,6 +250,6 @@ module.exports = class SequelizeMediaQueryRepository extends IMediaQueryReposito
     }
 
     const rows = await MediaModel.findAll(query);
-    return rows.map(row => row.media_id);
+    return rows.map(row => extractMediaIdValue(row));
   }
 };

--- a/src/infrastructure/SequelizeMediaQueryRepository.js
+++ b/src/infrastructure/SequelizeMediaQueryRepository.js
@@ -92,7 +92,7 @@ module.exports = class SequelizeMediaQueryRepository extends IMediaQueryReposito
   }
 
   async findOverviewsByMediaIds(mediaIds) {
-    if (!(mediaIds instanceof Array)) {
+    if (!Array.isArray(mediaIds)) {
       throw new Error();
     }
 

--- a/src/infrastructure/SequelizeMediaQueryRepository.js
+++ b/src/infrastructure/SequelizeMediaQueryRepository.js
@@ -45,7 +45,7 @@ module.exports = class SequelizeMediaQueryRepository extends IMediaQueryReposito
       throw new Error();
     }
 
-    const { MediaModel, ContentModel, TagModel, CategoryModel, MediaTagModel, MediaCategoryModel } = this.#models;
+    const { MediaModel, CategoryModel, TagModel, MediaTagModel } = this.#models;
 
     const mediaIds = await this.#findMatchedMediaIds({
       condition,
@@ -70,13 +70,26 @@ module.exports = class SequelizeMediaQueryRepository extends IMediaQueryReposito
       return new SearchResult({ mediaOverviews: [], totalCount });
     }
 
+    const mediaOverviews = await this.findOverviewsByMediaIds(pagedIds);
+    return new SearchResult({ mediaOverviews, totalCount });
+  }
+
+  async findOverviewsByMediaIds(mediaIds) {
+    if (!(mediaIds instanceof Array) || !mediaIds.every(mediaId => typeof mediaId === 'string')) {
+      throw new Error();
+    }
+    if (mediaIds.length === 0) {
+      return [];
+    }
+
+    const { MediaModel, ContentModel, TagModel, CategoryModel, MediaTagModel, MediaCategoryModel } = this.#models;
     const [contentRows, tagRows, categoryRows, mediaRows] = await Promise.all([
       ContentModel.findAll({
-        where: { media_id: pagedIds },
+        where: { media_id: mediaIds },
         order: [['media_id', 'ASC'], ['position', 'ASC']],
       }),
       MediaTagModel.findAll({
-        where: { media_id: pagedIds },
+        where: { media_id: mediaIds },
         include: [{
           model: TagModel,
           as: 'tag',
@@ -84,11 +97,11 @@ module.exports = class SequelizeMediaQueryRepository extends IMediaQueryReposito
         }],
       }),
       MediaCategoryModel.findAll({
-        where: { media_id: pagedIds },
+        where: { media_id: mediaIds },
         include: [{ model: CategoryModel, as: 'category' }],
         order: [['media_id', 'ASC'], ['priority', 'ASC']],
       }),
-      MediaModel.findAll({ where: { media_id: pagedIds } }),
+      MediaModel.findAll({ where: { media_id: mediaIds } }),
     ]);
 
     const mediaRowMap = new Map(mediaRows.map(row => [row.media_id, row]));
@@ -116,7 +129,7 @@ module.exports = class SequelizeMediaQueryRepository extends IMediaQueryReposito
       priorityCategoriesMap.set(row.media_id, items);
     });
 
-    const mediaOverviews = pagedIds
+    return mediaIds
       .map(mediaId => mediaRowMap.get(mediaId))
       .filter(Boolean)
       .map(row => new MediaOverview({
@@ -129,8 +142,6 @@ module.exports = class SequelizeMediaQueryRepository extends IMediaQueryReposito
         }),
         priorityCategories: priorityCategoriesMap.get(row.media_id) ?? [],
       }));
-
-    return new SearchResult({ mediaOverviews, totalCount });
   }
 
   #sortTags({ tags, priorityCategories }) {

--- a/src/infrastructure/SequelizeUserRepository.js
+++ b/src/infrastructure/SequelizeUserRepository.js
@@ -1,0 +1,115 @@
+const { DataTypes } = require('sequelize');
+
+const IUserRepository = require('../domain/user/IUserRepository');
+const User = require('../domain/user/user');
+const UserId = require('../domain/user/userId');
+const MediaId = require('../domain/media/mediaId');
+
+function defineModels(sequelize) {
+  const UserModel = sequelize.define('user', {
+    user_id: { type: DataTypes.STRING, primaryKey: true },
+  }, { tableName: 'user', timestamps: false });
+
+  const FavoriteModel = sequelize.define('favorite', {
+    user_id: { type: DataTypes.STRING, primaryKey: true },
+    media_id: { type: DataTypes.STRING, primaryKey: true },
+  }, { tableName: 'favorite', timestamps: false });
+
+  const QueueModel = sequelize.define('queue', {
+    user_id: { type: DataTypes.STRING, primaryKey: true },
+    media_id: { type: DataTypes.STRING, primaryKey: true },
+  }, { tableName: 'queue', timestamps: false });
+
+  UserModel.hasMany(FavoriteModel, { foreignKey: 'user_id', as: 'favorites', onDelete: 'CASCADE' });
+  FavoriteModel.belongsTo(UserModel, { foreignKey: 'user_id', as: 'user' });
+  UserModel.hasMany(QueueModel, { foreignKey: 'user_id', as: 'queueItems', onDelete: 'CASCADE' });
+  QueueModel.belongsTo(UserModel, { foreignKey: 'user_id', as: 'user' });
+
+  return {
+    UserModel,
+    FavoriteModel,
+    QueueModel,
+  };
+}
+
+module.exports = class SequelizeUserRepository extends IUserRepository {
+  #sequelize;
+  #models;
+  #unitOfWorkContext;
+
+  constructor({ sequelize, models, unitOfWorkContext } = {}) {
+    super();
+
+    if (!sequelize || typeof sequelize.transaction !== 'function') {
+      throw new Error();
+    }
+    if (!unitOfWorkContext || typeof unitOfWorkContext.getCurrent !== 'function') {
+      throw new Error();
+    }
+
+    this.#sequelize = sequelize;
+    this.#models = models || defineModels(sequelize);
+    this.#unitOfWorkContext = unitOfWorkContext;
+  }
+
+  async sync() {
+    await this.#sequelize.sync();
+  }
+
+  async save(user) {
+    if (!(user instanceof User)) {
+      throw new Error();
+    }
+
+    const executionScope = this.#unitOfWorkContext.getCurrent();
+    const { UserModel, FavoriteModel, QueueModel } = this.#models;
+    const userId = user.getUserId().getId();
+
+    await UserModel.upsert({ user_id: userId }, { transaction: executionScope });
+    await FavoriteModel.destroy({ where: { user_id: userId }, transaction: executionScope });
+    await QueueModel.destroy({ where: { user_id: userId }, transaction: executionScope });
+
+    const favorites = user.getFavorites().map(mediaId => ({
+      user_id: userId,
+      media_id: mediaId.getId(),
+    }));
+    const queue = user.getQueue().map(mediaId => ({
+      user_id: userId,
+      media_id: mediaId.getId(),
+    }));
+
+    if (favorites.length > 0) {
+      await FavoriteModel.bulkCreate(favorites, { transaction: executionScope });
+    }
+    if (queue.length > 0) {
+      await QueueModel.bulkCreate(queue, { transaction: executionScope });
+    }
+  }
+
+  async findByUserId(userId) {
+    if (!(userId instanceof UserId)) {
+      throw new Error();
+    }
+
+    const executionScope = this.#unitOfWorkContext.getCurrent();
+    const { UserModel, FavoriteModel, QueueModel } = this.#models;
+    const userRow = await UserModel.findByPk(userId.getId(), {
+      include: [
+        { model: FavoriteModel, as: 'favorites' },
+        { model: QueueModel, as: 'queueItems' },
+      ],
+      transaction: executionScope,
+    });
+
+    if (!userRow) {
+      return new User(new UserId(userId.getId()));
+    }
+
+    const user = new User(new UserId(userRow.user_id));
+    userRow.favorites.forEach(favorite => user.addFavorite(new MediaId(favorite.media_id)));
+    userRow.queueItems.forEach(queue => user.addQueue(new MediaId(queue.media_id)));
+    return user;
+  }
+};
+
+module.exports.defineModels = defineModels;

--- a/src/views/screen/detail.ejs
+++ b/src/views/screen/detail.ejs
@@ -130,7 +130,7 @@
 
         document.getElementById('favorite-add').addEventListener('click', () => request(`/api/favorite/${mediaId}`, 'POST', 'お気に入りに追加しました'));
         document.getElementById('favorite-remove').addEventListener('click', () => request(`/api/favorite/${mediaId}`, 'DELETE', 'お気に入りから削除しました'));
-        document.getElementById('queue-add').addEventListener('click', () => request(`/api/queue/${mediaId}`, 'POST', 'あとで見るに追加しました'));
+        document.getElementById('queue-add').addEventListener('click', () => request(`/api/queue/${mediaId}`, 'PUT', 'あとで見るに追加しました'));
         document.getElementById('queue-remove').addEventListener('click', () => request(`/api/queue/${mediaId}`, 'DELETE', 'あとで見るから削除しました'));
       })();
     </script>

--- a/src/views/screen/favorite.ejs
+++ b/src/views/screen/favorite.ejs
@@ -42,7 +42,7 @@
           <% } else { %>
             <div class="media-grid">
               <% mediaOverviews.forEach((media) => { %>
-                <article class="media-card" data-media-id="<%= media.mediaId %>">
+                <article class="media-card" data-media-id="<%= media.mediaId %>" data-favorite-delete-path="/api/favorite/<%= media.mediaId %>" data-queue-put-path="/api/queue/<%= media.mediaId %>">
                   <div class="media-body">
                     <a class="thumbnail" href="/screen/detail/<%= media.mediaId %>">
                       <% if (media.thumbnail) { %>
@@ -95,17 +95,18 @@
         };
 
         document.querySelectorAll('[data-media-id]').forEach(card => {
-          const mediaId = card.dataset.mediaId;
+          const favoriteDeletePath = card.dataset.favoriteDeletePath;
+          const queuePutPath = card.dataset.queuePutPath;
           const statusElement = card.querySelector('.status');
           card.querySelector('.js-favorite-remove').addEventListener('click', () => request({
-            path: `/api/favorite/${mediaId}`,
+            path: favoriteDeletePath,
             method: 'DELETE',
             successMessage: 'お気に入りから削除しました',
             statusElement,
             onSuccess: () => card.remove(),
           }));
           card.querySelector('.js-queue-add').addEventListener('click', () => request({
-            path: `/api/queue/${mediaId}`,
+            path: queuePutPath,
             method: 'PUT',
             successMessage: 'あとで見るに追加しました',
             statusElement,

--- a/src/views/screen/favorite.ejs
+++ b/src/views/screen/favorite.ejs
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title><%= pageTitle %></title>
+    <style>
+      :root { color-scheme: light; font-family: "Hiragino Sans", "Yu Gothic UI", sans-serif; background: #f5f6f8; color: #1f2937; }
+      * { box-sizing: border-box; }
+      body { margin: 0; background: #f5f6f8; }
+      a { color: #2563eb; text-decoration: none; }
+      a:hover { text-decoration: underline; }
+      .page { max-width: 1080px; margin: 0 auto; padding: 32px 16px 64px; }
+      .stack { display: grid; gap: 24px; }
+      .card { background: #fff; border: 1px solid #d1d5db; border-radius: 16px; padding: 24px; box-shadow: 0 10px 30px rgba(15, 23, 42, 0.06); }
+      .media-grid { display: grid; gap: 16px; }
+      .media-card { border: 1px solid #dbe3f0; border-radius: 16px; background: #f8fafc; padding: 16px; }
+      .media-body { display: grid; grid-template-columns: 160px 1fr; gap: 16px; }
+      .thumbnail { width: 160px; height: 120px; border-radius: 12px; background: #dbeafe; overflow: hidden; display:flex; align-items:center; justify-content:center; color:#1d4ed8; font-size:12px; }
+      .thumbnail img { width:100%; height:100%; object-fit:cover; }
+      .meta { display:grid; gap: 12px; }
+      .tag-list, .actions { display:flex; gap:12px; flex-wrap:wrap; }
+      .chip { background: #eff6ff; color: #1d4ed8; border-radius: 999px; padding: 6px 12px; font-size: 14px; }
+      .button { border: 0; border-radius: 10px; padding: 10px 16px; font-size: 14px; font-weight: 700; cursor: pointer; background:#2563eb; color:#fff; }
+      .button.secondary { background:#475569; }
+      .status { min-height: 20px; font-size: 13px; color: #475569; }
+      .empty { color: #64748b; }
+      @media (max-width: 720px) { .media-body { grid-template-columns: 1fr; } .thumbnail { width: 100%; height: 200px; } }
+    </style>
+  </head>
+  <body>
+    <div class="page">
+      <div class="stack">
+        <section class="card">
+          <h1><%= pageTitle %></h1>
+          <p>お気に入りに登録したメディアを一覧表示します。</p>
+        </section>
+
+        <section class="card">
+          <% if (mediaOverviews.length === 0) { %>
+            <p class="empty">お気に入りはまだありません。</p>
+          <% } else { %>
+            <div class="media-grid">
+              <% mediaOverviews.forEach((media) => { %>
+                <article class="media-card" data-media-id="<%= media.mediaId %>">
+                  <div class="media-body">
+                    <a class="thumbnail" href="/screen/detail/<%= media.mediaId %>">
+                      <% if (media.thumbnail) { %>
+                        <img src="<%= media.thumbnail %>" alt="<%= media.title %> のサムネイル" />
+                      <% } else { %>
+                        <span>NO IMAGE</span>
+                      <% } %>
+                    </a>
+                    <div class="meta">
+                      <div>
+                        <h2><%= media.title %></h2>
+                      </div>
+                      <div class="tag-list">
+                        <% media.tags.forEach((tag) => { %>
+                          <span class="chip"><%= tag.category %>:<%= tag.label %></span>
+                        <% }) %>
+                      </div>
+                      <div class="actions">
+                        <a href="/screen/detail/<%= media.mediaId %>">詳細画面へ</a>
+                        <a href="/screen/viewer/<%= media.mediaId %>/1">ビューアーへ</a>
+                        <button class="button secondary js-favorite-remove" type="button">お気に入り解除</button>
+                        <button class="button js-queue-add" type="button">あとで見る追加</button>
+                      </div>
+                      <p class="status" aria-live="polite"></p>
+                    </div>
+                  </div>
+                </article>
+              <% }) %>
+            </div>
+          <% } %>
+        </section>
+      </div>
+    </div>
+
+    <script>
+      (() => {
+        const request = async ({ path, method, successMessage, statusElement, onSuccess }) => {
+          statusElement.textContent = '通信中です...';
+          try {
+            const response = await fetch(path, { method, headers: { Accept: 'application/json' } });
+            if (!response.ok) {
+              statusElement.textContent = `${successMessage}に失敗しました (${response.status})`;
+              return;
+            }
+            statusElement.textContent = successMessage;
+            if (typeof onSuccess === 'function') onSuccess();
+          } catch (_error) {
+            statusElement.textContent = `${successMessage}に失敗しました`;
+          }
+        };
+
+        document.querySelectorAll('[data-media-id]').forEach(card => {
+          const mediaId = card.dataset.mediaId;
+          const statusElement = card.querySelector('.status');
+          card.querySelector('.js-favorite-remove').addEventListener('click', () => request({
+            path: `/api/favorite/${mediaId}`,
+            method: 'DELETE',
+            successMessage: 'お気に入りから削除しました',
+            statusElement,
+            onSuccess: () => card.remove(),
+          }));
+          card.querySelector('.js-queue-add').addEventListener('click', () => request({
+            path: `/api/queue/${mediaId}`,
+            method: 'PUT',
+            successMessage: 'あとで見るに追加しました',
+            statusElement,
+          }));
+        });
+      })();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
### Motivation
- ユーザーが保持する favorite の `mediaId` 群を画面表示に必要なメディア概要へ変換する read 経路が不足していたため、お気に入り一覧を表示できるようにする。 
- 永続化側に `user` / `favorite` / `queue` を扱う実装が必要だったため、Sequelize での保存・読取を整備する。 
- 画面導線（一覧 → 詳細／ビューアー）や favorites/queue の操作 API を揃えて UI から利用できるようにするため。 

### Description
- `GetFavoriteSummariesService` を追加し、`userRepository` から favorite の `mediaId` を取得して `mediaQueryRepository.findOverviewsByMediaIds` で画面用の概要へ変換するように実装した（`src/application/user/query/GetFavoriteSummariesService.js`）。
- `IMediaQueryRepository` に `findOverviewsByMediaIds` を追加し、`SequelizeMediaQueryRepository` に対応実装を追加して ID 列指定でメディア概要を取得できるようにした（`src/application/media/port/IMediaQueryRepository.js`, `src/infrastructure/SequelizeMediaQueryRepository.js`）。
- `SequelizeUserRepository` を追加して `user` / `favorite` / `queue` の永続化・復元を実装し（未登録ユーザーは空のユーザーとして扱う）、`createDependencies` で注入するようにした（`src/infrastructure/SequelizeUserRepository.js`, `src/app/createDependencies.js`）。
- 画面・ルータを追加・配線した：`GET /screen/favorite` の router（`setRouterScreenFavoriteGet`）とビュー `src/views/screen/favorite.ejs` を追加し、favorite/queue 操作用の API ルータ `setRouterApiFavoriteAndQueue` を追加して `setupRoutes` に組み込んだ（`src/controller/router/screen/setRouterScreenFavoriteGet.js`, `src/controller/router/user/setRouterApiFavoriteAndQueue.js`, `src/app/setupRoutes.js`）。
- 既存の詳細画面のあとで見るボタンを `PUT /api/queue/{mediaId}` に揃える修正を行った（`src/views/screen/detail.ejs`）。
- テスト用にモック拡張とユニット／ミドルテストを追加した（`__tests__/small/...` と `__tests__/medium/...` に関連ファイルを追加）。

### Testing
- `node --check` による主要変更ファイルの構文チェックを実行し成功した（変更した JS ファイルは構文エラーなし）。
- ユニット／統合テスト（Jest）はテストファイルを追加したが、環境からの依存取得で `jest` の取得が `403 Forbidden` となったため実行できなかった（`npx jest` および `npm test` 実行は失敗）。
- アプリ起動確認は環境により `express` 等の依存解決が必要であるため自動実行は限定的で、ローカルでの起動とエンドツーエンド検証は依存解決後に実行を想定している。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0229c3f8c832bace5e468a4b0add2)