### PR TITLE
test: Favorite と Queue の Value Object 単体テストを追加

### DIFF
--- a/__tests__/small/domain/user/favorite.test.js
+++ b/__tests__/small/domain/user/favorite.test.js
@@ -1,0 +1,53 @@
+const Favorite = require('../../../../src/domain/user/favorite');
+const MediaId = require('../../../../src/domain/media/mediaId');
+
+describe('[Domain][Value Object][Favorite]', () => {
+  it('有効な MediaId で生成できる', () => {
+    // arrange
+    const mediaId = new MediaId('media');
+
+    // act
+    const favorite = new Favorite(mediaId);
+
+    // assert
+    expect(favorite).toBeInstanceOf(Favorite);
+    expect(favorite.getMediaId()).toBe(mediaId);
+  });
+
+  it('MediaId 以外を渡すと例外になる', () => {
+    // arrange
+    const mediaId = null;
+
+    // act
+    // assert
+    expect(() => {
+      new Favorite(mediaId);
+    }).toThrow();
+  });
+
+  it('同じ MediaId を持つインスタンス同士が equals で同一判定される', () => {
+    // arrange
+    const mediaId1 = new MediaId('media');
+    const mediaId2 = new MediaId('media');
+    const favorite1 = new Favorite(mediaId1);
+    const favorite2 = new Favorite(mediaId2);
+
+    // act
+    const actual = favorite1.equals(favorite2);
+
+    // assert
+    expect(actual).toBe(true);
+  });
+
+  it('異なる MediaId では同一判定されない', () => {
+    // arrange
+    const favorite1 = new Favorite(new MediaId('media1'));
+    const favorite2 = new Favorite(new MediaId('media2'));
+
+    // act
+    const actual = favorite1.equals(favorite2);
+
+    // assert
+    expect(actual).toBe(false);
+  });
+});

--- a/__tests__/small/domain/user/queue.test.js
+++ b/__tests__/small/domain/user/queue.test.js
@@ -1,0 +1,53 @@
+const Queue = require('../../../../src/domain/user/queue');
+const MediaId = require('../../../../src/domain/media/mediaId');
+
+describe('[Domain][Value Object][Queue]', () => {
+  it('有効な MediaId で生成できる', () => {
+    // arrange
+    const mediaId = new MediaId('media');
+
+    // act
+    const queue = new Queue(mediaId);
+
+    // assert
+    expect(queue).toBeInstanceOf(Queue);
+    expect(queue.getMediaId()).toBe(mediaId);
+  });
+
+  it('MediaId 以外を渡すと例外になる', () => {
+    // arrange
+    const mediaId = null;
+
+    // act
+    // assert
+    expect(() => {
+      new Queue(mediaId);
+    }).toThrow();
+  });
+
+  it('同じ MediaId を持つインスタンス同士が equals で同一判定される', () => {
+    // arrange
+    const mediaId1 = new MediaId('media');
+    const mediaId2 = new MediaId('media');
+    const queue1 = new Queue(mediaId1);
+    const queue2 = new Queue(mediaId2);
+
+    // act
+    const actual = queue1.equals(queue2);
+
+    // assert
+    expect(actual).toBe(true);
+  });
+
+  it('異なる MediaId では同一判定されない', () => {
+    // arrange
+    const queue1 = new Queue(new MediaId('media1'));
+    const queue2 = new Queue(new MediaId('media2'));
+
+    // act
+    const actual = queue1.equals(queue2);
+
+    // assert
+    expect(actual).toBe(false);
+  });
+});


### PR DESCRIPTION
### Motivation
- `Favorite` と `Queue` の振る舞い（生成条件と同一性判定）を、aggregate 経由の間接確認に依存せず仕様書どおりに明示的に担保するために単体テストを追加する必要があった。 

### Description
- `__tests__/small/domain/user/favorite.test.js` を追加し、有効な `MediaId` で生成できること、`MediaId` 以外で例外になること、同一/非同一の `equals` 判定を検証するケースを実装した。 
- `__tests__/small/domain/user/queue.test.js` を追加し、`Queue` に対して上記と同等の単体検証を実装した。 
- 既存の実装やドキュメント（`doc/2_domain/aggregates/user/tests/*.md`）の記載どおりの振る舞いを確認するテストであり、本番コードの修正は行っていない。 

### Testing
- `npm test -- --runTestsByPath __tests__/small/domain/user/favorite.test.js __tests__/small/domain/user/queue.test.js` を試行したが、環境で `jest` が見つからず実行できなかった。 
- `npm install --save-dev jest@^28.1.0` による補完インストールはレジストリアクセスで `403 Forbidden` が返り失敗したため実行不可だった。 
- 追加テストと同等の検証を行う `node` スクリプトで生成・例外・`equals` 判定の各ケースを直接実行して確認し、期待どおり（成功）であることを確認した。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0af3175a8832b92ebe721de3953d2)