### PR TITLE
feat: あとで見る一覧画面のルートと描画を追加する

### DIFF
--- a/__tests__/medium/controller/router/screen/setRouterScreenQueueGet.test.js
+++ b/__tests__/medium/controller/router/screen/setRouterScreenQueueGet.test.js
@@ -1,0 +1,109 @@
+const express = require('express');
+const path = require('path');
+
+const setRouterScreenQueueGet = require('../../../../../src/controller/router/screen/setRouterScreenQueueGet');
+const SessionStateAuthAdapter = require('../../../../../src/infrastructure/SessionStateAuthAdapter');
+
+class InMemorySessionStateStore {
+  constructor(entries = []) {
+    this.tokenToUserId = new Map(entries);
+  }
+
+  findUserIdBySessionToken(sessionToken) {
+    return this.tokenToUserId.get(sessionToken) ?? null;
+  }
+}
+
+const requestApp = async ({ app, method, targetPath, headers = {} } = {}) => {
+  const server = app.listen(0);
+
+  try {
+    await new Promise((resolve, reject) => {
+      server.once('listening', resolve);
+      server.once('error', reject);
+    });
+
+    const address = server.address();
+    const response = await fetch(`http://127.0.0.1:${address.port}${targetPath}`, {
+      method,
+      headers,
+    });
+
+    return {
+      status: response.status,
+      headers: response.headers,
+      bodyText: await response.text(),
+    };
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close(error => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    });
+  }
+};
+
+describe('setRouterScreenQueueGet (middle)', () => {
+  const createApp = () => {
+    const app = express();
+    const router = express.Router();
+
+    app.set('views', path.join(process.cwd(), 'src', 'views'));
+    app.set('view engine', 'ejs');
+    app.engine('ejs', (filePath, options, callback) => {
+      callback(
+        null,
+        `<!DOCTYPE html><html lang="ja"><head><title>${options.pageTitle}</title></head><body>${filePath}:${options.mediaOverviews.length}</body></html>`
+      );
+    });
+
+    app.use((req, _res, next) => {
+      req.session = {
+        session_token: req.header('x-session-token'),
+      };
+      req.context = {};
+      next();
+    });
+
+    setRouterScreenQueueGet({
+      router,
+      authResolver: new SessionStateAuthAdapter({
+        sessionStateStore: new InMemorySessionStateStore([
+          ['valid-token', 'user-001'],
+        ]),
+      }),
+      getQueueService: {
+        execute: jest.fn().mockResolvedValue({
+          mediaOverviews: [{ mediaId: 'media-001', title: 'タイトル1', thumbnail: '', tags: [], priorityCategories: [] }],
+        }),
+      },
+    });
+
+    app.use(router);
+    return app;
+  };
+
+  test('GET /screen/queue で HTML を返す', async () => {
+    const app = createApp();
+
+    const response = await requestApp({
+      app,
+      method: 'GET',
+      targetPath: '/screen/queue',
+      headers: {
+        'x-session-token': 'valid-token',
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toContain('text/html');
+    expect(response.bodyText).toContain('<!DOCTYPE html>');
+    expect(response.bodyText).toContain('<title>あとで見る一覧</title>');
+    expect(response.bodyText).toContain(path.join('src', 'views', 'screen', 'queue.ejs'));
+    expect(response.bodyText).toContain(':1');
+  });
+});

--- a/__tests__/small/controller/router/screen/setRouterScreenQueueGet.test.js
+++ b/__tests__/small/controller/router/screen/setRouterScreenQueueGet.test.js
@@ -1,0 +1,66 @@
+const express = require('express');
+const path = require('path');
+
+const setRouterScreenQueueGet = require('../../../../../src/controller/router/screen/setRouterScreenQueueGet');
+const SessionStateAuthAdapter = require('../../../../../src/infrastructure/SessionStateAuthAdapter');
+const { Output } = require('../../../../../src/application/user/query/GetQueueService');
+
+class InMemorySessionStateStore {
+  constructor(entries = []) {
+    this.tokenToUserId = new Map(entries);
+  }
+  findUserIdBySessionToken(sessionToken) {
+    return this.tokenToUserId.get(sessionToken) ?? null;
+  }
+}
+
+describe('setRouterScreenQueueGet', () => {
+  test('GET /screen/queue であとで見る一覧HTMLを返す', async () => {
+    const app = express();
+    const router = express.Router();
+    const getQueueService = {
+      execute: jest.fn().mockResolvedValue(new Output({
+        mediaOverviews: [{
+          mediaId: 'media-001',
+          title: 'タイトル1',
+          thumbnail: '/contents/1.jpg',
+          tags: [{ category: '作者', label: '山田' }],
+          priorityCategories: ['作者'],
+        }],
+      })),
+    };
+
+    app.set('views', path.join(process.cwd(), 'src', 'views'));
+    app.set('view engine', 'ejs');
+    app.use((req, _res, next) => {
+      req.session = { session_token: req.header('x-session-token') };
+      req.context = {};
+      next();
+    });
+
+    setRouterScreenQueueGet({
+      router,
+      authResolver: new SessionStateAuthAdapter({
+        sessionStateStore: new InMemorySessionStateStore([['valid-token', 'user-001']]),
+      }),
+      getQueueService,
+    });
+    app.use(router);
+
+    const server = app.listen(0);
+    await new Promise(resolve => server.once('listening', resolve));
+    const { port } = server.address();
+    const response = await fetch(`http://127.0.0.1:${port}/screen/queue`, {
+      headers: { 'x-session-token': 'valid-token' },
+    });
+    const bodyText = await response.text();
+    await new Promise(resolve => server.close(resolve));
+
+    expect(response.status).toBe(200);
+    expect(bodyText).toContain('<title>あとで見る一覧</title>');
+    expect(bodyText).toContain('タイトル1');
+    expect(bodyText).toContain('/screen/detail/media-001');
+    expect(bodyText).toContain('/screen/summary?summaryPage=1&sort=date_asc&tags=');
+    expect(getQueueService.execute).toHaveBeenCalledWith(expect.objectContaining({ userId: 'user-001' }));
+  });
+});

--- a/src/app/createDependencies.js
+++ b/src/app/createDependencies.js
@@ -14,6 +14,7 @@ const setRouterScreenEditGet = require('../controller/router/screen/setRouterScr
 const setRouterScreenErrorGet = require('../controller/router/screen/setRouterScreenErrorGet');
 const setRouterScreenFavoriteGet = require('../controller/router/screen/setRouterScreenFavoriteGet');
 const setRouterScreenLoginGet = require('../controller/router/screen/setRouterScreenLoginGet');
+const setRouterScreenQueueGet = require('../controller/router/screen/setRouterScreenQueueGet');
 const setRouterScreenSearchGet = require('../controller/router/screen/setRouterScreenSearchGet');
 const setRouterScreenSummaryGet = require('../controller/router/screen/setRouterScreenSummaryGet');
 const setRouterApiFavoriteAndQueue = require('../controller/router/user/setRouterApiFavoriteAndQueue');
@@ -31,6 +32,7 @@ const UUIDMediaIdValueGenerator = require('../infrastructure/UUIDMediaIdValueGen
 const { SearchMediaService } = require('../application/media/query/SearchMediaService');
 const { GetMediaDetailService } = require('../application/media/query/GetMediaDetailService');
 const { GetFavoriteSummariesService } = require('../application/user/query/GetFavoriteSummariesService');
+const { GetQueueService } = require('../application/user/query/GetQueueService');
 const { AddFavoriteService } = require('../application/user/command/AddFavoriteService');
 const { RemoveFavoriteService } = require('../application/user/command/RemoveFavoriteService');
 const { AddQueueService } = require('../application/user/command/AddQueueService');
@@ -74,6 +76,7 @@ const createDependencies = (env = {}) => {
   const searchMediaService = new SearchMediaService({ mediaQueryRepository });
   const getMediaDetailService = new GetMediaDetailService({ mediaRepository });
   const getFavoriteSummariesService = new GetFavoriteSummariesService({ userRepository, mediaQueryRepository });
+  const getQueueService = new GetQueueService({ userRepository, mediaQueryRepository });
   const addFavoriteService = new AddFavoriteService({ mediaRepository, userRepository, unitOfWork });
   const removeFavoriteService = new RemoveFavoriteService({ userRepository, unitOfWork });
   const addQueueService = new AddQueueService({ mediaRepository, userRepository, unitOfWork });
@@ -113,6 +116,7 @@ const createDependencies = (env = {}) => {
     searchMediaService,
     getMediaDetailService,
     getFavoriteSummariesService,
+    getQueueService,
     addFavoriteService,
     removeFavoriteService,
     addQueueService,
@@ -144,6 +148,7 @@ const createDependencies = (env = {}) => {
       setRouterScreenErrorGet,
       setRouterScreenFavoriteGet,
       setRouterScreenLoginGet,
+      setRouterScreenQueueGet,
       setRouterScreenSearchGet,
       setRouterScreenSummaryGet,
       setRouterApiFavoriteAndQueue,

--- a/src/app/setupRoutes.js
+++ b/src/app/setupRoutes.js
@@ -29,6 +29,11 @@ const setupRoutes = (app, { env: _env, dependencies } = {}) => {
   dependencies.routeSetters.setRouterScreenLoginGet({
     router,
   });
+  dependencies.routeSetters.setRouterScreenQueueGet({
+    router,
+    authResolver: dependencies.authResolver,
+    getQueueService: dependencies.getQueueService,
+  });
   dependencies.routeSetters.setRouterScreenSearchGet({
     router,
     authResolver: dependencies.authResolver,

--- a/src/controller/router/screen/setRouterScreenQueueGet.js
+++ b/src/controller/router/screen/setRouterScreenQueueGet.js
@@ -1,0 +1,26 @@
+const SessionAuthMiddleware = require('../../middleware/SessionAuthMiddleware');
+const { Input } = require('../../../application/user/query/GetQueueService');
+
+const setRouterScreenQueueGet = ({ router, authResolver, getQueueService }) => {
+  const auth = new SessionAuthMiddleware(authResolver);
+
+  router.get('/screen/queue', ...[
+    auth.execute.bind(auth),
+    async (req, res, next) => {
+      try {
+        const result = await getQueueService.execute(new Input({
+          userId: req.context.userId,
+        }));
+
+        res.status(200).render('screen/queue', {
+          pageTitle: 'あとで見る一覧',
+          mediaOverviews: result.mediaOverviews,
+        });
+      } catch (error) {
+        next(error);
+      }
+    },
+  ]);
+};
+
+module.exports = setRouterScreenQueueGet;

--- a/src/views/screen/queue.ejs
+++ b/src/views/screen/queue.ejs
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title><%= pageTitle %></title>
+    <style>
+      :root { color-scheme: light; font-family: "Hiragino Sans", "Yu Gothic UI", sans-serif; background: #f5f6f8; color: #1f2937; }
+      * { box-sizing: border-box; }
+      body { margin: 0; background: #f5f6f8; }
+      a { color: #2563eb; text-decoration: none; }
+      a:hover { text-decoration: underline; }
+      .page { max-width: 1080px; margin: 0 auto; padding: 32px 16px 64px; }
+      .stack { display: grid; gap: 24px; }
+      .card { background: #fff; border: 1px solid #d1d5db; border-radius: 16px; padding: 24px; box-shadow: 0 10px 30px rgba(15, 23, 42, 0.06); }
+      .toolbar { display:flex; justify-content:space-between; gap:16px; align-items:center; flex-wrap:wrap; }
+      .sort-form { display:flex; gap:12px; align-items:center; flex-wrap:wrap; }
+      .select-input { border: 1px solid #cbd5e1; border-radius: 10px; padding: 10px 14px; background:#fff; }
+      .media-grid { display: grid; gap: 16px; }
+      .media-card { border: 1px solid #dbe3f0; border-radius: 16px; background: #f8fafc; padding: 16px; }
+      .media-body { display: grid; grid-template-columns: 160px 1fr; gap: 16px; }
+      .thumbnail { width: 160px; height: 120px; border-radius: 12px; background: #dbeafe; overflow: hidden; display:flex; align-items:center; justify-content:center; color:#1d4ed8; font-size:12px; }
+      .thumbnail img { width:100%; height:100%; object-fit:cover; }
+      .meta { display:grid; gap: 12px; }
+      .tag-list, .actions { display:flex; gap:12px; flex-wrap:wrap; }
+      .chip { background: #eff6ff; color: #1d4ed8; border-radius: 999px; padding: 6px 12px; font-size: 14px; }
+      .button { border: 0; border-radius: 10px; padding: 10px 16px; font-size: 14px; font-weight: 700; cursor: pointer; background:#475569; color:#fff; }
+      .empty { color: #64748b; }
+      @media (max-width: 720px) { .media-body { grid-template-columns: 1fr; } .thumbnail { width: 100%; height: 200px; } }
+    </style>
+  </head>
+  <body>
+    <div class="page">
+      <div class="stack">
+        <section class="card">
+          <h1><%= pageTitle %></h1>
+          <p>あとで見るに登録したメディアを一覧表示します。</p>
+        </section>
+
+        <section class="card">
+          <div class="toolbar">
+            <p><strong><%= mediaOverviews.length %></strong> 件</p>
+            <form class="sort-form" method="get" action="/screen/queue">
+              <label for="sort">並び順</label>
+              <select id="sort" name="sort" class="select-input" disabled>
+                <option selected>登録が新しい順</option>
+                <option>登録が古い順</option>
+                <option>ランダム</option>
+              </select>
+            </form>
+          </div>
+
+          <% if (mediaOverviews.length === 0) { %>
+            <p class="empty">検索結果0件ラベル</p>
+          <% } else { %>
+            <div class="media-grid">
+              <% mediaOverviews.forEach((media) => { %>
+                <article class="media-card">
+                  <div class="media-body">
+                    <a class="thumbnail" href="/screen/detail/<%= media.mediaId %>">
+                      <% if (media.thumbnail) { %>
+                        <img src="<%= media.thumbnail %>" alt="<%= media.title %> のサムネイル" />
+                      <% } else { %>
+                        <span>NO IMAGE</span>
+                      <% } %>
+                    </a>
+                    <div class="meta">
+                      <div>
+                        <h2><a href="/screen/detail/<%= media.mediaId %>"><%= media.title %></a></h2>
+                      </div>
+                      <div class="tag-list">
+                        <% media.tags.forEach((tag) => { %>
+                          <a class="chip" href="/screen/summary?summaryPage=1&sort=date_asc&tags=<%= encodeURIComponent(`${tag.category}:${tag.label}`) %>"><%= tag.category %>:<%= tag.label %></a>
+                        <% }) %>
+                      </div>
+                      <div class="actions">
+                        <a href="/screen/detail/<%= media.mediaId %>">詳細画面へ</a>
+                        <button class="button" type="button" disabled>あとで見る一覧</button>
+                      </div>
+                    </div>
+                  </div>
+                </article>
+              <% }) %>
+            </div>
+          <% } %>
+        </section>
+      </div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
### Motivation
- 認証済みユーザーが自分の「あとで見る」キューを閲覧できる画面とルートを追加するため。設計書の導線（0件表示、タイトル/サムネイルから詳細遷移、タグ検索導線）を反映する必要があった。 

### Description
- `GET /screen/queue` 用の route setter/controller を `src/controller/router/screen/setRouterScreenQueueGet.js` として追加し、`GetQueueService` を呼び出して `screen/queue` を描画するようにしました。 
- あとで見る一覧のテンプレートを `src/views/screen/queue.ejs` として追加し、0件時メッセージ、サムネイル・タイトルの詳細遷移、タグから `/screen/summary` への導線、並び順UIを実装しました。 
- 依存性注入に `GetQueueService` と route setter を登録するために `src/app/createDependencies.js` を更新しました。 
- アプリ起動時にルーティングされるよう `src/app/setupRoutes.js` に `/screen/queue` の route setter 呼び出しを追加しました。 
- small / medium レベルのルートテストを `__tests__/small/controller/router/screen/setRouterScreenQueueGet.test.js` と `__tests__/medium/controller/router/screen/setRouterScreenQueueGet.test.js` に追加しました。 

### Testing
- `node --check` による構文チェックで `src/controller/router/screen/setRouterScreenQueueGet.js`、`src/app/createDependencies.js`、`src/app/setupRoutes.js`、および追加した `__tests__` ファイルは問題ありませんでした。 
- 追加した small/medium のテストファイルはリポジトリに追加済みで、テストのロジックは期待通りの HTML レンダリングとサービス呼び出しを検証します。 
- `jest` 実行は試行しましたが、依存パッケージの取得が環境の npm レジストリで `403 Forbidden` となり `npm install` が失敗したため実行できませんでした。jest 実行は環境で依存関係を解決でき次第通る想定です。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1287fa3b4832b8c9d7707acdb0b0e)