### PR TITLE
docs: doc/7_infrastructure に未文書化インフラ実装の設計書とテストケースを追加・命名差異を統一

### DIFF
--- a/__tests__/small/infrastructure/SessionStateAuthAdapter.test.js
+++ b/__tests__/small/infrastructure/SessionStateAuthAdapter.test.js
@@ -5,11 +5,11 @@ describe('SessionStateAuthAdapter', () => {
     const sessionStateStore = {
       findUserIdBySessionToken: jest.fn().mockReturnValue('u1'),
     };
-    const resolver = new SessionStateAuthAdapter({
+    const adapter = new SessionStateAuthAdapter({
       sessionStateStore,
     });
 
-    await expect(resolver.execute('token-1')).resolves.toBe('u1');
+    await expect(adapter.execute('token-1')).resolves.toBe('u1');
     expect(sessionStateStore.findUserIdBySessionToken).toHaveBeenCalledWith('token-1');
   });
 

--- a/doc/7_infrastructure/InMemorySessionStateStore/readme.md
+++ b/doc/7_infrastructure/InMemorySessionStateStore/readme.md
@@ -1,0 +1,37 @@
+# InMemorySessionStateStore 設計書
+
+## 概要
+`InMemorySessionStateStore` は、セッショントークンとユーザーIDの対応をプロセス内メモリに保持するインフラ実装です。  
+ログイン時に発行した `sessionToken` を保存し、認証時には `sessionToken` から `userId` を逆引きします。  
+有効期限は TTL ミリ秒単位で管理し、参照時または明示的な purge 実行時に期限切れデータを削除します。
+
+## クラス
+- 配置: `src/infrastructure/InMemorySessionStateStore.js`
+- クラス名: `InMemorySessionStateStore`
+
+## 公開メソッド
+- `save({ sessionToken, userId, ttlMs })`
+  - セッション状態をメモリ上へ保存する
+  - `expiresAt = clock() + ttlMs` を計算して保持する
+  - 保存結果として `{ sessionToken, userId, expiresAt }` を返す
+- `findUserIdBySessionToken(sessionToken)`
+  - 期限切れセッションを purge したうえで、対応する `userId` を返す
+  - 未登録または期限切れの場合は `undefined` を返す
+- `delete(sessionToken)`
+  - 指定トークンの状態を削除し、`Map#delete` の結果を返す
+- `purgeExpired()`
+  - 現在時刻以前に失効したセッションを一括削除する
+
+## 状態管理方針
+- 内部ストレージは `Map<sessionToken, { userId, expiresAt }>` を用いる
+- `clock` はテスト容易性のため差し替え可能で、既定値は `Date.now()` である
+- `findUserIdBySessionToken` 実行時に自動 purge するため、失効データは参照を契機に自然に除去される
+
+## バリデーション方針
+- `sessionToken` は空文字でない文字列を必須とする
+- `userId` は空文字でない文字列を必須とする
+- `ttlMs` は 1 以上の整数を必須とする
+
+## エラー方針
+- 入力バリデーション違反は `Error` を送出する
+- 永続化先がメモリのみのため、I/O 起因の回復処理は持たない

--- a/doc/7_infrastructure/InMemorySessionStateStore/testcase.md
+++ b/doc/7_infrastructure/InMemorySessionStateStore/testcase.md
@@ -1,0 +1,54 @@
+# InMemorySessionStateStore テストケース
+
+## テストケース一覧
+- [save したセッショントークンから userId を取得できる](#save-したセッショントークンから-userid-を取得できる)
+- [TTL を過ぎたセッションは取得時に自動削除される](#ttl-を過ぎたセッションは取得時に自動削除される)
+- [delete は対象セッションを削除できる](#delete-は対象セッションを削除できる)
+- [purgeExpired は期限切れセッションのみ削除する](#purgeexpired-は期限切れセッションのみ削除する)
+- [save の入力が不正な場合は例外となる](#save-の入力が不正な場合は例外となる)
+
+---
+
+### save したセッショントークンから userId を取得できる
+- 前提
+  - 空でない `sessionToken` / `userId` と正の `ttlMs` がある
+- 操作
+  - `save` 実行後に `findUserIdBySessionToken(sessionToken)` を呼ぶ
+- 期待結果
+  - 保存した `userId` を取得できる
+
+### TTL を過ぎたセッションは取得時に自動削除される
+- 前提
+  - TTL 付きセッションが保存済みである
+  - `clock` を進めて有効期限に到達または超過させる
+- 操作
+  - `findUserIdBySessionToken(sessionToken)` を呼ぶ
+- 期待結果
+  - `undefined` が返る
+  - 対象セッションは内部ストアから削除される
+
+### delete は対象セッションを削除できる
+- 前提
+  - セッションが保存済みである
+- 操作
+  - `delete(sessionToken)` を実行する
+- 期待結果
+  - `true` が返る
+  - 以後 `findUserIdBySessionToken(sessionToken)` は `undefined` を返す
+
+### purgeExpired は期限切れセッションのみ削除する
+- 前提
+  - 期限切れになるセッションと、まだ有効なセッションが混在して保存されている
+- 操作
+  - 時刻を進めたあと `purgeExpired()` を実行する
+- 期待結果
+  - 期限切れセッションのみ削除される
+  - 有効期限内セッションは保持される
+
+### save の入力が不正な場合は例外となる
+- 前提
+  - ストアが生成済みである
+- 操作
+  - `sessionToken` 空文字、`userId` 空文字、`ttlMs` 0 以下など不正値で `save` を実行する
+- 期待結果
+  - `Error` が送出される

--- a/doc/7_infrastructure/MulterDiskStorageContentUploadAdapter/readme.md
+++ b/doc/7_infrastructure/MulterDiskStorageContentUploadAdapter/readme.md
@@ -1,0 +1,38 @@
+# MulterDiskStorageContentUploadAdapter 設計書
+
+## 概要
+`MulterDiskStorageContentUploadAdapter` は、multipart/form-data で送信されたメディアコンテンツをディスクへ保存し、アプリケーションで扱う `contentId` 配列へ変換するアダプターです。  
+既存コンテンツ参照と新規アップロードを同一リクエストで扱い、`position` 順に並べ替えた `contentIds` を `req.context` へ格納します。
+
+## クラス
+- 配置: `src/infrastructure/MulterDiskStorageContentUploadAdapter.js`
+- クラス名: `MulterDiskStorageContentUploadAdapter`
+- 継承: `IContentUploadAdapter`
+
+## 公開メソッド
+- `constructor({ rootDirectory })`
+  - 保存先ルートディレクトリを受け取る
+  - 内部で `multer.diskStorage(...).any()` を構成する
+- `execute(req, res, cb)`
+  - Multer で受信したファイルを保存する
+  - `req.body.contents` と `req.files` を突き合わせて `req.context.contentIds` を構築する
+  - 成功時は `cb()`、失敗時は `cb(error)` を呼ぶ
+
+## 保存方針
+- 新規ファイルの `contentId` は UUID 由来 32 文字小文字16進数で生成する
+- 保存パスは `rootDirectory/aa/bb/cc/dd/<contentId>` 形式で分散配置する
+- 既存パスと衝突した場合は `contentId` を再生成する
+- リクエスト上は `contents[n][position]` と `contents[n][file]` / `contents[n][url]` を組み合わせる
+- 返却する `contentIds` は `position` 昇順に並び替える
+
+## バリデーション方針
+- `rootDirectory` は空文字でない文字列を必須とする
+- `contents` は 1 件以上を必須とする
+- 各 content は `position >= 1` の整数を持つ
+- 1 件の content では「新規ファイル」または「既存 `contentId`」のどちらか一方のみ指定可能とする
+- 既存 `contentId` と生成済み `contentId` は 32 文字小文字16進数でなければならない
+- `position` 重複、`contents[n][file]` 以外の fieldname、同一 index への複数ファイルはエラーとする
+
+## エラー方針
+- Multer 保存中の例外は `cb(error)` へ伝える
+- リクエスト整形エラーは `execute` 内で補足し `cb(processingError)` へ渡す

--- a/doc/7_infrastructure/MulterDiskStorageContentUploadAdapter/testcase.md
+++ b/doc/7_infrastructure/MulterDiskStorageContentUploadAdapter/testcase.md
@@ -1,0 +1,44 @@
+# MulterDiskStorageContentUploadAdapter テストケース
+
+## テストケース一覧
+- [rootDirectory が不正な場合は初期化時に例外となる](#rootdirectory-が不正な場合は初期化時に例外となる)
+- [新規ファイルと既存contentIdをposition順に処理し、新規ファイルを分割パスへ保存できる](#新規ファイルと既存contentidをposition順に処理し新規ファイルを分割パスへ保存できる)
+- [保存先パスが衝突した場合はcontentIdを再生成して保存する](#保存先パスが衝突した場合はcontentidを再生成して保存する)
+- [不正な multipart 入力の場合は cb(error) 相当の失敗レスポンスを返す](#不正な-multipart-入力の場合は-cberror-相当の失敗レスポンスを返す)
+
+---
+
+### rootDirectory が不正な場合は初期化時に例外となる
+- 前提
+  - なし
+- 操作
+  - `undefined` / `null` / 空文字の `rootDirectory` で生成する
+- 期待結果
+  - コンストラクタで `Error` が送出される
+
+### 新規ファイルと既存contentIdをposition順に処理し、新規ファイルを分割パスへ保存できる
+- 前提
+  - 一時ディレクトリを保存先に使える
+- 操作
+  - 既存 `url` と新規 `file` を混在させて `/api/media` 相当の multipart リクエストを送る
+- 期待結果
+  - `contentIds` が `position` 順で返る
+  - 新規ファイルには 32 文字小文字16進数 `contentId` が採番される
+  - ファイルは分割ディレクトリ配下へ保存される
+
+### 保存先パスが衝突した場合はcontentIdを再生成して保存する
+- 前提
+  - 生成候補の `contentId` に対応するファイルが既に存在する
+- 操作
+  - 新規ファイルアップロードを実行する
+- 期待結果
+  - 既存ファイルは上書きされない
+  - 別の `contentId` が再生成され、そのパスへ保存される
+
+### 不正な multipart 入力の場合は cb(error) 相当の失敗レスポンスを返す
+- 前提
+  - Web アプリ経由でアダプターを呼び出せる
+- 操作
+  - `position` 欠落、`file` と `url` の両方指定、両方欠落、無効な `contentId`、`position` 重複、不正 fieldname などでリクエストする
+- 期待結果
+  - `cb(error)` 相当の分岐へ入り、失敗レスポンスが返る

--- a/doc/7_infrastructure/SequelizeMediaQueryRepository/readme.md
+++ b/doc/7_infrastructure/SequelizeMediaQueryRepository/readme.md
@@ -1,0 +1,40 @@
+# SequelizeMediaQueryRepository 設計書
+
+## 概要
+`SequelizeMediaQueryRepository` は、メディア一覧・検索画面向けの読み取り専用クエリーを Sequelize で実装したリポジトリです。  
+タイトル条件、タグ条件、ソート条件、ページング条件をもとにメディアIDを絞り込み、サムネイル・タグ・優先カテゴリーを含む `SearchResult` を構築します。
+
+## クラス
+- 配置: `src/infrastructure/SequelizeMediaQueryRepository.js`
+- クラス名: `SequelizeMediaQueryRepository`
+- 継承: `IMediaQueryRepository`
+
+## 公開メソッド
+- `search(condition)`
+  - `SearchCondition` に基づいて検索結果と総件数を返す
+  - 絞り込み -> ページング -> 概要復元の順で処理する
+- `findOverviewsByMediaIds(mediaIds)`
+  - 指定メディアID配列から `MediaOverview[]` を構築する
+  - 空配列なら空配列を返す
+
+## 検索方針
+- タイトル条件は `media.title LIKE %title%` で部分一致検索する
+- タグ条件は `category` と `tag` を順に解決し、各タグ条件を満たす `media_id` に絞り込む
+- `totalCount` は条件一致した全メディア件数で、ページング前の件数を返す
+- ページングは `start` / `size` を使って `offset` / `limit` に変換する
+- ソートは `SortType` ごとにタイトル順・擬似作成順・ランダム順を切り替える
+
+## 概要復元方針
+- 先頭 `content` をサムネイルとして採用する
+- タグは `MediaOverviewTag` に変換し、`priorityCategories` を優先した順序で並べ替える
+- `priorityCategories` にないタグはカテゴリ名・ラベル名のロケール比較で整列する
+- `findOverviewsByMediaIds` の返却順は、引数 `mediaIds` の順序を維持する
+
+## バリデーション方針
+- `constructor` は `sequelize.random` を持つ Sequelize 互換オブジェクトを必須とする
+- `search` は `SearchCondition` インスタンスのみ受け付ける
+- `findOverviewsByMediaIds` は文字列または Sequelize row から `media_id` を抽出できる配列のみ受け付ける
+
+## エラー方針
+- 入力バリデーション違反は `Error` を送出する
+- Sequelize クエリー失敗は握り潰さず上位へ伝播する

--- a/doc/7_infrastructure/SequelizeMediaQueryRepository/testcase.md
+++ b/doc/7_infrastructure/SequelizeMediaQueryRepository/testcase.md
@@ -1,0 +1,17 @@
+# SequelizeMediaQueryRepository テストケース
+
+## テストケース一覧
+- [search は一覧表示に必要な概要情報と totalCount を返す](#search-は一覧表示に必要な概要情報と-totalcount-を返す)
+
+---
+
+### search は一覧表示に必要な概要情報と totalCount を返す
+- 前提
+  - `SequelizeMediaRepository` 経由で複数メディアが保存済みである
+  - タイトル・タグ・優先カテゴリー・コンテンツ順が検索に使える状態である
+- 操作
+  - タイトル条件、タグ条件、ソート条件、ページング条件を含む `SearchCondition` で `search` を実行する
+- 期待結果
+  - 条件一致件数が `totalCount` に反映される
+  - 返却される `mediaOverviews` に `mediaId` / `title` / `thumbnail` / `priorityCategories` / `tags` が含まれる
+  - サムネイルは先頭コンテンツ、タグ順は優先カテゴリー順に整列される

--- a/doc/7_infrastructure/SequelizeUserRepository/readme.md
+++ b/doc/7_infrastructure/SequelizeUserRepository/readme.md
@@ -1,0 +1,39 @@
+# SequelizeUserRepository 設計書
+
+## 概要
+`SequelizeUserRepository` は、`User` 集約の favorite / queue 状態を RDB に永続化する Sequelize 実装です。  
+`user` テーブルを基点に、`favorite` と `queue` の中間テーブルへ現在状態を全置換で保存し、`findByUserId` で集約を再構築します。
+
+## クラス
+- 配置: `src/infrastructure/SequelizeUserRepository.js`
+- クラス名: `SequelizeUserRepository`
+- 継承: `IUserRepository`
+
+## 公開メソッド
+- `sync()`
+  - テスト用補助として Sequelize モデルを同期する
+- `save(user)`
+  - `User` 集約を `user` / `favorite` / `queue` へ保存する
+  - 既存 favorite / queue を削除して現状態で再作成する
+- `findByUserId(userId)`
+  - 指定ユーザーの favorite / queue を読み出して `User` 集約を復元する
+  - ユーザー未登録時も空状態の `User` を返す
+
+## 永続化方針
+- `save` は `unitOfWorkContext.getCurrent()` が返す実行文脈トランザクションへ参加する
+- `user` 行は `upsert` で作成または更新する
+- `favorite` / `queue` は毎回 `destroy` 後に `bulkCreate` し、重複のない現在状態へ置き換える
+
+## 復元方針
+- `findByUserId` は `favorites` / `queueItems` を include して取得する
+- 取得結果から `MediaId` を再生成し、`User` 集約へ `addFavorite` / `addQueue` で復元する
+- `user` 行が存在しない場合は、指定 `userId` を持つ空の `User` を返して上位の操作継続を容易にする
+
+## バリデーション方針
+- `constructor` は `sequelize.transaction` と `unitOfWorkContext.getCurrent` を必須とする
+- `save` は `User` インスタンスのみ受け付ける
+- `findByUserId` は `UserId` インスタンスのみ受け付ける
+
+## エラー方針
+- 入力バリデーション違反は `Error` を送出する
+- Sequelize 由来の例外は上位へ伝播する

--- a/doc/7_infrastructure/SequelizeUserRepository/testcase.md
+++ b/doc/7_infrastructure/SequelizeUserRepository/testcase.md
@@ -1,0 +1,17 @@
+# SequelizeUserRepository テストケース
+
+## テストケース一覧
+- [save / findByUserId で favorite と queue を永続化できる](#save--findbyuserid-で-favorite-と-queue-を永続化できる)
+
+---
+
+### save / findByUserId で favorite と queue を永続化できる
+- 前提
+  - `SequelizeUserRepository` が初期化済みである
+  - favorite / queue を持つ `User` 集約がある
+- 操作
+  - `save(user)` 実行後に `findByUserId(userId)` を呼ぶ
+- 期待結果
+  - favorite 一覧が保存順どおり復元される
+  - queue 一覧が保存され復元される
+  - 取得結果は `User` 集約として利用できる

--- a/doc/7_infrastructure/SessionStateAuthAdapter/readme.md
+++ b/doc/7_infrastructure/SessionStateAuthAdapter/readme.md
@@ -1,0 +1,30 @@
+# SessionStateAuthAdapter 設計書
+
+## 概要
+`SessionStateAuthAdapter` は、セッショントークンからユーザーIDを解決する認証アダプターです。  
+コントローラーやルーターで取得した `sessionToken` をセッション状態ストアへ委譲し、認証済みユーザーの識別子を返します。
+
+## 命名の統一方針
+- 実装クラス名: `SessionStateAuthAdapter`
+- 実装ファイル名: `src/infrastructure/SessionStateAuthAdapter.js`
+- 設計書ディレクトリ名: `doc/7_infrastructure/SessionStateAuthAdapter/`
+- small テストファイル名: `__tests__/small/infrastructure/SessionStateAuthAdapter.test.js`
+
+`execute` の責務は「認証判定そのもの」ではなく「セッション状態ストアを使う認証アダプター」であるため、`Resolver` ではなく既存実装と一致する `Adapter` を正とする。
+
+## クラス
+- 配置: `src/infrastructure/SessionStateAuthAdapter.js`
+- クラス名: `SessionStateAuthAdapter`
+
+## 公開メソッド
+- `execute(sessionToken)`
+  - `sessionStateStore.findUserIdBySessionToken(sessionToken)` を呼び出す
+  - 取得できた `userId`、または未登録時の `undefined` を返す
+
+## 依存関係
+- `sessionStateStore.findUserIdBySessionToken` を必須とする
+- セッション状態の保存方式はストア実装に委譲する
+
+## エラー方針
+- `sessionStateStore.findUserIdBySessionToken` を持たない依存はコンストラクタで `Error` を送出する
+- `execute` 内ではストアの例外を握り潰さず上位へ伝播する

--- a/doc/7_infrastructure/SessionStateAuthAdapter/testcase.md
+++ b/doc/7_infrastructure/SessionStateAuthAdapter/testcase.md
@@ -1,0 +1,24 @@
+# SessionStateAuthAdapter テストケース
+
+## テストケース一覧
+- [execute は sessionToken に紐づく userId を返す](#execute-は-sessiontoken-に紐づく-userid-を返す)
+- [sessionStateStore が不正な場合は初期化時に例外となる](#sessionstatestore-が不正な場合は初期化時に例外となる)
+
+---
+
+### execute は sessionToken に紐づく userId を返す
+- 前提
+  - `sessionStateStore.findUserIdBySessionToken` が `userId` を返す
+- 操作
+  - `execute(sessionToken)` を実行する
+- 期待結果
+  - ストアへ `sessionToken` が渡される
+  - 対応する `userId` で resolve する
+
+### sessionStateStore が不正な場合は初期化時に例外となる
+- 前提
+  - なし
+- 操作
+  - `findUserIdBySessionToken` を持たない `sessionStateStore` で生成する
+- 期待結果
+  - コンストラクタで `Error` が送出される

--- a/doc/7_infrastructure/SessionStateRegistrar/readme.md
+++ b/doc/7_infrastructure/SessionStateRegistrar/readme.md
@@ -1,0 +1,32 @@
+# SessionStateRegistrar 設計書
+
+## 概要
+`SessionStateRegistrar` は、ログイン成功後にセッションIDを再生成し、新しいセッショントークンを状態ストアへ登録するアダプターです。  
+セッション固定攻撃を避けるため `session.regenerate` を完了させてからトークンを保存し、最終的に有効な `session` オブジェクトへ `session_token` を設定します。
+
+## クラス
+- 配置: `src/infrastructure/SessionStateRegistrar.js`
+- クラス名: `SessionStateRegistrar`
+
+## 公開メソッド
+- `execute({ session, userId, ttlMs })`
+  - `session.regenerate` によりセッションを再生成する
+  - `sessionTokenGenerator` で新しいトークンを採番する
+  - `sessionStateStore.save` に `{ sessionToken, userId, ttlMs }` を保存する
+  - アクティブな `session` に `session_token` を設定し、ストアの戻り値を返す
+
+## 登録方針
+- トークンは既定で `crypto.randomUUID()` 由来の 32 文字英数字相当値をハイフン除去して生成する
+- `session.regenerate` 完了前にはストア保存も `session_token` 更新も行わない
+- `session.req.session` が差し替えられていれば、それを再生成後のアクティブセッションとして採用する
+- ストア保存成功後にのみ `activeSession.session_token` を更新する
+
+## 依存関係
+- `sessionStateStore.save` を持つこと
+- `sessionTokenGenerator` は非空文字列トークンを返す関数であること
+- `session.regenerate(callback)` は `express-session` 互換APIであること
+
+## エラー方針
+- `session` / `userId` / `sessionTokenGenerator` / `sessionStateStore` の不正は `Error` を送出する
+- `session.regenerate` 失敗時はストア保存も `session_token` 更新も行わずに reject する
+- `sessionStateStore.save` の失敗はそのまま上位へ伝播し、`session_token` は更新しない

--- a/doc/7_infrastructure/SessionStateRegistrar/testcase.md
+++ b/doc/7_infrastructure/SessionStateRegistrar/testcase.md
@@ -1,0 +1,78 @@
+# SessionStateRegistrar テストケース
+
+## テストケース一覧
+- [ログイン成功時にセッションIDをローテーションして session へ session_token を保存しストア登録できる](#ログイン成功時にセッションidをローテーションして-session-へ-session_token-を保存しストア登録できる)
+- [execute の入力が不正な場合は例外となる](#execute-の入力が不正な場合は例外となる)
+- [sessionTokenGenerator が空文字を返す場合は例外となる](#sessiontokengenerator-が空文字を返す場合は例外となる)
+- [セッション再生成の完了後にストア保存と session_token 更新を行う](#セッション再生成の完了後にストア保存と-session_token-更新を行う)
+- [express-session のように regenerate 後に req.session が差し替わる場合は新しい session に session_token を保存する](#express-session-のように-regenerate-後に-reqsession-が差し替わる場合は新しい-session-に-session_token-を保存する)
+- [セッション再生成が失敗した場合はストア保存と session_token 更新を行わない](#セッション再生成が失敗した場合はストア保存と-session_token-更新を行わない)
+- [非同期ストア保存が失敗した場合は session_token を更新しない](#非同期ストア保存が失敗した場合は-session_token-を更新しない)
+
+---
+
+### ログイン成功時にセッションIDをローテーションして session へ session_token を保存しストア登録できる
+- 前提
+  - `sessionStateStore.save` が成功する
+  - `sessionTokenGenerator` が有効なトークンを返す
+- 操作
+  - `execute({ session, userId, ttlMs })` を実行する
+- 期待結果
+  - `session.regenerate` が呼ばれる
+  - ストアに `sessionToken` / `userId` / `ttlMs` が保存される
+  - `session.session_token` が更新される
+  - ストアの戻り値がそのまま返る
+
+### execute の入力が不正な場合は例外となる
+- 前提
+  - Registrar が生成済みである
+- 操作
+  - `session` が `null`、`session.regenerate` 欠落、`userId` 空文字などで `execute` を実行する
+- 期待結果
+  - `Error` で reject する
+
+### sessionTokenGenerator が空文字を返す場合は例外となる
+- 前提
+  - `sessionTokenGenerator` が空文字を返す設定である
+- 操作
+  - `execute({ session, userId, ttlMs })` を実行する
+- 期待結果
+  - `sessionToken must be a non-empty string` で reject する
+
+### セッション再生成の完了後にストア保存と session_token 更新を行う
+- 前提
+  - `session.regenerate` が非同期完了する
+- 操作
+  - `execute` 開始後、`regenerate` のコールバックを遅延実行する
+- 期待結果
+  - `regenerate` 完了前はストア保存も `session_token` 更新も行われない
+  - 完了後に保存と更新が行われる
+
+### express-session のように regenerate 後に req.session が差し替わる場合は新しい session に session_token を保存する
+- 前提
+  - `session.req.session` が `regenerate` 完了前後で新しいオブジェクトへ差し替わる
+- 操作
+  - `execute` を実行し、差し替え後に regenerate を完了させる
+- 期待結果
+  - 新しい `req.session` 側へ `session_token` が保存される
+  - 元の `session` には `session_token` が保存されない
+
+### セッション再生成が失敗した場合はストア保存と session_token 更新を行わない
+- 前提
+  - `session.regenerate` がエラーを返す
+- 操作
+  - `execute({ session, userId, ttlMs })` を実行する
+- 期待結果
+  - Promise が reject する
+  - `sessionStateStore.save` は呼ばれない
+  - `session_token` は更新されない
+
+### 非同期ストア保存が失敗した場合は session_token を更新しない
+- 前提
+  - `session.regenerate` は成功する
+  - `sessionStateStore.save` が reject する
+- 操作
+  - `execute({ session, userId, ttlMs })` を実行する
+- 期待結果
+  - Promise が reject する
+  - `session_token` は更新されない

--- a/doc/7_infrastructure/SessionTerminator/readme.md
+++ b/doc/7_infrastructure/SessionTerminator/readme.md
@@ -1,0 +1,29 @@
+# SessionTerminator 設計書
+
+## 概要
+`SessionTerminator` は、ログアウト時にセッション状態ストアと `express-session` の両方を終了させるアダプターです。  
+保持中の `session.session_token` を無効化してから `session.destroy` を呼び出し、セッションの論理状態と実体を整合的に破棄します。
+
+## クラス
+- 配置: `src/infrastructure/SessionTerminator.js`
+- クラス名: `SessionTerminator`
+
+## 公開メソッド
+- `execute({ session })`
+  - `session.session_token` を取得してセッション状態ストアから削除する
+  - ストア削除成功時のみ `session.destroy` を await する
+  - 正常終了時は `true`、トークン不正またはストア削除失敗時は `false` を返す
+
+## 終了方針
+- `sessionStateStore.delete(sessionToken)` が `true` を返した場合のみ `session.destroy` を実行する
+- `session.session_token` が存在しない、または空文字の場合はセッション破棄処理を進めず `false` を返す
+- `session.destroy` はコールバックAPIを Promise 化して扱う
+
+## 依存関係
+- `sessionStateStore.delete` を持つオブジェクトを受け取る
+- `session.destroy` は `express-session` 互換のコールバック形式を想定する
+
+## エラー方針
+- `sessionStateStore.delete` を持たない依存はコンストラクタで `Error` を送出する
+- `session` がオブジェクトでない場合は `Error` を送出する
+- `session.destroy` が存在しない、または `session.destroy` 自体が失敗した場合は reject する

--- a/doc/7_infrastructure/SessionTerminator/testcase.md
+++ b/doc/7_infrastructure/SessionTerminator/testcase.md
@@ -1,0 +1,38 @@
+# SessionTerminator テストケース
+
+## テストケース一覧
+- [session_token を無効化して session.destroy を呼ぶ](#session_token-を無効化して-sessiondestroy-を呼ぶ)
+- [ストア削除に失敗した場合は false を返して session.destroy を呼ばない](#ストア削除に失敗した場合は-false-を返して-sessiondestroy-を呼ばない)
+- [session.destroy が失敗した場合は reject する](#sessiondestroy-が失敗した場合は-reject-する)
+
+---
+
+### session_token を無効化して session.destroy を呼ぶ
+- 前提
+  - `session.session_token` が存在する
+  - `sessionStateStore.delete` が `true` を返す
+- 操作
+  - `execute({ session })` を実行する
+- 期待結果
+  - `sessionStateStore.delete(sessionToken)` が呼ばれる
+  - `session.destroy` が 1 回呼ばれる
+  - `true` で resolve する
+
+### ストア削除に失敗した場合は false を返して session.destroy を呼ばない
+- 前提
+  - `session.session_token` が存在する
+  - `sessionStateStore.delete` が `false` を返す
+- 操作
+  - `execute({ session })` を実行する
+- 期待結果
+  - `false` で resolve する
+  - `session.destroy` は呼ばれない
+
+### session.destroy が失敗した場合は reject する
+- 前提
+  - `sessionStateStore.delete` が `true` を返す
+  - `session.destroy` がエラー付きコールバックを返す
+- 操作
+  - `execute({ session })` を実行する
+- 期待結果
+  - Promise が `Error` で reject する


### PR DESCRIPTION
### Motivation
- インフラ層のいくつかの実装が設計書未整備で参照コストが高かったため、責務・依存・バリデーション・エラー方針とテスト観点を明文化する目的で追加しました。 
- `SessionStateAuthAdapter` とテストで使われていた `SessionStateAuthResolver` の命名差異が混在していたため、実装に合わせて命名を統一し参照整合性を高めます。

### Description
- `doc/7_infrastructure/` 以下に各実装ごとの `readme.md` と `testcase.md` を追加しました：`MulterDiskStorageContentUploadAdapter`、`SequelizeMediaQueryRepository`、`SequelizeUserRepository`、`InMemorySessionStateStore`、`SessionStateRegistrar`、`SessionTerminator`、`SessionStateAuthAdapter`。 
- 各 readme はクラス配置・公開メソッド・バリデーション・永続化/復元方針・エラー方針を記載し、testcase は既存 small/medium テストで検証している正常系・永続化・エラー系の観点を反映しています。 
- small テストファイルの命名を `__tests__/small/infrastructure/SessionStateAuthResolver.test.js` から `__tests__/small/infrastructure/SessionStateAuthAdapter.test.js` にリネームし、テスト内の変数名も `resolver`→`adapter` に修正して実装名と一致させました。 
- 追加/変更はコミット済みで、ドキュメント群は該当ディレクトリへ新規作成されています。

### Testing
- 変更後に該当する small/medium テスト群を指定して `npm test` を実行しようとしましたが、実行環境に `jest` がインストールされておらずテストは実行できませんでした（`sh: 1: jest: not found`）。 
- ファイル操作・リネーム・ドキュメント追加はローカルリポジトリ上で `git` によりステージ・コミットされておりコミットは成功しています。 
- 実際の自動テスト（Jest）実行は環境に jest を導入のうえ再実行してください。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0c600d0b4832b97e391e1b74b3e04)