### PR TITLE
feat: あとで見る一覧取得サービスと対応テストを追加する

### DIFF
--- a/__tests__/small/applicationService/user/query/GetQueueService.test.js
+++ b/__tests__/small/applicationService/user/query/GetQueueService.test.js
@@ -1,0 +1,76 @@
+const MockUserRepository = require('../../../applicationService/__mocks__/MockUserRepository');
+const MockMediaQueryRepository = require('../../../applicationService/__mocks__/MockMediaQueryRepository');
+const User = require('../../../../../src/domain/user/user');
+const UserId = require('../../../../../src/domain/user/userId');
+const MediaId = require('../../../../../src/domain/media/mediaId');
+const {
+  Input,
+  GetQueueService,
+} = require('../../../../../src/application/user/query/GetQueueService');
+
+describe('GetQueueService', () => {
+  test('user の queue を media overview 一覧へ変換して返す', async () => {
+    const userRepository = new MockUserRepository();
+    const mediaQueryRepository = new MockMediaQueryRepository();
+    const user = new User(new UserId('user001'));
+    user.addQueue(new MediaId('media-001'));
+    user.addQueue(new MediaId('media-002'));
+
+    userRepository.findByUserId.mockResolvedValue(user);
+    mediaQueryRepository.findOverviewsByMediaIds.mockResolvedValue([
+      { mediaId: 'media-001', title: 'タイトル1', thumbnail: '/c1.jpg', tags: [], priorityCategories: [] },
+      { mediaId: 'media-002', title: 'タイトル2', thumbnail: '/c2.jpg', tags: [], priorityCategories: [] },
+    ]);
+
+    const service = new GetQueueService({ userRepository, mediaQueryRepository });
+    const result = await service.execute(new Input({ userId: 'user001' }));
+
+    expect(userRepository.findByUserId).toHaveBeenCalledWith(new UserId('user001'));
+    expect(mediaQueryRepository.findOverviewsByMediaIds).toHaveBeenCalledWith(['media-001', 'media-002']);
+    expect(result.mediaOverviews).toEqual([
+      { mediaId: 'media-001', title: 'タイトル1', thumbnail: '/c1.jpg', tags: [], priorityCategories: [] },
+      { mediaId: 'media-002', title: 'タイトル2', thumbnail: '/c2.jpg', tags: [], priorityCategories: [] },
+    ]);
+  });
+
+  test('queue が空のときは空配列を返す', async () => {
+    const userRepository = new MockUserRepository();
+    const mediaQueryRepository = new MockMediaQueryRepository();
+
+    userRepository.findByUserId.mockResolvedValue(new User(new UserId('user001')));
+
+    const service = new GetQueueService({ userRepository, mediaQueryRepository });
+    const result = await service.execute(new Input({ userId: 'user001' }));
+
+    expect(userRepository.findByUserId).toHaveBeenCalledWith(new UserId('user001'));
+    expect(mediaQueryRepository.findOverviewsByMediaIds).not.toHaveBeenCalled();
+    expect(result.mediaOverviews).toEqual([]);
+  });
+
+  test('user が存在しないときは空配列を返す', async () => {
+    const userRepository = new MockUserRepository();
+    const mediaQueryRepository = new MockMediaQueryRepository();
+
+    userRepository.findByUserId.mockResolvedValue(null);
+
+    const service = new GetQueueService({ userRepository, mediaQueryRepository });
+    const result = await service.execute(new Input({ userId: 'user001' }));
+
+    expect(userRepository.findByUserId).toHaveBeenCalledWith(new UserId('user001'));
+    expect(mediaQueryRepository.findOverviewsByMediaIds).not.toHaveBeenCalled();
+    expect(result.mediaOverviews).toEqual([]);
+  });
+
+  test('リポジトリ例外をそのまま伝播する', async () => {
+    const userRepository = new MockUserRepository();
+    const mediaQueryRepository = new MockMediaQueryRepository();
+    const error = new Error('failed');
+
+    userRepository.findByUserId.mockRejectedValue(error);
+
+    const service = new GetQueueService({ userRepository, mediaQueryRepository });
+
+    await expect(service.execute(new Input({ userId: 'user001' }))).rejects.toThrow(error);
+    expect(mediaQueryRepository.findOverviewsByMediaIds).not.toHaveBeenCalled();
+  });
+});

--- a/src/application/user/query/GetQueueService.js
+++ b/src/application/user/query/GetQueueService.js
@@ -1,0 +1,74 @@
+const UserId = require('../../../domain/user/userId');
+
+class Input {
+  constructor({ userId }) {
+    if (typeof userId !== 'string' || userId.length === 0) {
+      throw new Error();
+    }
+
+    this.userId = userId;
+  }
+}
+
+const isMediaOverviewLike = (obj) => {
+  if (typeof obj?.mediaId !== 'string') return false;
+  if (typeof obj?.title !== 'string') return false;
+  if (typeof obj?.thumbnail !== 'string') return false;
+  if (!(obj?.tags instanceof Array)) return false;
+  if (!obj.tags.every(tag => ['category', 'label'].every(prop => prop in tag))) return false;
+  if (!(obj?.priorityCategories instanceof Array)) return false;
+  if (!obj.priorityCategories.every(category => typeof category === 'string')) return false;
+  return true;
+};
+
+class Output {
+  constructor({ mediaOverviews }) {
+    if (!(mediaOverviews instanceof Array) || !mediaOverviews.every(isMediaOverviewLike)) {
+      throw new Error();
+    }
+
+    this.mediaOverviews = mediaOverviews;
+  }
+}
+
+class GetQueueService {
+  #userRepository;
+  #mediaQueryRepository;
+
+  constructor({ userRepository, mediaQueryRepository }) {
+    if (!userRepository || typeof userRepository.findByUserId !== 'function') {
+      throw new Error();
+    }
+    if (!mediaQueryRepository || typeof mediaQueryRepository.findOverviewsByMediaIds !== 'function') {
+      throw new Error();
+    }
+
+    this.#userRepository = userRepository;
+    this.#mediaQueryRepository = mediaQueryRepository;
+  }
+
+  async execute(input) {
+    if (!(input instanceof Input)) {
+      throw new Error();
+    }
+
+    const user = await this.#userRepository.findByUserId(new UserId(input.userId));
+    if (!user) {
+      return new Output({ mediaOverviews: [] });
+    }
+
+    const mediaIds = user.getQueue().map(mediaId => mediaId.getId());
+    if (mediaIds.length === 0) {
+      return new Output({ mediaOverviews: [] });
+    }
+
+    const mediaOverviews = await this.#mediaQueryRepository.findOverviewsByMediaIds(mediaIds);
+    return new Output({ mediaOverviews });
+  }
+}
+
+module.exports = {
+  Input,
+  Output,
+  GetQueueService,
+};


### PR DESCRIPTION
### Motivation
- `GetQueue` の仕様書に従い、ユーザーの「あとで見る」一覧を取得する application query service が未実装だったため追加しました。
- 既存の `GetFavoriteSummariesService` と同様の入力検証・出力クラス構成に揃えて query の実装パターンを統一するためです。

### Description
- `src/application/user/query/GetQueueService.js` を追加し、`userRepository.findByUserId` で取得した User Aggregate の `queue` から mediaId 一覧を取り出して `mediaQueryRepository.findOverviewsByMediaIds` でメディア概要一覧を取得する処理を実装しました。
- 入力は `Input` クラスで検証し、出力は `Output` クラスで `mediaOverviews` の形を検証する構成にしました。
- ユーザー未存在時および queue が空の場合は空配列を返す実装にし、コンストラクタで依存リポジトリのインターフェース存在チェックを行います。
- 対応する小テストを `__tests__/small/applicationService/user/query/GetQueueService.test.js` に追加し、一覧取得成功・queue 空時・user 不在時・リポジトリ例外の伝播をカバーしました。

### Testing
- 追加したテストは `__tests__/small/applicationService/user/query/GetQueueService.test.js` に実装しましたが、この実行環境では `npx jest ...` が npm レジストリへのアクセスで `403 Forbidden` となり実行できませんでした。
- ローカルの `./node_modules/.bin/jest` は存在せず、そのため CI 相当の自動実行は行えていません。
- Node 単体での簡易スモーク実行も、テスト内のモック (`__tests__/small/applicationService/__mocks__/MockUserRepository.js`) が `jest.fn()` 前提のため `ReferenceError: jest is not defined` で実行できませんでした。
- 以上を踏まえ、テストコードは追加済みで内容は仕様どおりですが、環境制約によりこの環境上では自動テストの実行確認は未完了です。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0ab6f86f8832b80bcd89e7b5597e4)