### PR TITLE
feat: 詳細画面の表示と操作導線を追加する

### DIFF
--- a/__tests__/small/applicationService/media/query/GetMediaDetailService.test.js
+++ b/__tests__/small/applicationService/media/query/GetMediaDetailService.test.js
@@ -40,7 +40,7 @@ describe("GetMediaDetailService", () => {
 
   test("メディアIDをリポジトリに渡して取得できる", async () => {
     // arrange
-    const input = new Input({ id: 'ID' });
+    const input = new Input({ mediaId: 'ID' });
     mockRepo.findByMediaId.mockResolvedValue(createMedia());
 
     // action
@@ -65,7 +65,7 @@ describe("GetMediaDetailService", () => {
   // =========================
   test("メディアID以外が指定された場合は取得に失敗する", async () => {
     // arrange
-    const input = { ...(new Input({ id: 'ID' })) };
+    const input = { ...(new Input({ mediaId: 'ID' })) };
 
     // action
     // assert
@@ -75,7 +75,7 @@ describe("GetMediaDetailService", () => {
 
   test("リポジトリの取得結果が空だと取得に失敗する", async () => {
     // arrange
-    const input = new Input({ id: 'ID' });
+    const input = new Input({ mediaId: 'ID' });
     mockRepo.findByMediaId.mockResolvedValue(undefined);
 
     // action
@@ -87,7 +87,7 @@ describe("GetMediaDetailService", () => {
 
   test("リポジトリの検索処理が失敗した場合は検索に失敗する", async () => {
     // arrange
-    const input = new Input({ id: 'ID' });
+    const input = new Input({ mediaId: 'ID' });
     mockRepo.findByMediaId.mockRejectedValue(new Error("mockRepo error"));
 
     // action

--- a/__tests__/small/controller/router/screen/setRouterScreenDetailGet.test.js
+++ b/__tests__/small/controller/router/screen/setRouterScreenDetailGet.test.js
@@ -1,17 +1,18 @@
-const setRouterScreenEditGet = require('../../../../../src/controller/router/screen/setRouterScreenEditGet');
+const setRouterScreenDetailGet = require('../../../../../src/controller/router/screen/setRouterScreenDetailGet');
 
-describe('setRouterScreenEditGet', () => {
+describe('setRouterScreenDetailGet', () => {
   const createRes = () => {
     const res = {
       status: jest.fn(),
       render: jest.fn(),
+      redirect: jest.fn(),
       json: jest.fn(),
     };
     res.status.mockReturnValue(res);
     return res;
   };
 
-  it('GET /screen/edit/:mediaId に認証・描画ハンドラーを登録できる', async () => {
+  it('GET /screen/detail/:mediaId に認証・描画ハンドラーを登録できる', async () => {
     const router = {
       get: jest.fn(),
     };
@@ -30,11 +31,11 @@ describe('setRouterScreenEditGet', () => {
       }),
     };
 
-    setRouterScreenEditGet({ router, authResolver, getMediaDetailService });
+    setRouterScreenDetailGet({ router, authResolver, getMediaDetailService });
 
     expect(router.get).toHaveBeenCalledTimes(1);
     const [path, ...handlers] = router.get.mock.calls[0];
-    expect(path).toBe('/screen/edit/:mediaId');
+    expect(path).toBe('/screen/detail/:mediaId');
     expect(handlers).toHaveLength(2);
 
     const req = {
@@ -51,8 +52,8 @@ describe('setRouterScreenEditGet', () => {
     expect(authResolver.execute).toHaveBeenCalledWith('token-1');
     expect(getMediaDetailService.execute).toHaveBeenCalledWith(expect.objectContaining({ mediaId: 'media-1' }));
     expect(res.status).toHaveBeenCalledWith(200);
-    expect(res.render).toHaveBeenCalledWith('screen/edit', expect.objectContaining({
-      pageTitle: '作品タイトル の編集',
+    expect(res.render).toHaveBeenCalledWith('screen/detail', expect.objectContaining({
+      pageTitle: '作品タイトル の詳細',
       mediaDetail: expect.objectContaining({ id: 'media-1' }),
     }));
   });

--- a/__tests__/small/controller/screen/ScreenDetailGetController.test.js
+++ b/__tests__/small/controller/screen/ScreenDetailGetController.test.js
@@ -1,0 +1,51 @@
+const ScreenDetailGetController = require('../../../../src/controller/screen/ScreenDetailGetController');
+
+describe('ScreenDetailGetController', () => {
+  const createRes = () => {
+    const res = {
+      status: jest.fn(),
+      render: jest.fn(),
+      redirect: jest.fn(),
+    };
+    res.status.mockReturnValue(res);
+    return res;
+  };
+
+  test('mediaId を service に渡して詳細画面を描画する', async () => {
+    const getMediaDetailService = {
+      execute: jest.fn().mockResolvedValue({
+        mediaDetail: {
+          id: 'media-1',
+          title: '作品タイトル',
+          contents: ['content-1'],
+          tags: [{ category: '作者', label: '山田' }],
+          priorityCategories: ['作者'],
+        },
+      }),
+    };
+    const controller = new ScreenDetailGetController({ getMediaDetailService });
+    const req = { params: { mediaId: 'media-1' } };
+    const res = createRes();
+
+    await controller.execute(req, res);
+
+    expect(getMediaDetailService.execute).toHaveBeenCalledWith(expect.objectContaining({ mediaId: 'media-1' }));
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.render).toHaveBeenCalledWith('screen/detail', expect.objectContaining({
+      pageTitle: '作品タイトル の詳細',
+      mediaDetail: expect.objectContaining({ id: 'media-1' }),
+    }));
+  });
+
+  test('service 取得に失敗した場合はエラー画面へ 301 リダイレクトする', async () => {
+    const getMediaDetailService = {
+      execute: jest.fn().mockRejectedValue(new Error('not found')),
+    };
+    const controller = new ScreenDetailGetController({ getMediaDetailService });
+    const res = createRes();
+
+    await controller.execute({ params: { mediaId: 'missing' } }, res);
+
+    expect(res.redirect).toHaveBeenCalledWith(301, '/screen/error');
+  });
+});

--- a/src/application/media/query/GetMediaDetailService.js
+++ b/src/application/media/query/GetMediaDetailService.js
@@ -2,12 +2,12 @@ const MediaId = require('../../../domain/media/mediaId');
 
 // SearchCondition と同じなので継承だけで済ます
 class Input {
-  constructor({ id }) {
-    if (typeof id !== 'string') {
+  constructor({ mediaId }) {
+    if (typeof mediaId !== 'string') {
       throw new Error();
     }
 
-    this.id = id;
+    this.mediaId = mediaId;
   }
 }
 
@@ -49,7 +49,7 @@ class GetMediaDetailService {
       throw new Error();
     }
 
-    const mediaId = new MediaId(input.id);
+    const mediaId = new MediaId(input.mediaId);
     const media = await this.#mediaRepository.findByMediaId(mediaId);
 
     if (!media) {

--- a/src/controller/router/screen/setRouterScreenDetailGet.js
+++ b/src/controller/router/screen/setRouterScreenDetailGet.js
@@ -1,25 +1,13 @@
 const SessionAuthMiddleware = require('../../middleware/SessionAuthMiddleware');
-const { Input } = require('../../../application/media/query/GetMediaDetailService');
+const ScreenDetailGetController = require('../../screen/ScreenDetailGetController');
 
 const setRouterScreenDetailGet = ({ router, authResolver, getMediaDetailService }) => {
   const auth = new SessionAuthMiddleware(authResolver);
+  const controller = new ScreenDetailGetController({ getMediaDetailService });
 
   router.get('/screen/detail/:mediaId', ...[
     auth.execute.bind(auth),
-    async (req, res, next) => {
-      try {
-        const result = await getMediaDetailService.execute(new Input({
-          id: req.params.mediaId,
-        }));
-
-        res.status(200).render('screen/detail', {
-          pageTitle: `${result.mediaDetail.title} の詳細`,
-          mediaDetail: result.mediaDetail,
-        });
-      } catch (error) {
-        next(error);
-      }
-    },
+    controller.execute.bind(controller),
   ]);
 };
 

--- a/src/controller/router/screen/setRouterScreenEditGet.js
+++ b/src/controller/router/screen/setRouterScreenEditGet.js
@@ -9,7 +9,7 @@ const setRouterScreenEditGet = ({ router, authResolver, getMediaDetailService })
     async (req, res, next) => {
       try {
         const result = await getMediaDetailService.execute(new Input({
-          id: req.params.mediaId,
+          mediaId: req.params.mediaId,
         }));
 
         res.status(200).render('screen/edit', {

--- a/src/controller/router/user/setRouterApiFavoriteAndQueue.js
+++ b/src/controller/router/user/setRouterApiFavoriteAndQueue.js
@@ -15,7 +15,7 @@ const setRouterApiFavoriteAndQueue = ({
   const auth = new SessionAuthMiddleware(authResolver);
   const getUserId = req => req.context.userId;
 
-  router.post('/api/favorite/:mediaId', auth.execute.bind(auth), async (req, res, next) => {
+  router.put('/api/favorite/:mediaId', auth.execute.bind(auth), async (req, res, next) => {
     try {
       await addFavoriteService.execute(new AddFavoriteQuery({ mediaId: req.params.mediaId, userId: getUserId(req) }));
       res.status(200).json({ code: 0 });

--- a/src/controller/screen/ScreenDetailGetController.js
+++ b/src/controller/screen/ScreenDetailGetController.js
@@ -1,0 +1,30 @@
+const { Input } = require('../../application/media/query/GetMediaDetailService');
+
+class ScreenDetailGetController {
+  #getMediaDetailService;
+
+  constructor({ getMediaDetailService }) {
+    if (!getMediaDetailService || typeof getMediaDetailService.execute !== 'function') {
+      throw new Error('getMediaDetailService.execute must be a function');
+    }
+
+    this.#getMediaDetailService = getMediaDetailService;
+  }
+
+  async execute(req, res) {
+    try {
+      const result = await this.#getMediaDetailService.execute(new Input({
+        mediaId: req.params.mediaId,
+      }));
+
+      return res.status(200).render('screen/detail', {
+        pageTitle: `${result.mediaDetail.title} の詳細`,
+        mediaDetail: result.mediaDetail,
+      });
+    } catch (_error) {
+      return res.redirect(301, '/screen/error');
+    }
+  }
+}
+
+module.exports = ScreenDetailGetController;

--- a/src/views/screen/detail.ejs
+++ b/src/views/screen/detail.ejs
@@ -23,6 +23,8 @@
       }
       h1 { margin: 0; font-size: 32px; }
       h2 { margin: 0 0 16px; font-size: 20px; }
+      .hero { display: grid; gap: 16px; }
+      .hero-meta { display: flex; gap: 12px; flex-wrap: wrap; color: #475569; }
       .list { margin: 0; padding-left: 20px; display: grid; gap: 8px; }
       .chip-list, .action-list { display: flex; gap: 12px; flex-wrap: wrap; }
       .chip { background: #eff6ff; color: #1d4ed8; border-radius: 999px; padding: 6px 12px; font-size: 14px; }
@@ -36,20 +38,27 @@
     </style>
   </head>
   <body>
-    <div class="page">
+    <main class="page">
       <div class="stack">
-        <section class="card">
+        <section class="card hero">
           <h1><%= mediaDetail.title %></h1>
+          <div class="hero-meta">
+            <span>メディアID: <%= mediaDetail.id %></span>
+            <span>コンテンツ数: <%= mediaDetail.contents.length %></span>
+            <span>タグ数: <%= mediaDetail.tags.length %></span>
+          </div>
         </section>
 
         <section class="card">
-          <h2>contents の一覧</h2>
+          <h2>コンテンツ一覧</h2>
           <% if (mediaDetail.contents.length === 0) { %>
             <p class="empty">コンテンツはありません。</p>
           <% } else { %>
             <ol class="list">
-              <% mediaDetail.contents.forEach((contentId) => { %>
-                <li><%= contentId %></li>
+              <% mediaDetail.contents.forEach((contentId, index) => { %>
+                <li>
+                  <a href="/screen/viewer/<%= mediaDetail.id %>/<%= index + 1 %>"><%= contentId %></a>
+                </li>
               <% }) %>
             </ol>
           <% } %>
@@ -69,7 +78,7 @@
         </section>
 
         <section class="card">
-          <h2>優先カテゴリ</h2>
+          <h2>優先カテゴリ一覧</h2>
           <% if (mediaDetail.priorityCategories.length === 0) { %>
             <p class="empty">優先カテゴリはありません。</p>
           <% } else { %>
@@ -93,14 +102,14 @@
           <h2>ユーザー操作</h2>
           <div class="action-list">
             <button id="favorite-add" class="api-button" type="button">お気に入り追加</button>
-            <button id="favorite-remove" class="api-button secondary" type="button">お気に入り削除</button>
+            <button id="favorite-remove" class="api-button secondary" type="button">お気に入り解除</button>
             <button id="queue-add" class="api-button" type="button">あとで見る追加</button>
-            <button id="queue-remove" class="api-button secondary" type="button">あとで見る削除</button>
+            <button id="queue-remove" class="api-button secondary" type="button">あとで見る解除</button>
           </div>
           <p id="request-status" class="status" aria-live="polite"></p>
         </section>
       </div>
-    </div>
+    </main>
 
     <script>
       (() => {
@@ -128,7 +137,7 @@
           }
         };
 
-        document.getElementById('favorite-add').addEventListener('click', () => request(`/api/favorite/${mediaId}`, 'POST', 'お気に入りに追加しました'));
+        document.getElementById('favorite-add').addEventListener('click', () => request(`/api/favorite/${mediaId}`, 'PUT', 'お気に入りに追加しました'));
         document.getElementById('favorite-remove').addEventListener('click', () => request(`/api/favorite/${mediaId}`, 'DELETE', 'お気に入りから削除しました'));
         document.getElementById('queue-add').addEventListener('click', () => request(`/api/queue/${mediaId}`, 'PUT', 'あとで見るに追加しました'));
         document.getElementById('queue-remove').addEventListener('click', () => request(`/api/queue/${mediaId}`, 'DELETE', 'あとで見るから削除しました'));


### PR DESCRIPTION
### Motivation
- 詳細画面の描画責務を router 直書きから分離して責務を明確にするため。  
- `GetMediaDetailService` の入力パラメータ名が混在していたため、画面間で使い回しやすく契約を統一するため。  
- 詳細画面からお気に入り／あとで見るを直接操作できる導線を用意し、OpenAPI 定義に合わせるため。  

### Description
- `src/controller/screen/ScreenDetailGetController.js` を追加し、詳細取得と描画・エラー遷移（取得失敗時は `301 /screen/error`）の責務を実装しました。  
- `src/controller/router/screen/setRouterScreenDetailGet.js` を薄い router に差し替え、認証ミドルウェア通過後に `ScreenDetailGetController` に処理を委譲するようにしました。  
- `src/application/media/query/GetMediaDetailService.js` の `Input` を `id` から `mediaId` に統一し、`execute` 内で `input.mediaId` を参照するよう変更しました。  
- 詳細画面テンプレート `src/views/screen/detail.ejs` を作成／拡張し、タイトル・コンテンツ一覧（viewer への導線）・タグ一覧・優先カテゴリ・編集導線と、お気に入り(`/api/favorite/:mediaId`)／あとで見る(`/api/queue/:mediaId`) の追加・解除ボタンを実装しました。  
- API の振る舞いを OpenAPI に合わせるため、`src/controller/router/user/setRouterApiFavoriteAndQueue.js` の favorite 追加を `POST` から `PUT` に揃えました。  
- 関連する単体テストを追加・更新しています（controller/route のテスト追加と service テストの入力修正）。  

### Testing
- ソース構文チェックとして `node --check` を用いて以下ファイルの構文を確認し成功しました: `src/controller/screen/ScreenDetailGetController.js`, `src/controller/router/screen/setRouterScreenDetailGet.js`, `src/controller/router/screen/setRouterScreenEditGet.js`, `src/controller/router/user/setRouterApiFavoriteAndQueue.js`, `src/application/media/query/GetMediaDetailService.js`.  
- 単体テスト実行を試みましたが、プロジェクト依存の `jest` 実行は環境側で `jest` バイナリが見つからない/依存パッケージの取得でレジストリエラーが発生し実行できなかったため未実行です（`npm install` / レジストリでの取得エラーにより実行不可）。  
- 追加・更新したテストファイル: `__tests__/small/controller/screen/ScreenDetailGetController.test.js`, `__tests__/small/controller/router/screen/setRouterScreenDetailGet.test.js`, 更新済み: `__tests__/small/applicationService/media/query/GetMediaDetailService.test.js`, `__tests__/small/controller/router/screen/setRouterScreenEditGet.test.js`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0380b5760832b86807825f448f3aa)