### PR TITLE
feat: メディア削除APIを追加する

### DIFF
--- a/__tests__/medium/controller/router/media/setRouterApiMediaDelete.test.js
+++ b/__tests__/medium/controller/router/media/setRouterApiMediaDelete.test.js
@@ -1,0 +1,120 @@
+const express = require('express');
+const request = require('supertest');
+const { Sequelize } = require('sequelize');
+
+const setRouterApiMediaDelete = require('../../../../../src/controller/router/media/setRouterApiMediaDelete');
+const SessionStateAuthAdapter = require('../../../../../src/infrastructure/SessionStateAuthAdapter');
+const SequelizeMediaRepository = require('../../../../../src/infrastructure/SequelizeMediaRepository');
+const SequelizeUnitOfWork = require('../../../../../src/infrastructure/SequelizeUnitOfWork');
+const { DeleteMediaService } = require('../../../../../src/application/media/command/DeleteMediaService');
+const Media = require('../../../../../src/domain/media/media');
+const MediaId = require('../../../../../src/domain/media/mediaId');
+const MediaTitle = require('../../../../../src/domain/media/mediaTitle');
+const ContentId = require('../../../../../src/domain/media/contentId');
+const Tag = require('../../../../../src/domain/media/tag');
+const Category = require('../../../../../src/domain/media/category');
+const Label = require('../../../../../src/domain/media/label');
+
+class InMemorySessionStateStore {
+  constructor(entries = []) {
+    this.tokenToUserId = new Map(entries);
+  }
+
+  findUserIdBySessionToken(sessionToken) {
+    return this.tokenToUserId.get(sessionToken) ?? null;
+  }
+}
+
+describe('setRouterApiMediaDelete (middle)', () => {
+  let sequelize;
+  let unitOfWork;
+  let mediaRepository;
+  const mediaId = '1234567890abcdef1234567890abcdef';
+
+  beforeEach(async () => {
+    sequelize = new Sequelize('sqlite::memory:', { logging: false });
+    unitOfWork = new SequelizeUnitOfWork({ sequelize });
+    mediaRepository = new SequelizeMediaRepository({
+      sequelize,
+      unitOfWorkContext: unitOfWork,
+    });
+    await mediaRepository.sync();
+
+    await unitOfWork.run(async () => {
+      await mediaRepository.save(new Media(
+        new MediaId(mediaId),
+        new MediaTitle('before title'),
+        [new ContentId('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')],
+        [new Tag(new Category('作者'), new Label('旧作者'))],
+        [new Category('作者')],
+      ));
+    });
+  });
+
+  afterEach(async () => {
+    await sequelize.close();
+  });
+
+  const createApp = () => {
+    const app = express();
+    const router = express.Router();
+
+    app.use((req, _res, next) => {
+      req.session = { session_token: req.header('x-session-token') };
+      req.context = {};
+      next();
+    });
+
+    setRouterApiMediaDelete({
+      router,
+      authResolver: new SessionStateAuthAdapter({
+        sessionStateStore: new InMemorySessionStateStore([['valid-token', 'user-001']]),
+      }),
+      deleteMediaService: new DeleteMediaService({ mediaRepository, unitOfWork }),
+    });
+
+    app.use(router);
+    return app;
+  };
+
+  test('DELETE /api/media/:mediaId で正常削除できる', async () => {
+    const app = createApp();
+
+    const response = await request(app)
+      .delete(`/api/media/${mediaId}`)
+      .set('x-session-token', 'valid-token');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ code: 0 });
+
+    const media = await mediaRepository.findByMediaId(new MediaId(mediaId));
+    expect(media).toBeNull();
+  });
+
+  test('削除対象が存在しない場合は code=1 を返す', async () => {
+    const app = createApp();
+
+    const response = await request(app)
+      .delete('/api/media/ffffffffffffffffffffffffffffffff')
+      .set('x-session-token', 'valid-token');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ code: 1 });
+  });
+
+  test('認証失敗時は 401 を返し既存メディアを保持する', async () => {
+    const app = createApp();
+
+    const response = await request(app)
+      .delete(`/api/media/${mediaId}`)
+      .set('x-session-token', 'invalid-token');
+
+    expect(response.status).toBe(401);
+    expect(response.body).toEqual({
+      message: '認証に失敗しました',
+    });
+
+    const media = await mediaRepository.findByMediaId(new MediaId(mediaId));
+    expect(media).not.toBeNull();
+  });
+});

--- a/__tests__/small/controller/api/MediaDeleteController.test.js
+++ b/__tests__/small/controller/api/MediaDeleteController.test.js
@@ -1,0 +1,66 @@
+const MediaDeleteController = require('../../../../src/controller/api/MediaDeleteController');
+const {
+  DeleteMediaServiceInput,
+} = require('../../../../src/application/media/command/DeleteMediaService');
+
+describe('MediaDeleteController', () => {
+  let deleteMediaService;
+  let controller;
+
+  const createRes = () => {
+    const res = {
+      status: jest.fn(),
+      json: jest.fn(),
+    };
+    res.status.mockReturnValue(res);
+    return res;
+  };
+
+  const execute = async params => {
+    const req = { params };
+    const res = createRes();
+
+    await controller.execute(req, res);
+
+    return { res };
+  };
+
+  beforeEach(() => {
+    deleteMediaService = {
+      execute: jest.fn().mockResolvedValue(undefined),
+    };
+
+    controller = new MediaDeleteController({ deleteMediaService });
+  });
+
+  it('mediaId を使ってメディア削除に成功する', async () => {
+    const { res } = await execute({ mediaId: 'm1' });
+
+    expect(deleteMediaService.execute).toHaveBeenCalledTimes(1);
+    const input = deleteMediaService.execute.mock.calls[0][0];
+    expect(input).toBeInstanceOf(DeleteMediaServiceInput);
+    expect(input).toMatchObject({ id: 'm1' });
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ code: 0 });
+  });
+
+  it('DeleteMediaService が失敗した場合は code=1 を返す', async () => {
+    deleteMediaService.execute.mockRejectedValue(new Error('fail'));
+
+    const { res } = await execute({ mediaId: 'm1' });
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ code: 1 });
+  });
+
+  it.each([
+    ['mediaIdが未設定', {}],
+    ['mediaIdが空文字', { mediaId: '' }],
+  ])('%sの場合は削除失敗を返す', async (_name, params) => {
+    const { res } = await execute(params);
+
+    expect(deleteMediaService.execute).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ code: 1 });
+  });
+});

--- a/__tests__/small/controller/router/media/setRouterApiMediaDelete.test.js
+++ b/__tests__/small/controller/router/media/setRouterApiMediaDelete.test.js
@@ -1,0 +1,47 @@
+const setRouterApiMediaDelete = require('../../../../../src/controller/router/media/setRouterApiMediaDelete');
+
+describe('setRouterApiMediaDelete', () => {
+  const createRes = () => {
+    const res = {
+      status: jest.fn(),
+      json: jest.fn(),
+    };
+    res.status.mockReturnValue(res);
+    return res;
+  };
+
+  it('DELETE /api/media/:mediaId に認証・削除の順でハンドラーを登録できる', async () => {
+    const router = { delete: jest.fn() };
+    const authResolver = { execute: jest.fn().mockResolvedValue('u1') };
+    const deleteMediaService = { execute: jest.fn().mockResolvedValue(undefined) };
+
+    setRouterApiMediaDelete({
+      router,
+      authResolver,
+      deleteMediaService,
+    });
+
+    expect(router.delete).toHaveBeenCalledTimes(1);
+    const [path, ...handlers] = router.delete.mock.calls[0];
+    expect(path).toBe('/api/media/:mediaId');
+    expect(handlers).toHaveLength(2);
+
+    const req = {
+      session: { session_token: 'token-1' },
+      params: { mediaId: 'media-1' },
+      context: {},
+    };
+    const res = createRes();
+
+    await handlers[0](req, res, async () => {
+      await handlers[1](req, res);
+    });
+
+    expect(authResolver.execute).toHaveBeenCalledWith('token-1');
+    expect(deleteMediaService.execute).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'media-1',
+    }));
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ code: 0 });
+  });
+});

--- a/src/app/createDependencies.js
+++ b/src/app/createDependencies.js
@@ -5,6 +5,7 @@ const { Sequelize } = require('sequelize');
 
 const setRouterApiMediaPost = require('../controller/router/media/setRouterApiMediaPost');
 const setRouterApiMediaPatch = require('../controller/router/media/setRouterApiMediaPatch');
+const setRouterApiMediaDelete = require('../controller/router/media/setRouterApiMediaDelete');
 const setRouterApiLogin = require('../controller/router/user/setRouterApiLogin');
 const setRouterApiLogout = require('../controller/router/user/setRouterApiLogout');
 const setRouterScreenEntryGet = require('../controller/router/screen/setRouterScreenEntryGet');
@@ -35,6 +36,7 @@ const { RemoveFavoriteService } = require('../application/user/command/RemoveFav
 const { AddQueueService } = require('../application/user/command/AddQueueService');
 const { RemoveQueueService } = require('../application/user/command/RemoveQueueService');
 const { UpdateMediaService } = require('../application/media/command/UpdateMediaService');
+const { DeleteMediaService } = require('../application/media/command/DeleteMediaService');
 const { LoginService } = require('../application/user/command/LoginService');
 const { LogoutService } = require('../application/user/command/LogoutService');
 const { hasDevelopmentSession } = require('./developmentSession');
@@ -84,6 +86,7 @@ const createDependencies = (env = {}) => {
     userId: env.loginUserId || 'admin',
   });
   const updateMediaService = new UpdateMediaService({ mediaRepository, unitOfWork });
+  const deleteMediaService = new DeleteMediaService({ mediaRepository, unitOfWork });
   const loginService = new LoginService({
     loginAuthenticator,
     sessionStateRegistrar,
@@ -119,6 +122,7 @@ const createDependencies = (env = {}) => {
     sessionTerminator,
     loginAuthenticator,
     updateMediaService,
+    deleteMediaService,
     loginService,
     logoutService,
     authResolver: new SessionStateAuthAdapter({
@@ -131,6 +135,7 @@ const createDependencies = (env = {}) => {
     routeSetters: {
       setRouterApiMediaPost,
       setRouterApiMediaPatch,
+      setRouterApiMediaDelete,
       setRouterApiLogin,
       setRouterApiLogout,
       setRouterScreenEntryGet,

--- a/src/app/setupRoutes.js
+++ b/src/app/setupRoutes.js
@@ -63,6 +63,11 @@ const setupRoutes = (app, { env: _env, dependencies } = {}) => {
     saveAdapter: dependencies.saveAdapter,
     updateMediaService: dependencies.updateMediaService,
   });
+  dependencies.routeSetters.setRouterApiMediaDelete({
+    router,
+    authResolver: dependencies.authResolver,
+    deleteMediaService: dependencies.deleteMediaService,
+  });
   dependencies.routeSetters.setRouterApiFavoriteAndQueue({
     router,
     authResolver: dependencies.authResolver,

--- a/src/controller/api/MediaDeleteController.js
+++ b/src/controller/api/MediaDeleteController.js
@@ -1,0 +1,49 @@
+const {
+  DeleteMediaServiceInput,
+} = require('../../application/media/command/DeleteMediaService');
+
+class MediaDeleteController {
+  #deleteMediaService;
+
+  constructor({ deleteMediaService }) {
+    if (!deleteMediaService || typeof deleteMediaService.execute !== 'function') {
+      throw new Error();
+    }
+
+    this.#deleteMediaService = deleteMediaService;
+  }
+
+  async execute(req, res) {
+    try {
+      const mediaId = req?.params?.mediaId;
+
+      if (!this.#validateMediaId(mediaId)) {
+        return this.#fail(res);
+      }
+
+      const input = new DeleteMediaServiceInput({
+        id: mediaId,
+      });
+
+      await this.#deleteMediaService.execute(input);
+
+      return res.status(200).json({
+        code: 0,
+      });
+    } catch (_error) {
+      return this.#fail(res);
+    }
+  }
+
+  #validateMediaId(mediaId) {
+    return typeof mediaId === 'string' && mediaId.length > 0;
+  }
+
+  #fail(res) {
+    return res.status(200).json({
+      code: 1,
+    });
+  }
+}
+
+module.exports = MediaDeleteController;

--- a/src/controller/router/media/setRouterApiMediaDelete.js
+++ b/src/controller/router/media/setRouterApiMediaDelete.js
@@ -1,0 +1,20 @@
+const SessionAuthMiddleware = require('../../middleware/SessionAuthMiddleware');
+const MediaDeleteController = require('../../api/MediaDeleteController');
+
+const setRouterApiMediaDelete = ({
+  router,
+  authResolver,
+  deleteMediaService,
+}) => {
+  const auth = new SessionAuthMiddleware(authResolver);
+  const controller = new MediaDeleteController({
+    deleteMediaService,
+  });
+
+  router.delete('/api/media/:mediaId', ...[
+    auth.execute.bind(auth),
+    controller.execute.bind(controller),
+  ]);
+};
+
+module.exports = setRouterApiMediaDelete;


### PR DESCRIPTION
### Motivation

- 既存の `DeleteMediaService` を外部から呼び出す API が存在せず、フロントや外部クライアントでメディア削除が行えなかったためエンドポイントを追加する。 
- 既存の `MediaPostController`/`MediaPatchController` と同様のレスポンス方針（成功 `{ code: 0 }`、失敗 `{ code: 1 }`）で統一する。 

### Description

- `src/controller/api/MediaDeleteController.js` を追加し、`req.params.mediaId` を `DeleteMediaServiceInput` に変換して `DeleteMediaService.execute` を呼び出すように実装した。 
- `src/controller/router/media/setRouterApiMediaDelete.js` を追加し、`DELETE /api/media/:mediaId` を `SessionAuthMiddleware` 経由で `MediaDeleteController` に接続するように登録した。 
- 依存注入側である `src/app/createDependencies.js` に `DeleteMediaService` の生成と `routeSetters` への登録を追加し、`src/app/setupRoutes.js` にルート設定を追加してアプリへ組み込んだ。 
- 小・中テストを追加し、`__tests__/small/controller/api/MediaDeleteController.test.js`、`__tests__/small/controller/router/media/setRouterApiMediaDelete.test.js`、`__tests__/medium/controller/router/media/setRouterApiMediaDelete.test.js` で正常系・対象なし・認証失敗を検証するテストを追加した。 

### Testing

- 追加した Jest テストファイルはリポジトリに追加済みで、テスト群としては `__tests__/small/...` と `__tests__/medium/...` を用意した。 
- ローカルで `jest` を起動してのフル実行を試みたが、実行環境で `jest` や `sequelize` などの依存解決が完了できなかったためテストの完全実行はできなかった。 
- 追加ファイル単体の `require` による構文/依存チェックでは `MediaDeleteController` と `setRouterApiMediaDelete` の読み込みは確認済みで問題はなかった。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c09e48a980832b82deb57179bb51d0)