### PR TITLE
feat: 認証付きのPOST /api/logoutを追加する

### DIFF
--- a/__tests__/medium/controller/router/user/setRouterApiLogout.test.js
+++ b/__tests__/medium/controller/router/user/setRouterApiLogout.test.js
@@ -1,0 +1,109 @@
+const express = require('express');
+const request = require('supertest');
+
+const setRouterApiLogin = require('../../../../../src/controller/router/user/setRouterApiLogin');
+const setRouterApiLogout = require('../../../../../src/controller/router/user/setRouterApiLogout');
+const SessionAuthMiddleware = require('../../../../../src/controller/middleware/SessionAuthMiddleware');
+const SessionStateRegistrar = require('../../../../../src/infrastructure/SessionStateRegistrar');
+const SessionStateAuthAdapter = require('../../../../../src/infrastructure/SessionStateAuthAdapter');
+const InMemorySessionStateStore = require('../../../../../src/infrastructure/InMemorySessionStateStore');
+const SessionTerminator = require('../../../../../src/infrastructure/SessionTerminator');
+const StaticLoginAuthenticator = require('../../../../../src/infrastructure/StaticLoginAuthenticator');
+const { LoginService } = require('../../../../../src/application/user/command/LoginService');
+const { LogoutService } = require('../../../../../src/application/user/command/LogoutService');
+const setupMiddleware = require('../../../../../src/app/setupMiddleware');
+
+describe('setRouterApiLogout (middle)', () => {
+  const createApp = ({ sessionTerminator } = {}) => {
+    const app = express();
+    const router = express.Router();
+    const sessionStateStore = new InMemorySessionStateStore();
+    const authResolver = new SessionStateAuthAdapter({ sessionStateStore });
+    const auth = new SessionAuthMiddleware(authResolver);
+
+    setupMiddleware(app, {
+      env: {},
+      dependencies: {},
+    });
+
+    setRouterApiLogin({
+      router,
+      loginService: new LoginService({
+        loginAuthenticator: new StaticLoginAuthenticator({
+          username: 'admin',
+          password: 'secret',
+          userId: 'user-001',
+        }),
+        sessionStateRegistrar: new SessionStateRegistrar({ sessionStateStore }),
+        sessionTtlMs: 60_000,
+      }),
+    });
+
+    setRouterApiLogout({
+      router,
+      authResolver,
+      logoutService: new LogoutService({
+        sessionTerminator: sessionTerminator || new SessionTerminator({ sessionStateStore }),
+      }),
+    });
+
+    router.get('/api/protected', auth.execute.bind(auth), (req, res) => {
+      res.status(200).json({ userId: req.context.userId });
+    });
+
+    app.use(router);
+    return app;
+  };
+
+  test('認証済みなら POST /api/logout でcode=0を返し、後続リクエストは401になる', async () => {
+    const app = createApp();
+
+    const loginResponse = await request(app)
+      .post('/api/login')
+      .type('form')
+      .send({ username: 'admin', password: 'secret' });
+
+    const logoutResponse = await request(app)
+      .post('/api/logout')
+      .set('Cookie', loginResponse.headers['set-cookie']);
+
+    expect(logoutResponse.status).toBe(200);
+    expect(logoutResponse.body).toEqual({ code: 0 });
+
+    const protectedResponse = await request(app)
+      .get('/api/protected')
+      .set('Cookie', loginResponse.headers['set-cookie']);
+
+    expect(protectedResponse.status).toBe(401);
+    expect(protectedResponse.body).toEqual({ message: '認証に失敗しました' });
+  });
+
+  test('未認証で POST /api/logout を呼ぶと既存仕様どおり401 JSONを返す', async () => {
+    const app = createApp();
+
+    const response = await request(app)
+      .post('/api/logout');
+
+    expect(response.status).toBe(401);
+    expect(response.body).toEqual({ message: '認証に失敗しました' });
+  });
+
+  test('セッション破棄失敗時は POST /api/logout がcode=1を返す', async () => {
+    const sessionTerminator = {
+      execute: jest.fn().mockResolvedValue(false),
+    };
+    const app = createApp({ sessionTerminator });
+
+    const loginResponse = await request(app)
+      .post('/api/login')
+      .type('form')
+      .send({ username: 'admin', password: 'secret' });
+
+    const logoutResponse = await request(app)
+      .post('/api/logout')
+      .set('Cookie', loginResponse.headers['set-cookie']);
+
+    expect(logoutResponse.status).toBe(200);
+    expect(logoutResponse.body).toEqual({ code: 1 });
+  });
+});

--- a/__tests__/small/application/user/command/LogoutService.test.js
+++ b/__tests__/small/application/user/command/LogoutService.test.js
@@ -1,0 +1,44 @@
+const {
+  Query,
+  LogoutService,
+  LogoutSucceededResult,
+  LogoutFailedResult,
+} = require('../../../../../src/application/user/command/LogoutService');
+
+describe('LogoutService', () => {
+  test('sessionTerminator 成功時は成功結果を返す', async () => {
+    const sessionTerminator = {
+      execute: jest.fn().mockResolvedValue(true),
+    };
+    const service = new LogoutService({ sessionTerminator });
+    const query = new Query({ session: { session_token: 'token-1' } });
+
+    const result = await service.execute(query);
+
+    expect(sessionTerminator.execute).toHaveBeenCalledWith({
+      session: query.session,
+    });
+    expect(result).toBeInstanceOf(LogoutSucceededResult);
+    expect(result.code).toBe(0);
+  });
+
+  test('sessionTerminator 失敗時は失敗結果を返す', async () => {
+    const service = new LogoutService({
+      sessionTerminator: {
+        execute: jest.fn().mockResolvedValue(false),
+      },
+    });
+
+    await expect(service.execute(new Query({ session: {} }))).resolves.toBeInstanceOf(LogoutFailedResult);
+  });
+
+  test('Query 以外は例外となる', async () => {
+    const service = new LogoutService({
+      sessionTerminator: {
+        execute: jest.fn(),
+      },
+    });
+
+    await expect(service.execute({ session: {} })).rejects.toThrow('query must be an instance of Query');
+  });
+});

--- a/__tests__/small/controller/api/LogoutPostController.test.js
+++ b/__tests__/small/controller/api/LogoutPostController.test.js
@@ -1,0 +1,71 @@
+const LogoutPostController = require('../../../../src/controller/api/LogoutPostController');
+const {
+  LogoutSucceededResult,
+  LogoutFailedResult,
+} = require('../../../../src/application/user/command/LogoutService');
+
+describe('LogoutPostController', () => {
+  let logoutService;
+  let controller;
+
+  const createRes = () => {
+    const res = {
+      status: jest.fn(),
+      json: jest.fn(),
+    };
+    res.status.mockReturnValue(res);
+    return res;
+  };
+
+  const execute = async ({ session }) => {
+    const req = { session };
+    const res = createRes();
+
+    await controller.execute(req, res);
+
+    return { req, res };
+  };
+
+  beforeEach(() => {
+    logoutService = {
+      execute: jest.fn().mockResolvedValue(new LogoutSucceededResult()),
+    };
+    controller = new LogoutPostController({ logoutService });
+  });
+
+  it('ログアウト成功時はcode=0を返す', async () => {
+    const session = { session_token: 'token-1' };
+    const { res } = await execute({ session });
+
+    expect(logoutService.execute).toHaveBeenCalledTimes(1);
+    expect(logoutService.execute.mock.calls[0][0]).toMatchObject({ session });
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ code: 0 });
+  });
+
+  it('ログアウト失敗時はcode=1を返す', async () => {
+    logoutService.execute.mockResolvedValue(new LogoutFailedResult());
+
+    const { res } = await execute({ session: { session_token: 'token-1' } });
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ code: 1 });
+  });
+
+  it('sessionが未設定の場合はcode=1を返す', async () => {
+    const { res } = await execute({ session: undefined });
+
+    expect(logoutService.execute).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ code: 1 });
+  });
+
+  it('サービス例外時もcode=1を返す', async () => {
+    logoutService.execute.mockRejectedValue(new Error('boom'));
+
+    const { res } = await execute({ session: { session_token: 'token-1' } });
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ code: 1 });
+  });
+});

--- a/__tests__/small/controller/router/user/setRouterApiLogout.test.js
+++ b/__tests__/small/controller/router/user/setRouterApiLogout.test.js
@@ -1,0 +1,48 @@
+const setRouterApiLogout = require('../../../../../src/controller/router/user/setRouterApiLogout');
+
+describe('setRouterApiLogout', () => {
+  const createRes = () => {
+    const res = {
+      status: jest.fn(),
+      json: jest.fn(),
+    };
+    res.status.mockReturnValue(res);
+    return res;
+  };
+
+  it('POST /api/logout に認証付きログアウトコントローラーを登録できる', async () => {
+    const router = { post: jest.fn() };
+    const authResolver = { execute: jest.fn().mockResolvedValue('user-1') };
+    const logoutService = { execute: jest.fn().mockResolvedValue({ code: 0 }) };
+
+    setRouterApiLogout({ router, authResolver, logoutService });
+
+    expect(router.post).toHaveBeenCalledTimes(1);
+    const [path, middleware, handler] = router.post.mock.calls[0];
+    expect(path).toBe('/api/logout');
+    expect(typeof middleware).toBe('function');
+    expect(typeof handler).toBe('function');
+
+    const req = {
+      session: { session_token: 'token-1' },
+      context: {},
+    };
+    const res = createRes();
+    const next = jest.fn();
+
+    await middleware(req, res, next);
+    expect(next).toHaveBeenCalledTimes(1);
+
+    await handler(req, res);
+    expect(logoutService.execute).toHaveBeenCalledTimes(1);
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('logoutServiceが不正な場合は初期化時に例外となる', () => {
+    expect(() => setRouterApiLogout({
+      router: { post: jest.fn() },
+      authResolver: { execute: jest.fn() },
+      logoutService: {},
+    })).toThrow('logoutService.execute must be a function');
+  });
+});

--- a/__tests__/small/infrastructure/SessionTerminator.test.js
+++ b/__tests__/small/infrastructure/SessionTerminator.test.js
@@ -1,0 +1,46 @@
+const SessionTerminator = require('../../../src/infrastructure/SessionTerminator');
+
+describe('SessionTerminator', () => {
+  test('session_token を無効化して session.destroy を呼ぶ', async () => {
+    const sessionStateStore = {
+      delete: jest.fn().mockReturnValue(true),
+    };
+    const terminator = new SessionTerminator({ sessionStateStore });
+    const session = {
+      session_token: 'token-1',
+      destroy: jest.fn(callback => callback(null)),
+    };
+
+    await expect(terminator.execute({ session })).resolves.toBe(true);
+    expect(sessionStateStore.delete).toHaveBeenCalledWith('token-1');
+    expect(session.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  test('ストア削除に失敗した場合は false を返して session.destroy を呼ばない', async () => {
+    const sessionStateStore = {
+      delete: jest.fn().mockReturnValue(false),
+    };
+    const terminator = new SessionTerminator({ sessionStateStore });
+    const session = {
+      session_token: 'token-1',
+      destroy: jest.fn(),
+    };
+
+    await expect(terminator.execute({ session })).resolves.toBe(false);
+    expect(session.destroy).not.toHaveBeenCalled();
+  });
+
+  test('session.destroy が失敗した場合は reject する', async () => {
+    const terminator = new SessionTerminator({
+      sessionStateStore: {
+        delete: jest.fn().mockReturnValue(true),
+      },
+    });
+    const session = {
+      session_token: 'token-1',
+      destroy: jest.fn(callback => callback(new Error('destroy failed'))),
+    };
+
+    await expect(terminator.execute({ session })).rejects.toThrow('destroy failed');
+  });
+});

--- a/src/app/createDependencies.js
+++ b/src/app/createDependencies.js
@@ -5,6 +5,7 @@ const { Sequelize } = require('sequelize');
 
 const setRouterApiMediaPost = require('../controller/router/media/setRouterApiMediaPost');
 const setRouterApiLogin = require('../controller/router/user/setRouterApiLogin');
+const setRouterApiLogout = require('../controller/router/user/setRouterApiLogout');
 const setRouterScreenEntryGet = require('../controller/router/screen/setRouterScreenEntryGet');
 const setRouterScreenDetailGet = require('../controller/router/screen/setRouterScreenDetailGet');
 const setRouterScreenEditGet = require('../controller/router/screen/setRouterScreenEditGet');
@@ -22,6 +23,7 @@ const SequelizeUserRepository = require('../infrastructure/SequelizeUserReposito
 const SequelizeUnitOfWork = require('../infrastructure/SequelizeUnitOfWork');
 const SessionStateAuthAdapter = require('../infrastructure/SessionStateAuthAdapter');
 const SessionStateRegistrar = require('../infrastructure/SessionStateRegistrar');
+const SessionTerminator = require('../infrastructure/SessionTerminator');
 const StaticLoginAuthenticator = require('../infrastructure/StaticLoginAuthenticator');
 const UUIDMediaIdValueGenerator = require('../infrastructure/UUIDMediaIdValueGenerator');
 const { SearchMediaService } = require('../application/media/query/SearchMediaService');
@@ -32,6 +34,7 @@ const { RemoveFavoriteService } = require('../application/user/command/RemoveFav
 const { AddQueueService } = require('../application/user/command/AddQueueService');
 const { RemoveQueueService } = require('../application/user/command/RemoveQueueService');
 const { LoginService } = require('../application/user/command/LoginService');
+const { LogoutService } = require('../application/user/command/LogoutService');
 const { hasDevelopmentSession } = require('./developmentSession');
 
 const ensureParentDirectory = targetPath => {
@@ -72,6 +75,7 @@ const createDependencies = (env = {}) => {
   const addQueueService = new AddQueueService({ mediaRepository, userRepository, unitOfWork });
   const removeQueueService = new RemoveQueueService({ userRepository, unitOfWork });
   const sessionStateRegistrar = new SessionStateRegistrar({ sessionStateStore });
+  const sessionTerminator = new SessionTerminator({ sessionStateStore });
   const loginAuthenticator = new StaticLoginAuthenticator({
     username: env.loginUsername || 'admin',
     password: env.loginPassword || 'admin',
@@ -81,6 +85,9 @@ const createDependencies = (env = {}) => {
     loginAuthenticator,
     sessionStateRegistrar,
     sessionTtlMs: env.loginSessionTtlMs || 86_400_000,
+  });
+  const logoutService = new LogoutService({
+    sessionTerminator,
   });
 
   if (hasDevelopmentSession(env)) {
@@ -106,8 +113,10 @@ const createDependencies = (env = {}) => {
     removeQueueService,
     sessionStateStore,
     sessionStateRegistrar,
+    sessionTerminator,
     loginAuthenticator,
     loginService,
+    logoutService,
     authResolver: new SessionStateAuthAdapter({
       sessionStateStore,
     }),
@@ -118,6 +127,7 @@ const createDependencies = (env = {}) => {
     routeSetters: {
       setRouterApiMediaPost,
       setRouterApiLogin,
+      setRouterApiLogout,
       setRouterScreenEntryGet,
       setRouterScreenDetailGet,
       setRouterScreenEditGet,

--- a/src/app/setupMiddleware.js
+++ b/src/app/setupMiddleware.js
@@ -37,6 +37,11 @@ const attachSessionHelpers = req => {
     attachSessionHelpers(req);
     callback(null);
   };
+  req.session.destroy = callback => {
+    req.session = {};
+    attachSessionHelpers(req);
+    callback(null);
+  };
 };
 
 const setupMiddleware = (app, { env = {}, dependencies: _dependencies } = {}) => {

--- a/src/app/setupRoutes.js
+++ b/src/app/setupRoutes.js
@@ -43,6 +43,11 @@ const setupRoutes = (app, { env: _env, dependencies } = {}) => {
     router,
     loginService: dependencies.loginService,
   });
+  dependencies.routeSetters.setRouterApiLogout({
+    router,
+    authResolver: dependencies.authResolver,
+    logoutService: dependencies.logoutService,
+  });
 
   dependencies.routeSetters.setRouterApiMediaPost({
     router,

--- a/src/application/user/command/LogoutService.js
+++ b/src/application/user/command/LogoutService.js
@@ -1,0 +1,56 @@
+class Query {
+  constructor({ session } = {}) {
+    if (!session || typeof session !== 'object') {
+      throw new Error('session must be an object');
+    }
+
+    this.session = session;
+  }
+}
+
+class LogoutSucceededResult {
+  constructor() {
+    this.code = 0;
+  }
+}
+
+class LogoutFailedResult {
+  constructor() {
+    this.code = 1;
+  }
+}
+
+class LogoutService {
+  #sessionTerminator;
+
+  constructor({ sessionTerminator } = {}) {
+    if (!sessionTerminator || typeof sessionTerminator.execute !== 'function') {
+      throw new Error('sessionTerminator.execute must be a function');
+    }
+
+    this.#sessionTerminator = sessionTerminator;
+  }
+
+  async execute(query) {
+    if (!(query instanceof Query)) {
+      throw new Error('query must be an instance of Query');
+    }
+
+    const terminated = await this.#sessionTerminator.execute({
+      session: query.session,
+    });
+
+    if (!terminated) {
+      return new LogoutFailedResult();
+    }
+
+    return new LogoutSucceededResult();
+  }
+}
+
+module.exports = {
+  Query,
+  LogoutSucceededResult,
+  LogoutFailedResult,
+  LogoutService,
+};

--- a/src/controller/api/LogoutPostController.js
+++ b/src/controller/api/LogoutPostController.js
@@ -1,0 +1,35 @@
+const {
+  Query: LogoutQuery,
+} = require('../../application/user/command/LogoutService');
+
+class LogoutPostController {
+  #logoutService;
+
+  constructor({ logoutService } = {}) {
+    if (!logoutService || typeof logoutService.execute !== 'function') {
+      throw new Error('logoutService.execute must be a function');
+    }
+
+    this.#logoutService = logoutService;
+  }
+
+  async execute(req, res) {
+    try {
+      const session = req?.session;
+      if (!session) {
+        return this.#fail(res);
+      }
+
+      const result = await this.#logoutService.execute(new LogoutQuery({ session }));
+      return res.status(200).json({ code: result.code });
+    } catch (_error) {
+      return this.#fail(res);
+    }
+  }
+
+  #fail(res) {
+    return res.status(200).json({ code: 1 });
+  }
+}
+
+module.exports = LogoutPostController;

--- a/src/controller/router/user/setRouterApiLogout.js
+++ b/src/controller/router/user/setRouterApiLogout.js
@@ -1,0 +1,11 @@
+const SessionAuthMiddleware = require('../../middleware/SessionAuthMiddleware');
+const LogoutPostController = require('../../api/LogoutPostController');
+
+const setRouterApiLogout = ({ router, authResolver, logoutService } = {}) => {
+  const auth = new SessionAuthMiddleware(authResolver);
+  const controller = new LogoutPostController({ logoutService });
+
+  router.post('/api/logout', auth.execute.bind(auth), controller.execute.bind(controller));
+};
+
+module.exports = setRouterApiLogout;

--- a/src/infrastructure/SessionTerminator.js
+++ b/src/infrastructure/SessionTerminator.js
@@ -1,0 +1,54 @@
+class SessionTerminator {
+  #sessionStateStore;
+
+  constructor({ sessionStateStore } = {}) {
+    if (!sessionStateStore || typeof sessionStateStore.delete !== 'function') {
+      throw new Error('sessionStateStore.delete must be a function');
+    }
+
+    this.#sessionStateStore = sessionStateStore;
+  }
+
+  async execute({ session } = {}) {
+    if (!session || typeof session !== 'object') {
+      throw new Error('session must be an object');
+    }
+
+    const sessionToken = session.session_token;
+    if (!this.#isNonEmptyString(sessionToken)) {
+      return false;
+    }
+
+    const deleted = this.#sessionStateStore.delete(sessionToken);
+    if (!deleted) {
+      return false;
+    }
+
+    await this.#destroySession(session);
+    return true;
+  }
+
+  #destroySession(session) {
+    return new Promise((resolve, reject) => {
+      if (typeof session.destroy !== 'function') {
+        reject(new Error('session.destroy must be a function'));
+        return;
+      }
+
+      session.destroy(error => {
+        if (error) {
+          reject(error);
+          return;
+        }
+
+        resolve();
+      });
+    });
+  }
+
+  #isNonEmptyString(value) {
+    return typeof value === 'string' && value.length > 0;
+  }
+}
+
+module.exports = SessionTerminator;


### PR DESCRIPTION
### Motivation
- OpenAPI の `/api/logout` 仕様に合わせて、認証必須のログアウト処理を実装してセッション無効化を行えるようにするため。 

### Description
- 新規に `LogoutPostController` (`src/controller/api/LogoutPostController.js`) を追加し、正常時 `{ code: 0 }`、失敗時 `{ code: 1 }` を返すように実装しました。 
- セッション無効化責務を持つ `LogoutService` (`src/application/user/command/LogoutService.js`) と `SessionTerminator` (`src/infrastructure/SessionTerminator.js`) を追加し、`session_token` の削除と `req.session.destroy()` を行う設計にしました。 
- ルーター設定 `setRouterApiLogout` (`src/controller/router/user/setRouterApiLogout.js`) を追加し、`router.post('/api/logout', auth.execute.bind(auth), controller.execute.bind(controller))` を登録するようにしました。 
- 依存注入のために `src/app/createDependencies.js` とルート登録のために `src/app/setupRoutes.js` を更新し、テスト実行のために `src/app/setupMiddleware.js` に擬似セッションの `destroy` ヘルパーを追加しました。 

### Testing
- 各実装ファイルの構文チェックとして `node -c` によるファイル確認を実行し、`src/*` と追加したテストファイルは構文エラーなしで通過しました。 
- small/medium の単体・結合テストを追加（`__tests__/small/...` と `__tests__/medium/...`）しており、ロジック単位のノード実行によるスモーク確認が成功しました（ログアウト周りのユニットスモークで `logout unit smoke ok` を確認）。 
- フルテスト実行（`jest`）はこの実行環境での依存解決（npm registry へのアクセスやローカル `jest`/`supertest` の配置）により実行できませんでしたので、CI 環境やローカルで `npm install` 後に `npm test` をお願いします。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0985f5008832ba0d93e08ee0f8bf0)