### PR TITLE
docs: Login/Logout/MediaDelete/MediaPatch コントローラの設計・テストケースを追加

### DIFF
--- a/doc/5_api/controller/api/LoginPostController/readme.md
+++ b/doc/5_api/controller/api/LoginPostController/readme.md
@@ -1,0 +1,74 @@
+# LoginPostController
+
+## 概要
+- `POST /api/login` のHTTPリクエストを受け取り、ログイン処理を `LoginService` へ委譲する。
+- `req.body.username` / `req.body.password` / `req.session` を検証し、妥当な場合のみ `LoginService.Query` を生成して `execute` を呼び出す。
+- `LoginService` の戻り値が `LoginSucceededResult` のときだけ `session_token` Cookie を発行し、レスポンスは常に HTTP `200` で `code` を返す。
+- 入力不備、サービス失敗、想定外例外はすべて失敗レスポンス `code: 1` に正規化する。
+
+## 対象API
+- `POST /api/login`
+
+## 責務
+- ログインAPIの入力値を検証する。
+- `LoginService` に渡す `username` / `password` / `session` を組み立てる。
+- ログイン成功時のみ `session_token` Cookie を `httpOnly: true`, `path: '/'` で設定する。
+- 成功・失敗を `json` レスポンス `{ code }` に変換する。
+
+## 入力パラメータ
+| 項目 | 取得元 | 型 | 必須 | 説明 |
+| --- | --- | --- | --- | --- |
+| `username` | `req.body.username` | `string` | 必須 | 空文字不可。 |
+| `password` | `req.body.password` | `string` | 必須 | 空文字不可。 |
+| `session` | `req.session` | `object` | 必須 | セッションオブジェクト。 |
+
+## バリデーション
+- `username` は `string` かつ空文字以外であること。
+- `password` は `string` かつ空文字以外であること。
+- `session` が存在すること。
+- 上記を満たさない場合は `LoginService` を呼び出さず、失敗レスポンスを返す。
+
+## 依存する application service
+- [LoginService](/doc/4_application/user/command/LoginService/readme.md)
+  - `Query`: `username` / `password` / `session` を保持する入力DTO。
+  - `LoginSucceededResult`: 成功時結果。`sessionToken` と `code: 0` を持つ。
+  - 失敗時結果: `code: 1` を持つ結果オブジェクト。
+
+## 成功時レスポンス
+### ログイン成功
+- 条件: `LoginService` が `LoginSucceededResult` を返す。
+- HTTPステータス: `200`
+- Cookie:
+  - `session_token=<sessionToken>`
+  - `httpOnly: true`
+  - `path: '/'`
+- ボディ:
+
+```json
+{
+  "code": 0
+}
+```
+
+### 認証失敗
+- 条件: `LoginService` が失敗結果を返す。
+- HTTPステータス: `200`
+- Cookie: 発行しない。
+- ボディ:
+
+```json
+{
+  "code": 1
+}
+```
+
+## 失敗時レスポンス
+- 入力不備時: HTTP `200` + `{ "code": 1 }`
+- `LoginService` の失敗結果返却時: HTTP `200` + `{ "code": 1 }`
+
+## 例外時の振る舞い
+- `LoginService.execute` が例外を送出した場合は `catch` し、HTTP `200` + `{ "code": 1 }` を返す。
+- Cookie設定処理を含む `execute` 内の想定外例外も同様に失敗レスポンスへ変換する。
+
+## 関連ドキュメント
+- [Controllerテストケース](/doc/5_api/controller/api/LoginPostController/testcase.md)

--- a/doc/5_api/controller/api/LoginPostController/testcase.md
+++ b/doc/5_api/controller/api/LoginPostController/testcase.md
@@ -1,0 +1,76 @@
+# LoginPostController テストケース
+
+## テスト観点
+- 正常系: ログイン成功時に Cookie と `code=0` を返す。
+- 入力不備: `username` / `password` / `session` の不備でサービスを呼ばず `code=1` を返す。
+- サービス失敗: 認証失敗結果を `code=1` で返す。
+- 想定外例外: `LoginService` 例外時も失敗レスポンス形式を維持する。
+
+## 正常系
+
+### ログイン成功時はcookie付きでcode=0を返す
+- **前提**
+  - `username` と `password` が空文字ではない `string`。
+  - `session` が存在する。
+  - `LoginService` が `LoginSucceededResult` を返し、`sessionToken` を持つ。
+- **操作**
+  - `LoginPostController.execute` を実行する。
+- **結果**
+  - `LoginService` に `username` / `password` / `session` を渡して呼び出す。
+  - `session_token` Cookie を `httpOnly: true`, `path: '/'` で設定する。
+  - HTTPステータス `200` と `{"code":0}` を返す。
+
+## 異常系
+
+### ログイン失敗時はcookieを発行せずcode=1を返す
+- **前提**
+  - 入力値はすべて有効である。
+  - `LoginService` が失敗結果を返す。
+- **操作**
+  - `LoginPostController.execute` を実行する。
+- **結果**
+  - Cookie を発行しない。
+  - HTTPステータス `200` と `{"code":1}` を返す。
+
+### usernameが未設定の場合はcode=1を返す
+- **前提**
+  - `req.body.username` が未設定である。
+- **操作**
+  - `LoginPostController.execute` を実行する。
+- **結果**
+  - `LoginService` を呼び出さない。
+  - Cookie を発行せず、HTTPステータス `200` と `{"code":1}` を返す。
+
+### usernameが空文字の場合はcode=1を返す
+- **前提**
+  - `req.body.username` が空文字である。
+- **操作 / 結果**
+  - 上記と同様に `LoginService` を呼び出さず `code=1` を返す。
+
+### passwordが未設定の場合はcode=1を返す
+- **前提**
+  - `req.body.password` が未設定である。
+- **操作 / 結果**
+  - `LoginService` を呼び出さず、HTTPステータス `200` と `{"code":1}` を返す。
+
+### passwordが空文字の場合はcode=1を返す
+- **前提**
+  - `req.body.password` が空文字である。
+- **操作 / 結果**
+  - `LoginService` を呼び出さず、HTTPステータス `200` と `{"code":1}` を返す。
+
+### sessionが未設定の場合はcode=1を返す
+- **前提**
+  - `req.session` が未設定である。
+- **操作 / 結果**
+  - `LoginService` を呼び出さず、HTTPステータス `200` と `{"code":1}` を返す。
+
+### サービス例外時もcode=1を返す
+- **前提**
+  - 入力値はすべて有効である。
+  - `LoginService.execute` が例外を送出する。
+- **操作**
+  - `LoginPostController.execute` を実行する。
+- **結果**
+  - HTTPステータス `200` と `{"code":1}` を返す。
+  - 想定外例外がそのまま外へ送出されない。

--- a/doc/5_api/controller/api/LogoutPostController/readme.md
+++ b/doc/5_api/controller/api/LogoutPostController/readme.md
@@ -1,0 +1,52 @@
+# LogoutPostController
+
+## 概要
+- `POST /api/logout` のHTTPリクエストを受け取り、ログアウト処理を `LogoutService` へ委譲する。
+- `req.session` の存在のみを確認し、妥当な場合は `LogoutService.Query` を生成して `execute` を呼び出す。
+- `LogoutService` の結果コードをそのまま返し、入力不備や例外は失敗レスポンス `code: 1` に統一する。
+
+## 対象API
+- `POST /api/logout`
+
+## 責務
+- ログアウトAPIに必要な `session` の存在を確認する。
+- `LogoutService` に対して `session` を渡す。
+- 成功・失敗レスポンスを HTTP `200` の JSON `{ code }` に変換する。
+
+## 入力パラメータ
+| 項目 | 取得元 | 型 | 必須 | 説明 |
+| --- | --- | --- | --- | --- |
+| `session` | `req.session` | `object` | 必須 | ログアウト対象のセッション。 |
+
+## バリデーション
+- `session` が存在すること。
+- 未設定の場合は `LogoutService` を呼び出さず、失敗レスポンスを返す。
+
+## 依存する application service
+- [LogoutService](/doc/4_application/user/command/LogoutService/readme.md)
+  - `Query`: `session` を保持する入力DTO。
+  - 成功時結果: `code: 0` を持つ。
+  - 失敗時結果: `code: 1` を持つ。
+
+## 成功時レスポンス
+### ログアウト成功
+- 条件: `LogoutService` が成功結果を返す。
+- HTTPステータス: `200`
+- ボディ:
+
+```json
+{
+  "code": 0
+}
+```
+
+## 失敗時レスポンス
+- `session` 未設定時: HTTP `200` + `{ "code": 1 }`
+- `LogoutService` が失敗結果を返した時: HTTP `200` + `{ "code": 1 }`
+
+## 例外時の振る舞い
+- `LogoutService.execute` が例外を送出した場合は `catch` し、HTTP `200` + `{ "code": 1 }` を返す。
+- 想定外例外は外へ再送出せず、ログアウト失敗として扱う。
+
+## 関連ドキュメント
+- [Controllerテストケース](/doc/5_api/controller/api/LogoutPostController/testcase.md)

--- a/doc/5_api/controller/api/LogoutPostController/testcase.md
+++ b/doc/5_api/controller/api/LogoutPostController/testcase.md
@@ -1,0 +1,49 @@
+# LogoutPostController テストケース
+
+## テスト観点
+- 正常系: `session` がある場合に `LogoutService` を呼び出し `code=0` を返す。
+- 入力不備: `session` 未設定時は `code=1` を返す。
+- サービス失敗: `LogoutService` の失敗結果を `code=1` で返す。
+- 想定外例外: `LogoutService` 例外時も失敗レスポンス形式を維持する。
+
+## 正常系
+
+### ログアウト成功時はcode=0を返す
+- **前提**
+  - `req.session` が存在する。
+  - `LogoutService` が成功結果を返す。
+- **操作**
+  - `LogoutPostController.execute` を実行する。
+- **結果**
+  - `LogoutService` に `session` を渡して呼び出す。
+  - HTTPステータス `200` と `{"code":0}` を返す。
+
+## 異常系
+
+### ログアウト失敗時はcode=1を返す
+- **前提**
+  - `req.session` が存在する。
+  - `LogoutService` が失敗結果を返す。
+- **操作**
+  - `LogoutPostController.execute` を実行する。
+- **結果**
+  - HTTPステータス `200` と `{"code":1}` を返す。
+
+### sessionが未設定の場合はcode=1を返す
+- **前提**
+  - `req.session` が未設定である。
+- **操作**
+  - `LogoutPostController.execute` を実行する。
+- **結果**
+  - `LogoutService` を呼び出さない。
+  - HTTPステータス `200` と `{"code":1}` を返す。
+
+### サービス例外時もcode=1を返す
+- **前提**
+  - `req.session` が存在する。
+  - `LogoutService.execute` が例外を送出する。
+- **操作**
+  - `LogoutPostController.execute` を実行する。
+- **結果**
+  - HTTPステータス `200` と `{"code":1}` を返す。
+  - 想定外例外がそのまま外へ送出されない。

--- a/doc/5_api/controller/api/MediaDeleteController/readme.md
+++ b/doc/5_api/controller/api/MediaDeleteController/readme.md
@@ -1,0 +1,49 @@
+# MediaDeleteController
+
+## 概要
+- `DELETE /api/media/:mediaId` のHTTPリクエストを受け取り、メディア削除処理を `DeleteMediaService` へ委譲する。
+- パスパラメータ `req.params.mediaId` を検証し、妥当な場合のみ `DeleteMediaServiceInput` を生成して `execute` を呼び出す。
+- 成功時は `code: 0`、入力不備・サービス失敗・想定外例外時は `code: 1` を返す。
+
+## 対象API
+- `DELETE /api/media/:mediaId`
+
+## 責務
+- 削除対象 `mediaId` の入力検証を行う。
+- `DeleteMediaService` に渡す入力DTOを生成する。
+- 削除結果を HTTP `200` の JSON レスポンスへ整形する。
+
+## 入力パラメータ
+| 項目 | 取得元 | 型 | 必須 | 説明 |
+| --- | --- | --- | --- | --- |
+| `mediaId` | `req.params.mediaId` | `string` | 必須 | 削除対象メディアID。空文字不可。 |
+
+## バリデーション
+- `mediaId` は `string` かつ空文字以外であること。
+- 不正な場合は `DeleteMediaService` を呼び出さず失敗レスポンスを返す。
+
+## 依存する application service
+- [DeleteMediaService](/doc/4_application/media/command/DeleteMediaService/readme.md)
+  - `DeleteMediaServiceInput`: `id` を保持する入力DTO。
+
+## 成功時レスポンス
+- 条件: `DeleteMediaService.execute` が正常終了する。
+- HTTPステータス: `200`
+- ボディ:
+
+```json
+{
+  "code": 0
+}
+```
+
+## 失敗時レスポンス
+- `mediaId` 入力不備時: HTTP `200` + `{ "code": 1 }`
+- `DeleteMediaService.execute` 失敗時: HTTP `200` + `{ "code": 1 }`
+
+## 例外時の振る舞い
+- `DeleteMediaService.execute` が例外を送出した場合は `catch` し、HTTP `200` + `{ "code": 1 }` を返す。
+- DTO生成やレスポンス組み立て中の想定外例外も同じ失敗レスポンスに正規化する。
+
+## 関連ドキュメント
+- [Controllerテストケース](/doc/5_api/controller/api/MediaDeleteController/testcase.md)

--- a/doc/5_api/controller/api/MediaDeleteController/testcase.md
+++ b/doc/5_api/controller/api/MediaDeleteController/testcase.md
@@ -1,0 +1,53 @@
+# MediaDeleteController テストケース
+
+## テスト観点
+- 正常系: `mediaId` を使って削除に成功し `code=0` を返す。
+- 入力不備: `mediaId` 未設定・空文字時はサービスを呼ばず `code=1` を返す。
+- サービス失敗: `DeleteMediaService` 例外時は `code=1` を返す。
+- 想定外例外: 失敗レスポンス形式を維持する。
+
+## 正常系
+
+### mediaId を使ってメディア削除に成功する
+- **前提**
+  - `req.params.mediaId` が空文字ではない `string`。
+  - `DeleteMediaService.execute` が正常終了する。
+- **操作**
+  - `MediaDeleteController.execute` を実行する。
+- **結果**
+  - `DeleteMediaServiceInput` に `id=mediaId` を設定してサービスを呼び出す。
+  - HTTPステータス `200` と `{"code":0}` を返す。
+
+## 異常系
+
+### mediaIdが未設定の場合は削除失敗を返す
+- **前提**
+  - `req.params.mediaId` が未設定である。
+- **操作**
+  - `MediaDeleteController.execute` を実行する。
+- **結果**
+  - `DeleteMediaService` を呼び出さない。
+  - HTTPステータス `200` と `{"code":1}` を返す。
+
+### mediaIdが空文字の場合は削除失敗を返す
+- **前提**
+  - `req.params.mediaId` が空文字である。
+- **操作 / 結果**
+  - 上記と同様に `DeleteMediaService` を呼び出さず `code=1` を返す。
+
+### DeleteMediaService が失敗した場合は code=1 を返す
+- **前提**
+  - `req.params.mediaId` は有効である。
+  - `DeleteMediaService.execute` が例外を送出する。
+- **操作**
+  - `MediaDeleteController.execute` を実行する。
+- **結果**
+  - HTTPステータス `200` と `{"code":1}` を返す。
+
+### 想定外例外発生時も失敗レスポンス形式を維持する
+- **前提**
+  - Controller内部で想定外例外が発生する。
+- **操作**
+  - `MediaDeleteController.execute` を実行する。
+- **結果**
+  - 例外を外へ送出せず、HTTPステータス `200` と `{"code":1}` を返す。

--- a/doc/5_api/controller/api/MediaPatchController/readme.md
+++ b/doc/5_api/controller/api/MediaPatchController/readme.md
@@ -1,0 +1,59 @@
+# MediaPatchController
+
+## 概要
+- `PATCH /api/media/:mediaId` のHTTPリクエストを受け取り、メディア更新処理を `UpdateMediaService` へ委譲する。
+- `req.params.mediaId`、`req.body.title`、`req.body.tags`、`req.context.contentIds` を検証し、妥当な場合のみ `UpdateMediaServiceInput` を生成して `execute` を呼び出す。
+- `priorityCategories` は `tags[n].category` を先頭から見た出現順で重複除去して生成する。
+- 入力不備、サービス失敗、想定外例外はすべて HTTP `200` + `code: 1` で返す。
+
+## 対象API
+- `PATCH /api/media/:mediaId`
+
+## 責務
+- 更新API入力の妥当性確認を行う。
+- `UpdateMediaServiceInput` に `id` / `title` / `contents` / `tags` / `priorityCategories` を設定する。
+- 更新結果を HTTP `200` の JSON `{ code }` へ変換する。
+
+## 入力パラメータ
+| 項目 | 取得元 | 型 | 必須 | 説明 |
+| --- | --- | --- | --- | --- |
+| `mediaId` | `req.params.mediaId` | `string` | 必須 | 更新対象メディアID。空文字不可。 |
+| `title` | `req.body.title` | `string` | 必須 | 更新後タイトル。空文字不可。 |
+| `tags` | `req.body.tags` | `Array<object>` | 必須 | `{ category, label }` 配列。空配列は許可。 |
+| `contentIds` | `req.context.contentIds` | `Array<string>` | 必須 | 紐付けるコンテンツID配列。1件以上、重複不可。 |
+
+## バリデーション
+- `mediaId` は `string` かつ空文字以外であること。
+- `title` は `string` かつ空文字以外であること。
+- `tags` は配列であること。
+- `tags` の各要素はオブジェクトであり、`category` / `label` がともに `string` かつ空文字以外であること。
+- `contentIds` は配列であり、1件以上含むこと。
+- `contentIds` の各要素は `string` かつ空文字以外であること。
+- `contentIds` は重複を許可しない。
+- いずれかを満たさない場合は `UpdateMediaService` を呼び出さず失敗レスポンスを返す。
+
+## 依存する application service
+- [UpdateMediaService](/doc/4_application/media/command/UpdateMediaService/readme.md)
+  - `UpdateMediaServiceInput`: `id` / `title` / `contents` / `tags` / `priorityCategories` を保持する入力DTO。
+
+## 成功時レスポンス
+- 条件: `UpdateMediaService.execute` が正常終了する。
+- HTTPステータス: `200`
+- ボディ:
+
+```json
+{
+  "code": 0
+}
+```
+
+## 失敗時レスポンス
+- 入力不備時: HTTP `200` + `{ "code": 1 }`
+- `UpdateMediaService.execute` 失敗時: HTTP `200` + `{ "code": 1 }`
+
+## 例外時の振る舞い
+- `UpdateMediaService.execute` が例外を送出した場合は `catch` し、HTTP `200` + `{ "code": 1 }` を返す。
+- `priorityCategories` 生成や入力DTO生成中の想定外例外も外へ送出せず、失敗レスポンスへ変換する。
+
+## 関連ドキュメント
+- [Controllerテストケース](/doc/5_api/controller/api/MediaPatchController/testcase.md)

--- a/doc/5_api/controller/api/MediaPatchController/testcase.md
+++ b/doc/5_api/controller/api/MediaPatchController/testcase.md
@@ -1,0 +1,68 @@
+# MediaPatchController テストケース
+
+## テスト観点
+- 正常系: 有効な `mediaId` / `title` / `tags` / `contentIds` で `code=0` を返す。
+- 入力不備: 各入力値の不足・型不正・重複時はサービスを呼ばず `code=1` を返す。
+- サービス失敗: `UpdateMediaService` 例外時は `code=1` を返す。
+- 想定外例外: 失敗レスポンス形式を維持する。
+
+## 正常系
+
+### mediaId・title・tags・contentIdsを使ってメディア更新に成功する
+- **前提**
+  - `mediaId` と `title` が空文字ではない `string`。
+  - `tags` が妥当な `{ category, label }` 配列である。
+  - `contentIds` が1件以上の重複しない `string` 配列である。
+  - `UpdateMediaService.execute` が正常終了する。
+- **操作**
+  - `MediaPatchController.execute` を実行する。
+- **結果**
+  - `UpdateMediaServiceInput` に `id` / `title` / `contents` / `tags` / `priorityCategories` を設定してサービスを呼び出す。
+  - HTTPステータス `200` と `{"code":0}` を返す。
+
+### priorityCategoriesはtags.categoryの出現順で重複なく生成される
+- **前提**
+  - `tags` に同一 `category` を複数回含む。
+- **操作**
+  - `MediaPatchController.execute` を実行する。
+- **結果**
+  - `priorityCategories` は `tags.category` を先頭から見た順で重複除去した配列となる。
+
+## 異常系
+
+### UpdateMediaServiceが失敗した場合はcode=1を返す
+- **前提**
+  - 入力値はすべて有効である。
+  - `UpdateMediaService.execute` が例外を送出する。
+- **操作**
+  - `MediaPatchController.execute` を実行する。
+- **結果**
+  - HTTPステータス `200` と `{"code":1}` を返す。
+
+### mediaIdが未設定の場合は更新失敗を返す
+### mediaIdが空文字の場合は更新失敗を返す
+### titleが空文字の場合は更新失敗を返す
+### titleがstring以外の場合は更新失敗を返す
+### tagsが未設定の場合は更新失敗を返す
+### tagsが配列以外の場合は更新失敗を返す
+### tags配列要素がnullの場合は更新失敗を返す
+### tagsのcategoryが空文字の場合は更新失敗を返す
+### tagsのlabelが空文字の場合は更新失敗を返す
+### contentIdsが未設定の場合は更新失敗を返す
+### contentIdsが空配列の場合は更新失敗を返す
+### contentIdsに重複がある場合は更新失敗を返す
+- **前提**
+  - 見出しに記載した不正入力が存在する。
+- **操作**
+  - `MediaPatchController.execute` を実行する。
+- **結果**
+  - `UpdateMediaService` を呼び出さない。
+  - HTTPステータス `200` と `{"code":1}` を返す。
+
+### 想定外例外発生時も失敗レスポンス形式を維持する
+- **前提**
+  - Controller内部で想定外例外が発生する。
+- **操作**
+  - `MediaPatchController.execute` を実行する。
+- **結果**
+  - 例外を外へ送出せず、HTTPステータス `200` と `{"code":1}` を返す。


### PR DESCRIPTION
### Motivation
- API 層の `LoginPostController` / `LogoutPostController` / `MediaDeleteController` / `MediaPatchController` の責務や入出力、例外時挙動が実装・テストから逆読みに頼っており参照コストが高かったため、仕様として明文化する目的で追加しました。
- 既存の small テスト（`__tests__/small/controller/api/*.test.js`）の観点をドキュメント化して、実装とテストの対応関係を明確にすることを狙いとしています。

### Description
- 各コントローラごとに `doc/5_api/controller/api/<ControllerName>/readme.md` を追加し、責務、入力パラメータ、バリデーション、成功時/失敗時レスポンス、依存する application service、例外時の振る舞いを定義しました（対象: `LoginPostController` / `LogoutPostController` / `MediaDeleteController` / `MediaPatchController`）。
- 各コントローラごとに `doc/5_api/controller/api/<ControllerName>/testcase.md` を追加し、既存 small テストを基準に正常系・入力不備・サービス失敗・想定外例外を明記しました。
- `MediaPatchController` では特に `priorityCategories` の生成ルール（`tags[n].category` の出現順で重複除去）や `contentIds` の要件（1件以上・重複不可）を明示しています。
- ドキュメントは既存実装とテストに合わせた仕様記述になっており、コントローラ実装への参照リンク（依存サービス）を含めています。

### Testing
- `npx jest __tests__/small/controller/api/LoginPostController.test.js __tests__/small/controller/api/LogoutPostController.test.js __tests__/small/controller/api/MediaDeleteController.test.js __tests__/small/controller/api/MediaPatchController.test.js` を実行しましたが、`npm` レジストリからの取得で `403 Forbidden` が返りテストは実行できませんでした。
- ローカルの `./node_modules/.bin/jest` を使う実行チェックは `NO_LOCAL_JEST`（ローカルに jest がインストールされていない）だったため実行不可でした。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0af3dd850832b8c0588185f400eaa)