### PR TITLE
feat: メディア更新APIをAPI層へ接続する

### DIFF
--- a/__tests__/medium/controller/middleware/ContentSaveMiddleware.test.js
+++ b/__tests__/medium/controller/middleware/ContentSaveMiddleware.test.js
@@ -37,7 +37,7 @@ describe('ContentSaveMiddleware (middle)', () => {
     const response = await request(app)
       .post('/api/media')
       .field('contents[0][position]', '2')
-      .field('contents[0][url]', 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb')
+      .field('contents[0][id]', 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb')
       .field('contents[1][position]', '1')
       .attach('contents[1][file]', Buffer.from('a'), 'same-name.jpg');
 
@@ -68,7 +68,7 @@ describe('ContentSaveMiddleware (middle)', () => {
       .field('contents[0][position]', '1')
       .attach('contents[0][file]', Buffer.from('a'), 'same-name.jpg')
       .field('contents[1][position]', '1')
-      .field('contents[1][url]', 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb');
+      .field('contents[1][id]', 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb');
 
     expect(response.status).toBe(200);
     expect(response.body).toEqual({ code: 1 });

--- a/__tests__/medium/controller/router/media/setRouterApiMediaPatch.test.js
+++ b/__tests__/medium/controller/router/media/setRouterApiMediaPatch.test.js
@@ -1,0 +1,153 @@
+const express = require('express');
+const request = require('supertest');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { Sequelize } = require('sequelize');
+
+const setRouterApiMediaPatch = require('../../../../../src/controller/router/media/setRouterApiMediaPatch');
+const SessionStateAuthAdapter = require('../../../../../src/infrastructure/SessionStateAuthAdapter');
+const SequelizeMediaRepository = require('../../../../../src/infrastructure/SequelizeMediaRepository');
+const SequelizeUnitOfWork = require('../../../../../src/infrastructure/SequelizeUnitOfWork');
+const MulterDiskStorageContentUploadAdapter = require('../../../../../src/infrastructure/MulterDiskStorageContentUploadAdapter');
+const { UpdateMediaService } = require('../../../../../src/application/media/command/UpdateMediaService');
+const Media = require('../../../../../src/domain/media/media');
+const MediaId = require('../../../../../src/domain/media/mediaId');
+const MediaTitle = require('../../../../../src/domain/media/mediaTitle');
+const ContentId = require('../../../../../src/domain/media/contentId');
+const Tag = require('../../../../../src/domain/media/tag');
+const Category = require('../../../../../src/domain/media/category');
+const Label = require('../../../../../src/domain/media/label');
+
+class InMemorySessionStateStore {
+  constructor(entries = []) {
+    this.tokenToUserId = new Map(entries);
+  }
+
+  findUserIdBySessionToken(sessionToken) {
+    return this.tokenToUserId.get(sessionToken) ?? null;
+  }
+}
+
+describe('setRouterApiMediaPatch (middle)', () => {
+  let sequelize;
+  let unitOfWork;
+  let mediaRepository;
+  let rootDirectory;
+  const mediaId = '1234567890abcdef1234567890abcdef';
+  const existingContent1 = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+  const existingContent2 = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+  beforeEach(async () => {
+    rootDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'router-media-patch-'));
+    sequelize = new Sequelize('sqlite::memory:', { logging: false });
+    unitOfWork = new SequelizeUnitOfWork({ sequelize });
+    mediaRepository = new SequelizeMediaRepository({
+      sequelize,
+      unitOfWorkContext: unitOfWork,
+    });
+    await mediaRepository.sync();
+
+    await unitOfWork.run(async () => {
+      await mediaRepository.save(new Media(
+        new MediaId(mediaId),
+        new MediaTitle('before title'),
+        [new ContentId(existingContent1), new ContentId(existingContent2)],
+        [new Tag(new Category('作者'), new Label('旧作者'))],
+        [new Category('作者')],
+      ));
+    });
+  });
+
+  afterEach(async () => {
+    fs.rmSync(rootDirectory, { recursive: true, force: true });
+    await sequelize.close();
+  });
+
+  const createApp = () => {
+    const app = express();
+    const router = express.Router();
+
+    app.use((req, _res, next) => {
+      req.session = { session_token: req.header('x-session-token') };
+      req.context = {};
+      next();
+    });
+
+    setRouterApiMediaPatch({
+      router,
+      authResolver: new SessionStateAuthAdapter({
+        sessionStateStore: new InMemorySessionStateStore([['valid-token', 'user-001']]),
+      }),
+      saveAdapter: new MulterDiskStorageContentUploadAdapter({ rootDirectory }),
+      updateMediaService: new UpdateMediaService({ mediaRepository, unitOfWork }),
+    });
+
+    app.use(router);
+    return app;
+  };
+
+  test('PATCH /api/media/:mediaId でタイトル変更・並び替え・新規画像追加まで完了する', async () => {
+    const app = createApp();
+
+    const response = await request(app)
+      .patch(`/api/media/${mediaId}`)
+      .set('x-session-token', 'valid-token')
+      .field('title', 'after title')
+      .field('tags[0][category]', '作者')
+      .field('tags[0][label]', '新作者')
+      .field('tags[1][category]', '雑誌')
+      .field('tags[1][label]', 'ジャンプ')
+      .field('contents[0][position]', '1')
+      .attach('contents[0][file]', Buffer.from('new-image'), 'new.jpg')
+      .field('contents[1][position]', '2')
+      .field('contents[1][id]', existingContent2)
+      .field('contents[2][position]', '3')
+      .field('contents[2][id]', existingContent1);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ code: 0 });
+
+    const media = await mediaRepository.findByMediaId(new MediaId(mediaId));
+    expect(media.getTitle().getTitle()).toBe('after title');
+    expect(media.getContents().map(content => content.getId())).toEqual([
+      expect.stringMatching(/^[0-9a-f]{32}$/),
+      existingContent2,
+      existingContent1,
+    ]);
+    expect(media.getTags().map(tag => ({
+      category: tag.getCategory().getValue(),
+      label: tag.getLabel().getLabel(),
+    }))).toEqual(expect.arrayContaining([
+      { category: '作者', label: '新作者' },
+      { category: '雑誌', label: 'ジャンプ' },
+    ]));
+    expect(media.getPriorityCategories().map(category => category.getValue())).toEqual([
+      '作者',
+      '雑誌',
+    ]);
+  });
+
+  test('入力不正な場合は code=1 を返して既存メディアを変更しない', async () => {
+    const app = createApp();
+
+    const response = await request(app)
+      .patch(`/api/media/${mediaId}`)
+      .set('x-session-token', 'valid-token')
+      .field('title', '')
+      .field('tags[0][category]', '作者')
+      .field('tags[0][label]', '新作者')
+      .field('contents[0][position]', '1')
+      .field('contents[0][id]', existingContent1);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ code: 1 });
+
+    const media = await mediaRepository.findByMediaId(new MediaId(mediaId));
+    expect(media.getTitle().getTitle()).toBe('before title');
+    expect(media.getContents().map(content => content.getId())).toEqual([
+      existingContent1,
+      existingContent2,
+    ]);
+  });
+});

--- a/__tests__/small/controller/api/MediaPatchController.test.js
+++ b/__tests__/small/controller/api/MediaPatchController.test.js
@@ -1,0 +1,120 @@
+const MediaPatchController = require('../../../../src/controller/api/MediaPatchController');
+const {
+  UpdateMediaServiceInput,
+} = require('../../../../src/application/media/command/UpdateMediaService');
+
+describe('MediaPatchController', () => {
+  let updateMediaService;
+  let controller;
+
+  const createRes = () => {
+    const res = {
+      status: jest.fn(),
+      json: jest.fn(),
+    };
+    res.status.mockReturnValue(res);
+    return res;
+  };
+
+  const execute = async ({ params, body, contentIds }) => {
+    const req = {
+      params,
+      body,
+      context: {
+        contentIds,
+      },
+    };
+    const res = createRes();
+
+    await controller.execute(req, res);
+
+    return { res };
+  };
+
+  beforeEach(() => {
+    updateMediaService = {
+      execute: jest.fn().mockResolvedValue(undefined),
+    };
+
+    controller = new MediaPatchController({ updateMediaService });
+  });
+
+  it('mediaId・title・tags・contentIdsを使ってメディア更新に成功する', async () => {
+    const { res } = await execute({
+      params: { mediaId: 'm1' },
+      body: {
+        title: 'updated',
+        tags: [{ category: '作者', label: 'A' }],
+      },
+      contentIds: ['c2', 'c1'],
+    });
+
+    expect(updateMediaService.execute).toHaveBeenCalledTimes(1);
+    const input = updateMediaService.execute.mock.calls[0][0];
+    expect(input).toBeInstanceOf(UpdateMediaServiceInput);
+    expect(input).toMatchObject({
+      id: 'm1',
+      title: 'updated',
+      contents: ['c2', 'c1'],
+      tags: [{ category: '作者', label: 'A' }],
+      priorityCategories: ['作者'],
+    });
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ code: 0 });
+  });
+
+  it('priorityCategoriesはtags.categoryの出現順で重複なく生成される', async () => {
+    await execute({
+      params: { mediaId: 'm1' },
+      body: {
+        title: 'updated',
+        tags: [
+          { category: '作者', label: 'A' },
+          { category: 'ジャンル', label: 'バトル' },
+          { category: '作者', label: 'B' },
+        ],
+      },
+      contentIds: ['c1'],
+    });
+
+    const input = updateMediaService.execute.mock.calls[0][0];
+    expect(input.priorityCategories).toEqual(['作者', 'ジャンル']);
+  });
+
+  it('UpdateMediaServiceが失敗した場合はcode=1を返す', async () => {
+    updateMediaService.execute.mockRejectedValue(new Error('fail'));
+
+    const { res } = await execute({
+      params: { mediaId: 'm1' },
+      body: {
+        title: 'updated',
+        tags: [],
+      },
+      contentIds: ['c1'],
+    });
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ code: 1 });
+  });
+
+  it.each([
+    ['mediaIdが未設定', {}, { title: 'title', tags: [] }, ['c1']],
+    ['mediaIdが空文字', { mediaId: '' }, { title: 'title', tags: [] }, ['c1']],
+    ['titleが空文字', { mediaId: 'm1' }, { title: '', tags: [] }, ['c1']],
+    ['titleがstring以外', { mediaId: 'm1' }, { title: 1, tags: [] }, ['c1']],
+    ['tagsが未設定', { mediaId: 'm1' }, { title: 'title' }, ['c1']],
+    ['tagsが配列以外', { mediaId: 'm1' }, { title: 'title', tags: {} }, ['c1']],
+    ['tags配列要素がnull', { mediaId: 'm1' }, { title: 'title', tags: [null] }, ['c1']],
+    ['tagsのcategoryが空文字', { mediaId: 'm1' }, { title: 'title', tags: [{ category: '', label: 'A' }] }, ['c1']],
+    ['tagsのlabelが空文字', { mediaId: 'm1' }, { title: 'title', tags: [{ category: 'A', label: '' }] }, ['c1']],
+    ['contentIdsが未設定', { mediaId: 'm1' }, { title: 'title', tags: [] }, undefined],
+    ['contentIdsが空配列', { mediaId: 'm1' }, { title: 'title', tags: [] }, []],
+    ['contentIdsに重複がある', { mediaId: 'm1' }, { title: 'title', tags: [] }, ['c1', 'c1']],
+  ])('%sの場合は更新失敗を返す', async (_name, params, body, contentIds) => {
+    const { res } = await execute({ params, body, contentIds });
+
+    expect(updateMediaService.execute).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ code: 1 });
+  });
+});

--- a/__tests__/small/controller/middleware/ContentSaveMiddleware.test.js
+++ b/__tests__/small/controller/middleware/ContentSaveMiddleware.test.js
@@ -50,6 +50,19 @@ describe('ContentSaveMiddleware', () => {
     expect(res.status).not.toHaveBeenCalled();
   });
 
+  it('contentIdsが既存IDと新規ファイルの混在でも後続へ委譲する', async () => {
+    const req = {
+      context: {
+        contentIds: ['c1', '0123456789abcdef0123456789abcdef'],
+      },
+    };
+
+    const { next, res } = await execute({ req });
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
   it.each([
     ['contextが未設定', {}],
     ['contentIdsが未設定', { context: {} }],

--- a/__tests__/small/controller/router/media/setRouterApiMediaPatch.test.js
+++ b/__tests__/small/controller/router/media/setRouterApiMediaPatch.test.js
@@ -1,0 +1,72 @@
+const setRouterApiMediaPatch = require('../../../../../src/controller/router/media/setRouterApiMediaPatch');
+
+describe('setRouterApiMediaPatch', () => {
+  const createRes = () => {
+    const res = {
+      status: jest.fn(),
+      json: jest.fn(),
+    };
+    res.status.mockReturnValue(res);
+    return res;
+  };
+
+  const createReq = () => ({
+    session: {
+      session_token: 'token-1',
+    },
+    params: {
+      mediaId: 'media-1',
+    },
+    body: {
+      title: 'updated title',
+      tags: [
+        { category: '作者', label: '山田' },
+        { category: 'ジャンル', label: 'バトル' },
+      ],
+    },
+    context: {},
+  });
+
+  it('PATCH /api/media/:mediaId に認証・保存・更新の順でハンドラーを登録できる', async () => {
+    const router = { patch: jest.fn() };
+    const authResolver = { execute: jest.fn().mockResolvedValue('u1') };
+    const saveAdapter = {
+      execute: jest.fn((req, _res, cb) => {
+        req.context.contentIds = ['c2', 'c1'];
+        cb();
+      }),
+    };
+    const updateMediaService = { execute: jest.fn().mockResolvedValue(undefined) };
+
+    setRouterApiMediaPatch({
+      router,
+      authResolver,
+      saveAdapter,
+      updateMediaService,
+    });
+
+    expect(router.patch).toHaveBeenCalledTimes(1);
+    const [path, ...handlers] = router.patch.mock.calls[0];
+    expect(path).toBe('/api/media/:mediaId');
+    expect(handlers).toHaveLength(3);
+
+    const req = createReq();
+    const res = createRes();
+
+    await handlers[0](req, res, async () => {
+      await handlers[1](req, res, async () => {
+        await handlers[2](req, res);
+      });
+    });
+
+    expect(authResolver.execute).toHaveBeenCalledWith('token-1');
+    expect(saveAdapter.execute).toHaveBeenCalledWith(req, res, expect.any(Function));
+    expect(updateMediaService.execute).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'media-1',
+      title: 'updated title',
+      contents: ['c2', 'c1'],
+    }));
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ code: 0 });
+  });
+});

--- a/src/app/createDependencies.js
+++ b/src/app/createDependencies.js
@@ -4,6 +4,7 @@ const path = require('path');
 const { Sequelize } = require('sequelize');
 
 const setRouterApiMediaPost = require('../controller/router/media/setRouterApiMediaPost');
+const setRouterApiMediaPatch = require('../controller/router/media/setRouterApiMediaPatch');
 const setRouterApiLogin = require('../controller/router/user/setRouterApiLogin');
 const setRouterApiLogout = require('../controller/router/user/setRouterApiLogout');
 const setRouterScreenEntryGet = require('../controller/router/screen/setRouterScreenEntryGet');
@@ -33,6 +34,7 @@ const { AddFavoriteService } = require('../application/user/command/AddFavoriteS
 const { RemoveFavoriteService } = require('../application/user/command/RemoveFavoriteService');
 const { AddQueueService } = require('../application/user/command/AddQueueService');
 const { RemoveQueueService } = require('../application/user/command/RemoveQueueService');
+const { UpdateMediaService } = require('../application/media/command/UpdateMediaService');
 const { LoginService } = require('../application/user/command/LoginService');
 const { LogoutService } = require('../application/user/command/LogoutService');
 const { hasDevelopmentSession } = require('./developmentSession');
@@ -81,6 +83,7 @@ const createDependencies = (env = {}) => {
     password: env.loginPassword || 'admin',
     userId: env.loginUserId || 'admin',
   });
+  const updateMediaService = new UpdateMediaService({ mediaRepository, unitOfWork });
   const loginService = new LoginService({
     loginAuthenticator,
     sessionStateRegistrar,
@@ -115,6 +118,7 @@ const createDependencies = (env = {}) => {
     sessionStateRegistrar,
     sessionTerminator,
     loginAuthenticator,
+    updateMediaService,
     loginService,
     logoutService,
     authResolver: new SessionStateAuthAdapter({
@@ -126,6 +130,7 @@ const createDependencies = (env = {}) => {
     mediaIdValueGenerator: new UUIDMediaIdValueGenerator(),
     routeSetters: {
       setRouterApiMediaPost,
+      setRouterApiMediaPatch,
       setRouterApiLogin,
       setRouterApiLogout,
       setRouterScreenEntryGet,

--- a/src/app/setupRoutes.js
+++ b/src/app/setupRoutes.js
@@ -57,6 +57,12 @@ const setupRoutes = (app, { env: _env, dependencies } = {}) => {
     mediaRepository: dependencies.mediaRepository,
     unitOfWork: dependencies.unitOfWork,
   });
+  dependencies.routeSetters.setRouterApiMediaPatch({
+    router,
+    authResolver: dependencies.authResolver,
+    saveAdapter: dependencies.saveAdapter,
+    updateMediaService: dependencies.updateMediaService,
+  });
   dependencies.routeSetters.setRouterApiFavoriteAndQueue({
     router,
     authResolver: dependencies.authResolver,

--- a/src/controller/api/MediaPatchController.js
+++ b/src/controller/api/MediaPatchController.js
@@ -1,0 +1,100 @@
+const {
+  UpdateMediaServiceInput,
+} = require('../../application/media/command/UpdateMediaService');
+
+class MediaPatchController {
+  #updateMediaService;
+
+  constructor({ updateMediaService }) {
+    if (!updateMediaService || typeof updateMediaService.execute !== 'function') {
+      throw new Error();
+    }
+
+    this.#updateMediaService = updateMediaService;
+  }
+
+  async execute(req, res) {
+    try {
+      const mediaId = req?.params?.mediaId;
+      const title = req?.body?.title;
+      const tags = req?.body?.tags;
+      const contentIds = req?.context?.contentIds;
+
+      if (!this.#validateMediaId(mediaId)
+        || !this.#validateTitle(title)
+        || !this.#validateTags(tags)
+        || !this.#validateContentIds(contentIds)) {
+        return this.#fail(res);
+      }
+
+      const input = new UpdateMediaServiceInput({
+        id: mediaId,
+        title,
+        contents: contentIds,
+        tags,
+        priorityCategories: this.#createPriorityCategories(tags),
+      });
+
+      await this.#updateMediaService.execute(input);
+
+      return res.status(200).json({
+        code: 0,
+      });
+    } catch (error) {
+      return this.#fail(res);
+    }
+  }
+
+  #createPriorityCategories(tags) {
+    return [...new Set(tags.map(tag => tag.category))];
+  }
+
+  #fail(res) {
+    return res.status(200).json({
+      code: 1,
+    });
+  }
+
+  #validateMediaId(mediaId) {
+    return typeof mediaId === 'string' && mediaId.length > 0;
+  }
+
+  #validateTitle(title) {
+    return typeof title === 'string' && title.length > 0;
+  }
+
+  #validateTags(tags) {
+    if (!Array.isArray(tags)) {
+      return false;
+    }
+
+    for (const tag of tags) {
+      if (!tag || typeof tag !== 'object') {
+        return false;
+      }
+
+      if (!(typeof tag.category === 'string' && tag.category.length > 0
+        && typeof tag.label === 'string' && tag.label.length > 0)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  #validateContentIds(contentIds) {
+    if (!Array.isArray(contentIds) || contentIds.length === 0) {
+      return false;
+    }
+
+    for (const contentId of contentIds) {
+      if (!(typeof contentId === 'string' && contentId.length > 0)) {
+        return false;
+      }
+    }
+
+    return new Set(contentIds).size === contentIds.length;
+  }
+}
+
+module.exports = MediaPatchController;

--- a/src/controller/router/media/setRouterApiMediaPatch.js
+++ b/src/controller/router/media/setRouterApiMediaPatch.js
@@ -1,0 +1,26 @@
+const SessionAuthMiddleware = require('../../middleware/SessionAuthMiddleware');
+const ContentSaveMiddleware = require('../../middleware/ContentSaveMiddleware');
+const MediaPatchController = require('../../api/MediaPatchController');
+
+const setRouterApiMediaPatch = ({
+  router,
+  authResolver,
+  saveAdapter,
+  updateMediaService,
+}) => {
+  const auth = new SessionAuthMiddleware(authResolver);
+  const save = new ContentSaveMiddleware({
+    contentUploadAdapter: saveAdapter,
+  });
+  const controller = new MediaPatchController({
+    updateMediaService,
+  });
+
+  router.patch('/api/media/:mediaId', ...[
+    auth.execute.bind(auth),
+    save.execute.bind(save),
+    controller.execute.bind(controller),
+  ]);
+};
+
+module.exports = setRouterApiMediaPatch;

--- a/src/infrastructure/MulterDiskStorageContentUploadAdapter.js
+++ b/src/infrastructure/MulterDiskStorageContentUploadAdapter.js
@@ -119,10 +119,11 @@ module.exports = class MulterDiskStorageContentUploadAdapter extends IContentUpl
     }
 
     const hasFile = uploadedFile !== null;
-    const hasUrl = typeof content.url === 'string' && content.url.length > 0;
+    const contentId = this.#readExistingContentId(content);
+    const hasExistingContentId = contentId !== null;
 
-    if (hasFile === hasUrl) {
-      throw new Error('file xor url is required');
+    if (hasFile === hasExistingContentId) {
+      throw new Error('file xor id is required');
     }
 
     if (hasFile) {
@@ -137,15 +138,27 @@ module.exports = class MulterDiskStorageContentUploadAdapter extends IContentUpl
       };
     }
 
-    if (!(/^[0-9a-f]{32}$/).test(content.url)) {
-      throw new Error('url contentId is invalid');
+    if (!(/^[0-9a-f]{32}$/).test(contentId)) {
+      throw new Error('contentId is invalid');
     }
 
     return {
       index,
       position,
-      contentId: content.url,
+      contentId,
     };
+  }
+
+  #readExistingContentId(content) {
+    if (typeof content.id === 'string' && content.id.length > 0) {
+      return content.id;
+    }
+
+    if (typeof content.url === 'string' && content.url.length > 0) {
+      return content.url;
+    }
+
+    return null;
   }
 
   #createUniqueContentId() {


### PR DESCRIPTION
### Motivation
- 編集画面からのメディア編集をバックエンドで完結させるため、既存の `UpdateMediaService` を HTTP API 経由で利用できるようにする必要がありました。 
- OpenAPI の examples に沿って、既存コンテンツID と新規アップロードを混在させた multipart/form-data に対応する必要がありました。 

### Description
- `PATCH /api/media/:mediaId` 用のコントローラー `src/controller/api/MediaPatchController.js` を追加し、`req.params.mediaId`・`req.body.title`・`req.body.tags`・`req.context.contentIds` を `UpdateMediaServiceInput` に変換して呼び出すようにしました。 
- 既存のアップロード処理を拡張し、`src/infrastructure/MulterDiskStorageContentUploadAdapter.js` で `contents[n][id]`（既存ID）と `contents[n][file]`（新規ファイル）を混在して扱えるようにし、従来の `url` も引き続き読み取る後方互換を保持しました。 
- ルーターセッター `src/controller/router/media/setRouterApiMediaPatch.js` を追加し、`SessionAuthMiddleware` → `ContentSaveMiddleware` → `MediaPatchController` の順でハンドラーを登録するようにしました。 
- 依存注入側で `UpdateMediaService` の生成と routeSetter の登録を追加し（`src/app/createDependencies.js`、`src/app/setupRoutes.js`）、ルート配線を有効化しました。 
- 更新API向けに small / medium レイヤーのテストを追加・更新し、タイトル変更・並び替え・新規画像追加・既存IDと新規ファイル混在・入力不正ケースを網羅しました（`__tests__/small/...` と `__tests__/medium/...` に関連テストを追加）。 

### Testing
- モジュールの読み込み確認として `node -e "require('./src/controller/api/MediaPatchController'); require('./src/controller/router/media/setRouterApiMediaPatch'); require('./src/controller/middleware/ContentSaveMiddleware'); console.log('require-ok')"` を実行し成功しました。 
- `git diff --check` を実行して差分問題がないことを確認しました。 
- 追加したテスト群はリポジトリに作成済みですが、ローカルで `jest` を実行する試行は環境依存で失敗しており、`jest` 未インストール（`jest: not found`）および `npx jest` 実行時に npm registry へのアクセスで 403 が返り取得不可のため実行できませんでした。 
- 変更はコミット済みです（コミットID: `67386f2`）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c09bc012d0832b957de3baa7d082e0)