### PR TITLE
feat: POST /api/login の認証処理とセッション確立を追加する

### DIFF
--- a/__tests__/medium/controller/router/user/setRouterApiLogin.test.js
+++ b/__tests__/medium/controller/router/user/setRouterApiLogin.test.js
@@ -1,0 +1,87 @@
+const express = require('express');
+const request = require('supertest');
+
+const setRouterApiLogin = require('../../../../../src/controller/router/user/setRouterApiLogin');
+const SessionAuthMiddleware = require('../../../../../src/controller/middleware/SessionAuthMiddleware');
+const SessionStateRegistrar = require('../../../../../src/infrastructure/SessionStateRegistrar');
+const SessionStateAuthAdapter = require('../../../../../src/infrastructure/SessionStateAuthAdapter');
+const InMemorySessionStateStore = require('../../../../../src/infrastructure/InMemorySessionStateStore');
+const StaticLoginAuthenticator = require('../../../../../src/infrastructure/StaticLoginAuthenticator');
+const { LoginService } = require('../../../../../src/application/user/command/LoginService');
+const setupMiddleware = require('../../../../../src/app/setupMiddleware');
+
+describe('setRouterApiLogin (middle)', () => {
+  const createApp = () => {
+    const app = express();
+    const router = express.Router();
+    const sessionStateStore = new InMemorySessionStateStore();
+    const authResolver = new SessionStateAuthAdapter({ sessionStateStore });
+    const auth = new SessionAuthMiddleware(authResolver);
+
+    setupMiddleware(app, {
+      env: {},
+      dependencies: {},
+    });
+
+    setRouterApiLogin({
+      router,
+      loginService: new LoginService({
+        loginAuthenticator: new StaticLoginAuthenticator({
+          username: 'admin',
+          password: 'secret',
+          userId: 'user-001',
+        }),
+        sessionStateRegistrar: new SessionStateRegistrar({ sessionStateStore }),
+        sessionTtlMs: 60_000,
+      }),
+    });
+
+    router.get('/api/protected', auth.execute.bind(auth), (req, res) => {
+      res.status(200).json({ userId: req.context.userId });
+    });
+
+    app.use(router);
+    return app;
+  };
+
+  test('POST /api/login に成功すると Set-Cookie を返し、後続リクエストで認証できる', async () => {
+    const app = createApp();
+
+    const loginResponse = await request(app)
+      .post('/api/login')
+      .type('form')
+      .send({ username: 'admin', password: 'secret' });
+
+    expect(loginResponse.status).toBe(200);
+    expect(loginResponse.body).toEqual({ code: 0 });
+    expect(loginResponse.headers['set-cookie']).toEqual(
+      expect.arrayContaining([expect.stringMatching(/^session_token=[^;]+; Path=\/; HttpOnly/)]),
+    );
+
+    const protectedResponse = await request(app)
+      .get('/api/protected')
+      .set('Cookie', loginResponse.headers['set-cookie']);
+
+    expect(protectedResponse.status).toBe(200);
+    expect(protectedResponse.body).toEqual({ userId: 'user-001' });
+  });
+
+  test('POST /api/login に失敗すると code=1 を返し、認証状態を確立しない', async () => {
+    const app = createApp();
+
+    const loginResponse = await request(app)
+      .post('/api/login')
+      .type('form')
+      .send({ username: 'admin', password: 'wrong' });
+
+    expect(loginResponse.status).toBe(200);
+    expect(loginResponse.body).toEqual({ code: 1 });
+    expect(loginResponse.headers['set-cookie']).toBeUndefined();
+
+    const protectedResponse = await request(app)
+      .get('/api/protected');
+
+    expect(protectedResponse.status).toBe(401);
+    expect(protectedResponse.body).toEqual({ message: '認証に失敗しました' });
+  });
+});

--- a/__tests__/small/controller/api/LoginPostController.test.js
+++ b/__tests__/small/controller/api/LoginPostController.test.js
@@ -1,0 +1,97 @@
+const LoginPostController = require('../../../../src/controller/api/LoginPostController');
+const {
+  LoginSucceededResult,
+  LoginFailedResult,
+} = require('../../../../src/application/user/command/LoginService');
+
+describe('LoginPostController', () => {
+  let loginService;
+  let controller;
+
+  const createRes = () => {
+    const res = {
+      status: jest.fn(),
+      json: jest.fn(),
+      cookie: jest.fn(),
+    };
+    res.status.mockReturnValue(res);
+    return res;
+  };
+
+  const execute = async ({ body, session }) => {
+    const req = { body, session };
+    const res = createRes();
+
+    await controller.execute(req, res);
+
+    return { req, res };
+  };
+
+  beforeEach(() => {
+    loginService = {
+      execute: jest.fn().mockResolvedValue(new LoginSucceededResult({ sessionToken: 'token-1' })),
+    };
+    controller = new LoginPostController({ loginService });
+  });
+
+  it('ログイン成功時はcookie付きでcode=0を返す', async () => {
+    const session = { regenerate: jest.fn() };
+    const { res } = await execute({
+      body: { username: 'admin', password: 'secret' },
+      session,
+    });
+
+    expect(loginService.execute).toHaveBeenCalledTimes(1);
+    expect(loginService.execute.mock.calls[0][0]).toMatchObject({
+      username: 'admin',
+      password: 'secret',
+      session,
+    });
+    expect(res.cookie).toHaveBeenCalledWith('session_token', 'token-1', {
+      httpOnly: true,
+      path: '/',
+    });
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ code: 0 });
+  });
+
+  it('ログイン失敗時はcookieを発行せずcode=1を返す', async () => {
+    loginService.execute.mockResolvedValue(new LoginFailedResult());
+
+    const { res } = await execute({
+      body: { username: 'admin', password: 'wrong' },
+      session: { regenerate: jest.fn() },
+    });
+
+    expect(res.cookie).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ code: 1 });
+  });
+
+  it.each([
+    ['usernameが未設定', { password: 'secret' }, { regenerate: jest.fn() }],
+    ['usernameが空文字', { username: '', password: 'secret' }, { regenerate: jest.fn() }],
+    ['passwordが未設定', { username: 'admin' }, { regenerate: jest.fn() }],
+    ['passwordが空文字', { username: 'admin', password: '' }, { regenerate: jest.fn() }],
+    ['sessionが未設定', { username: 'admin', password: 'secret' }, undefined],
+  ])('%sの場合はcode=1を返す', async (_name, body, session) => {
+    const { res } = await execute({ body, session });
+
+    expect(loginService.execute).not.toHaveBeenCalled();
+    expect(res.cookie).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ code: 1 });
+  });
+
+  it('サービス例外時もcode=1を返す', async () => {
+    loginService.execute.mockRejectedValue(new Error('boom'));
+
+    const { res } = await execute({
+      body: { username: 'admin', password: 'secret' },
+      session: { regenerate: jest.fn() },
+    });
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ code: 1 });
+  });
+});

--- a/__tests__/small/controller/router/user/setRouterApiLogin.test.js
+++ b/__tests__/small/controller/router/user/setRouterApiLogin.test.js
@@ -1,0 +1,43 @@
+const setRouterApiLogin = require('../../../../../src/controller/router/user/setRouterApiLogin');
+
+describe('setRouterApiLogin', () => {
+  const createRes = () => {
+    const res = {
+      status: jest.fn(),
+      json: jest.fn(),
+      cookie: jest.fn(),
+    };
+    res.status.mockReturnValue(res);
+    return res;
+  };
+
+  it('POST /api/login にログインコントローラーを登録できる', async () => {
+    const router = { post: jest.fn() };
+    const loginService = {
+      execute: jest.fn().mockResolvedValue({ code: 0, sessionToken: 'token-1', constructor: { name: 'LoginSucceededResult' } }),
+    };
+
+    setRouterApiLogin({ router, loginService });
+
+    expect(router.post).toHaveBeenCalledTimes(1);
+    const [path, handler] = router.post.mock.calls[0];
+    expect(path).toBe('/api/login');
+    expect(typeof handler).toBe('function');
+
+    const req = {
+      body: { username: 'admin', password: 'secret' },
+      session: { regenerate: jest.fn() },
+    };
+    const res = createRes();
+
+    await handler(req, res);
+
+    expect(loginService.execute).toHaveBeenCalledTimes(1);
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('loginServiceが不正な場合は初期化時に例外となる', () => {
+    expect(() => setRouterApiLogin({ router: { post: jest.fn() }, loginService: {} }))
+      .toThrow('loginService.execute must be a function');
+  });
+});

--- a/src/app/createDependencies.js
+++ b/src/app/createDependencies.js
@@ -4,6 +4,7 @@ const path = require('path');
 const { Sequelize } = require('sequelize');
 
 const setRouterApiMediaPost = require('../controller/router/media/setRouterApiMediaPost');
+const setRouterApiLogin = require('../controller/router/user/setRouterApiLogin');
 const setRouterScreenEntryGet = require('../controller/router/screen/setRouterScreenEntryGet');
 const setRouterScreenDetailGet = require('../controller/router/screen/setRouterScreenDetailGet');
 const setRouterScreenEditGet = require('../controller/router/screen/setRouterScreenEditGet');
@@ -20,6 +21,8 @@ const SequelizeMediaQueryRepository = require('../infrastructure/SequelizeMediaQ
 const SequelizeUserRepository = require('../infrastructure/SequelizeUserRepository');
 const SequelizeUnitOfWork = require('../infrastructure/SequelizeUnitOfWork');
 const SessionStateAuthAdapter = require('../infrastructure/SessionStateAuthAdapter');
+const SessionStateRegistrar = require('../infrastructure/SessionStateRegistrar');
+const StaticLoginAuthenticator = require('../infrastructure/StaticLoginAuthenticator');
 const UUIDMediaIdValueGenerator = require('../infrastructure/UUIDMediaIdValueGenerator');
 const { SearchMediaService } = require('../application/media/query/SearchMediaService');
 const { GetMediaDetailService } = require('../application/media/query/GetMediaDetailService');
@@ -28,6 +31,7 @@ const { AddFavoriteService } = require('../application/user/command/AddFavoriteS
 const { RemoveFavoriteService } = require('../application/user/command/RemoveFavoriteService');
 const { AddQueueService } = require('../application/user/command/AddQueueService');
 const { RemoveQueueService } = require('../application/user/command/RemoveQueueService');
+const { LoginService } = require('../application/user/command/LoginService');
 const { hasDevelopmentSession } = require('./developmentSession');
 
 const ensureParentDirectory = targetPath => {
@@ -67,6 +71,17 @@ const createDependencies = (env = {}) => {
   const removeFavoriteService = new RemoveFavoriteService({ userRepository, unitOfWork });
   const addQueueService = new AddQueueService({ mediaRepository, userRepository, unitOfWork });
   const removeQueueService = new RemoveQueueService({ userRepository, unitOfWork });
+  const sessionStateRegistrar = new SessionStateRegistrar({ sessionStateStore });
+  const loginAuthenticator = new StaticLoginAuthenticator({
+    username: env.loginUsername || 'admin',
+    password: env.loginPassword || 'admin',
+    userId: env.loginUserId || 'admin',
+  });
+  const loginService = new LoginService({
+    loginAuthenticator,
+    sessionStateRegistrar,
+    sessionTtlMs: env.loginSessionTtlMs || 86_400_000,
+  });
 
   if (hasDevelopmentSession(env)) {
     sessionStateStore.save({
@@ -90,6 +105,9 @@ const createDependencies = (env = {}) => {
     addQueueService,
     removeQueueService,
     sessionStateStore,
+    sessionStateRegistrar,
+    loginAuthenticator,
+    loginService,
     authResolver: new SessionStateAuthAdapter({
       sessionStateStore,
     }),
@@ -99,6 +117,7 @@ const createDependencies = (env = {}) => {
     mediaIdValueGenerator: new UUIDMediaIdValueGenerator(),
     routeSetters: {
       setRouterApiMediaPost,
+      setRouterApiLogin,
       setRouterScreenEntryGet,
       setRouterScreenDetailGet,
       setRouterScreenEditGet,

--- a/src/app/setupMiddleware.js
+++ b/src/app/setupMiddleware.js
@@ -3,6 +3,42 @@ const express = require('express');
 
 const { shouldApplyDevelopmentSession } = require('./developmentSession');
 
+const parseCookieHeader = cookieHeader => {
+  if (typeof cookieHeader !== 'string' || cookieHeader.length === 0) {
+    return {};
+  }
+
+  return cookieHeader
+    .split(';')
+    .map(entry => entry.trim())
+    .filter(entry => entry.length > 0)
+    .reduce((cookies, entry) => {
+      const separatorIndex = entry.indexOf('=');
+      if (separatorIndex <= 0) {
+        return cookies;
+      }
+
+      const key = entry.slice(0, separatorIndex).trim();
+      const value = entry.slice(separatorIndex + 1).trim();
+      if (key.length === 0) {
+        return cookies;
+      }
+
+      cookies[key] = value;
+      return cookies;
+    }, {});
+};
+
+const attachSessionHelpers = req => {
+  req.session = req.session ?? {};
+  req.session.req = req;
+  req.session.regenerate = callback => {
+    req.session = {};
+    attachSessionHelpers(req);
+    callback(null);
+  };
+};
+
 const setupMiddleware = (app, { env = {}, dependencies: _dependencies } = {}) => {
   app.set('views', path.join(__dirname, '..', 'views'));
   app.set('view engine', 'ejs');
@@ -11,11 +47,14 @@ const setupMiddleware = (app, { env = {}, dependencies: _dependencies } = {}) =>
 
   app.use((req, _res, next) => {
     req.context = req.context ?? {};
-    req.session = req.session ?? {};
+    attachSessionHelpers(req);
 
     const sessionToken = req.header('x-session-token');
+    const cookies = parseCookieHeader(req.header('cookie'));
     if (typeof sessionToken === 'string' && sessionToken.length > 0) {
       req.session.session_token = sessionToken;
+    } else if (typeof cookies.session_token === 'string' && cookies.session_token.length > 0) {
+      req.session.session_token = cookies.session_token;
     } else if (shouldApplyDevelopmentSession({ env, requestPath: req.path })) {
       req.session.session_token = env.devSessionToken;
     }

--- a/src/app/setupRoutes.js
+++ b/src/app/setupRoutes.js
@@ -39,6 +39,11 @@ const setupRoutes = (app, { env: _env, dependencies } = {}) => {
     searchMediaService: dependencies.searchMediaService,
   });
 
+  dependencies.routeSetters.setRouterApiLogin({
+    router,
+    loginService: dependencies.loginService,
+  });
+
   dependencies.routeSetters.setRouterApiMediaPost({
     router,
     authResolver: dependencies.authResolver,

--- a/src/application/user/command/LoginService.js
+++ b/src/application/user/command/LoginService.js
@@ -1,0 +1,94 @@
+class Query {
+  constructor({ username, password, session } = {}) {
+    if (typeof username !== 'string' || username.length === 0) {
+      throw new Error('username must be a non-empty string');
+    }
+    if (typeof password !== 'string' || password.length === 0) {
+      throw new Error('password must be a non-empty string');
+    }
+    if (!session || typeof session !== 'object') {
+      throw new Error('session must be an object');
+    }
+
+    this.username = username;
+    this.password = password;
+    this.session = session;
+  }
+}
+
+class Result {
+  constructor({ code, sessionToken = null } = {}) {
+    this.code = code;
+    this.sessionToken = sessionToken;
+  }
+}
+
+class LoginSucceededResult extends Result {
+  constructor({ sessionToken }) {
+    super({ code: 0, sessionToken });
+  }
+}
+
+class LoginFailedResult extends Result {
+  constructor() {
+    super({ code: 1 });
+  }
+}
+
+class LoginService {
+  #loginAuthenticator;
+  #sessionStateRegistrar;
+  #sessionTtlMs;
+
+  constructor({ loginAuthenticator, sessionStateRegistrar, sessionTtlMs = 86_400_000 } = {}) {
+    if (!loginAuthenticator || typeof loginAuthenticator.execute !== 'function') {
+      throw new Error('loginAuthenticator.execute must be a function');
+    }
+    if (!sessionStateRegistrar || typeof sessionStateRegistrar.execute !== 'function') {
+      throw new Error('sessionStateRegistrar.execute must be a function');
+    }
+    if (!Number.isInteger(sessionTtlMs) || sessionTtlMs <= 0) {
+      throw new Error('sessionTtlMs must be a positive integer');
+    }
+
+    this.#loginAuthenticator = loginAuthenticator;
+    this.#sessionStateRegistrar = sessionStateRegistrar;
+    this.#sessionTtlMs = sessionTtlMs;
+  }
+
+  async execute(query) {
+    if (!(query instanceof Query)) {
+      throw new Error('query must be an instance of Query');
+    }
+
+    const userId = await this.#loginAuthenticator.execute({
+      username: query.username,
+      password: query.password,
+    });
+
+    if (!this.#isNonEmptyString(userId)) {
+      return new LoginFailedResult();
+    }
+
+    const sessionState = await this.#sessionStateRegistrar.execute({
+      session: query.session,
+      userId,
+      ttlMs: this.#sessionTtlMs,
+    });
+
+    return new LoginSucceededResult({
+      sessionToken: sessionState.sessionToken,
+    });
+  }
+
+  #isNonEmptyString(value) {
+    return typeof value === 'string' && value.length > 0;
+  }
+}
+
+module.exports = {
+  Query,
+  LoginSucceededResult,
+  LoginFailedResult,
+  LoginService,
+};

--- a/src/controller/api/LoginPostController.js
+++ b/src/controller/api/LoginPostController.js
@@ -1,0 +1,55 @@
+const {
+  Query: LoginQuery,
+  LoginSucceededResult,
+} = require('../../application/user/command/LoginService');
+
+class LoginPostController {
+  #loginService;
+
+  constructor({ loginService } = {}) {
+    if (!loginService || typeof loginService.execute !== 'function') {
+      throw new Error('loginService.execute must be a function');
+    }
+
+    this.#loginService = loginService;
+  }
+
+  async execute(req, res) {
+    try {
+      const username = req?.body?.username;
+      const password = req?.body?.password;
+      const session = req?.session;
+
+      if (!this.#isValidCredential(username) || !this.#isValidCredential(password) || !session) {
+        return this.#fail(res);
+      }
+
+      const result = await this.#loginService.execute(new LoginQuery({
+        username,
+        password,
+        session,
+      }));
+
+      if (result instanceof LoginSucceededResult) {
+        res.cookie('session_token', result.sessionToken, {
+          httpOnly: true,
+          path: '/',
+        });
+      }
+
+      return res.status(200).json({ code: result.code });
+    } catch (_error) {
+      return this.#fail(res);
+    }
+  }
+
+  #isValidCredential(value) {
+    return typeof value === 'string' && value.length > 0;
+  }
+
+  #fail(res) {
+    return res.status(200).json({ code: 1 });
+  }
+}
+
+module.exports = LoginPostController;

--- a/src/controller/router/user/setRouterApiLogin.js
+++ b/src/controller/router/user/setRouterApiLogin.js
@@ -1,0 +1,9 @@
+const LoginPostController = require('../../api/LoginPostController');
+
+const setRouterApiLogin = ({ router, loginService } = {}) => {
+  const controller = new LoginPostController({ loginService });
+
+  router.post('/api/login', controller.execute.bind(controller));
+};
+
+module.exports = setRouterApiLogin;

--- a/src/infrastructure/StaticLoginAuthenticator.js
+++ b/src/infrastructure/StaticLoginAuthenticator.js
@@ -1,0 +1,35 @@
+class StaticLoginAuthenticator {
+  #username;
+  #password;
+  #userId;
+
+  constructor({ username, password, userId } = {}) {
+    if (!this.#isNonEmptyString(username)) {
+      throw new Error('username must be a non-empty string');
+    }
+    if (!this.#isNonEmptyString(password)) {
+      throw new Error('password must be a non-empty string');
+    }
+    if (!this.#isNonEmptyString(userId)) {
+      throw new Error('userId must be a non-empty string');
+    }
+
+    this.#username = username;
+    this.#password = password;
+    this.#userId = userId;
+  }
+
+  async execute({ username, password } = {}) {
+    if (username === this.#username && password === this.#password) {
+      return this.#userId;
+    }
+
+    return null;
+  }
+
+  #isNonEmptyString(value) {
+    return typeof value === 'string' && value.length > 0;
+  }
+}
+
+module.exports = StaticLoginAuthenticator;

--- a/src/server.js
+++ b/src/server.js
@@ -18,6 +18,10 @@ const createEnv = source => ({
   devSessionUserId: source.DEV_SESSION_USER_ID || '',
   devSessionTtlMs: Number.parseInt(source.DEV_SESSION_TTL_MS, 10) || 0,
   devSessionPaths: parseSessionPaths(source.DEV_SESSION_PATHS),
+  loginUsername: source.LOGIN_USERNAME || 'admin',
+  loginPassword: source.LOGIN_PASSWORD || 'admin',
+  loginUserId: source.LOGIN_USER_ID || 'admin',
+  loginSessionTtlMs: Number.parseInt(source.LOGIN_SESSION_TTL_MS, 10) || 86_400_000,
 });
 
 const startServer = async () => {


### PR DESCRIPTION
### Motivation
- OpenAPI で定義されている `POST /api/login` が未実装で、ログイン画面から認証済み状態を確立できなかったため実装を追加しました。 
- 既存の `SessionStateRegistrar`／`SessionAuthMiddleware` を利用して、認証成功時に永続的なセッションを発行・利用できるようにする目的です。

### Description
- 新規にログイン用アプリケーションサービスを追加し、`src/application/user/command/LoginService.js` で資格情報検証→`SessionStateRegistrar` によるセッション発行を行うようにしました。 
- 静的な認証アダプタ `src/infrastructure/StaticLoginAuthenticator.js` を追加し、環境変数で指定できる固定の username/password → userId を返すようにしています。 
- コントローラー `src/controller/api/LoginPostController.js` とルーターセッター `src/controller/router/user/setRouterApiLogin.js` を追加し、`application/x-www-form-urlencoded` の `username`/`password` を受けて `{ code: 0 | 1 }` を返し、成功時に `session_token` Cookie を `HttpOnly` かつ `Path=/` でセットするようにしました。 
- ミドルウェア `src/app/setupMiddleware.js` を拡張して Cookie ヘッダから `session_token` を復元し、簡易な `session.regenerate` ヘルパーを追加して `SessionStateRegistrar` と連携できるようにしました。 
- 依存登録 `src/app/createDependencies.js` とルート設定 `src/app/setupRoutes.js`、起動環境 `src/server.js` を更新して login 関連の依存と routeSetter を組み込みました。 
- small/medium テストを追加し、コントローラー単体、ルーター登録、および Cookie を使った認証継続シナリオを確認するテスト群を追加しました（`__tests__/small/controller/api/LoginPostController.test.js`, `__tests__/small/controller/router/user/setRouterApiLogin.test.js`, `__tests__/medium/controller/router/user/setRouterApiLogin.test.js`）。

### Testing
- 追加したテストファイルはリポジトリに作成済みで `node --check` による構文チェックは全ファイルで成功しました。 
- 主要なログインフロー（`LoginService` と `SessionStateRegistrar` を組み合わせたシナリオ）は手動 Node スクリプトで実行確認し、期待どおりセッション発行と `SessionAuthMiddleware` による認証継続が確認できました（出力: `manual-login-flow: ok`）。 
- 既存のテスト実行（`jest`）は環境内で npm レジストリから `jest` を取得できず実行できなかったため自動実行は失敗しましたが、ローカル環境では追加した small/medium テストを実行いただけます。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c095973a78832ba815711f16805333)