### PR TITLE
queue API を PUT に統一して OpenAPI と整合させる

### DIFF
--- a/__tests__/small/controller/router/user/setRouterApiFavoriteAndQueue.test.js
+++ b/__tests__/small/controller/router/user/setRouterApiFavoriteAndQueue.test.js
@@ -24,7 +24,7 @@ describe('setRouterApiFavoriteAndQueue', () => {
   };
 
   it('favorite / queue の各ルートに認証付きハンドラーを登録できる', () => {
-    const router = { put: jest.fn(), post: jest.fn(), delete: jest.fn() };
+    const router = { put: jest.fn(), delete: jest.fn() };
 
     setRouterApiFavoriteAndQueue({
       router,
@@ -36,23 +36,21 @@ describe('setRouterApiFavoriteAndQueue', () => {
     });
 
     expect(router.put).toHaveBeenCalledTimes(2);
-    expect(router.post).toHaveBeenCalledTimes(1);
     expect(router.delete).toHaveBeenCalledTimes(2);
 
     expect(router.put.mock.calls[0][0]).toBe('/api/favorite/:mediaId');
     expect(router.delete.mock.calls[0][0]).toBe('/api/favorite/:mediaId');
     expect(router.put.mock.calls[1][0]).toBe('/api/queue/:mediaId');
-    expect(router.post.mock.calls[0][0]).toBe('/api/queue/:mediaId');
     expect(router.delete.mock.calls[1][0]).toBe('/api/queue/:mediaId');
 
-    [...router.put.mock.calls, ...router.post.mock.calls, ...router.delete.mock.calls].forEach(([, middleware, handler]) => {
+    [...router.put.mock.calls, ...router.delete.mock.calls].forEach(([, middleware, handler]) => {
       expect(typeof middleware).toBe('function');
       expect(typeof handler).toBe('function');
     });
   });
 
   it('favorite の PUT / DELETE で対応サービスを呼び出せる', async () => {
-    const router = { put: jest.fn(), post: jest.fn(), delete: jest.fn() };
+    const router = { put: jest.fn(), delete: jest.fn() };
     const authResolver = { execute: jest.fn().mockResolvedValue('user-1') };
     const addFavoriteService = { execute: jest.fn().mockResolvedValue(undefined) };
     const removeFavoriteService = { execute: jest.fn().mockResolvedValue(undefined) };
@@ -92,8 +90,8 @@ describe('setRouterApiFavoriteAndQueue', () => {
     expect(deleteRes.json).toHaveBeenCalledWith({ code: 0 });
   });
 
-  it('queue の PUT / POST / DELETE で対応サービスを呼び出せる', async () => {
-    const router = { put: jest.fn(), post: jest.fn(), delete: jest.fn() };
+  it('queue の PUT / DELETE で対応サービスを呼び出せる', async () => {
+    const router = { put: jest.fn(), delete: jest.fn() };
     const authResolver = { execute: jest.fn().mockResolvedValue('user-1') };
     const addQueueService = { execute: jest.fn().mockResolvedValue(undefined) };
     const removeQueueService = { execute: jest.fn().mockResolvedValue(undefined) };
@@ -112,24 +110,18 @@ describe('setRouterApiFavoriteAndQueue', () => {
     const putRes = createRes();
     await executeRegisteredRoute({ middleware: queuePutMiddleware, handler: queuePutHandler, req: putReq, res: putRes });
 
-    const [, queuePostMiddleware, queuePostHandler] = router.post.mock.calls[0];
-    const postReq = createRequest('queue-post');
-    const postRes = createRes();
-    await executeRegisteredRoute({ middleware: queuePostMiddleware, handler: queuePostHandler, req: postReq, res: postRes });
-
     const [, queueDeleteMiddleware, queueDeleteHandler] = router.delete.mock.calls[1];
     const deleteReq = createRequest('queue-delete');
     const deleteRes = createRes();
     await executeRegisteredRoute({ middleware: queueDeleteMiddleware, handler: queueDeleteHandler, req: deleteReq, res: deleteRes });
 
-    expect(addQueueService.execute).toHaveBeenNthCalledWith(1, expect.objectContaining({ mediaId: 'queue-put', userId: 'user-1' }));
-    expect(addQueueService.execute).toHaveBeenNthCalledWith(2, expect.objectContaining({ mediaId: 'queue-post', userId: 'user-1' }));
+    expect(addQueueService.execute).toHaveBeenCalledWith(expect.objectContaining({ mediaId: 'queue-put', userId: 'user-1' }));
     expect(removeQueueService.execute).toHaveBeenCalledWith(expect.objectContaining({ mediaId: 'queue-delete', userId: 'user-1' }));
     expect(deleteRes.json).toHaveBeenCalledWith({ code: 0 });
   });
 
   it('サービス呼び出し時の例外を next に委譲する', async () => {
-    const router = { put: jest.fn(), post: jest.fn(), delete: jest.fn() };
+    const router = { put: jest.fn(), delete: jest.fn() };
     const expectedError = new Error('failed');
 
     setRouterApiFavoriteAndQueue({

--- a/doc/5_api/controller/router/user/setRouterApiFavoriteAndQueue/readme.md
+++ b/doc/5_api/controller/router/user/setRouterApiFavoriteAndQueue/readme.md
@@ -3,13 +3,12 @@
 ## 概要
 - お気に入り・キュー操作 API のルーティング定義を担当する。
 - 各ルートでセッション認証後に、対応するアプリケーションサービスへ処理を委譲する。
-- `PUT /api/favorite/:mediaId`、`DELETE /api/favorite/:mediaId`、`PUT /api/queue/:mediaId`、`POST /api/queue/:mediaId`、`DELETE /api/queue/:mediaId` を登録する。
+- `PUT /api/favorite/:mediaId`、`DELETE /api/favorite/:mediaId`、`PUT /api/queue/:mediaId`、`DELETE /api/queue/:mediaId` を登録する。
 
 ## 対象
 - `PUT /api/favorite/:mediaId`
 - `DELETE /api/favorite/:mediaId`
 - `PUT /api/queue/:mediaId`
-- `POST /api/queue/:mediaId`
 - `DELETE /api/queue/:mediaId`
 
 ## 依存
@@ -22,7 +21,7 @@
 ## 依存注入
 - `router`
   - Express Router。
-  - `put(path, ...handlers)` / `post(path, ...handlers)` / `delete(path, ...handlers)` を持つ。
+  - `put(path, ...handlers)` / `delete(path, ...handlers)` を持つ。
 - `authResolver`
   - セッショントークンから `userId` を解決するアダプタ。
   - `execute(token)` を持つ。
@@ -44,7 +43,7 @@
    - `req.session.session_token` から `req.context.userId` を設定する。
 2. ルート別ハンドラー
    - お気に入り追加/解除では `mediaId` と `userId` から Query を生成してサービスを呼ぶ。
-   - キュー追加/解除では `PUT` / `POST` / `DELETE` に応じて対応サービスを呼ぶ。
+   - キュー追加/解除では `PUT` / `DELETE` に応じて対応サービスを呼ぶ。
    - いずれも成功時は `200` + `code: 0` を返す。
 
 ## エラーハンドリング

--- a/doc/5_api/controller/router/user/setRouterApiFavoriteAndQueue/testcase.md
+++ b/doc/5_api/controller/router/user/setRouterApiFavoriteAndQueue/testcase.md
@@ -1,21 +1,21 @@
 # router (favorite / queue API) テストケース
 
 ## テストケース一覧
-- [favorite / queue の5ルートを登録する](#favorite--queue-の5ルートを登録する)
+- [favorite / queue の4ルートを登録する](#favorite--queue-の4ルートを登録する)
 - [favorite の PUT / DELETE で対応サービスが呼ばれる](#favorite-の-put--delete-で対応サービスが呼ばれる)
-- [queue の PUT / POST / DELETE で対応サービスが呼ばれる](#queue-の-put--post--delete-で対応サービスが呼ばれる)
+- [queue の PUT / DELETE で対応サービスが呼ばれる](#queue-の-put--delete-で対応サービスが呼ばれる)
 - [サービス実行で例外が発生した場合は next に委譲する](#サービス実行で例外が発生した場合は-next-に委譲する)
 
 ---
 
-### favorite / queue の5ルートを登録する
+### favorite / queue の4ルートを登録する
 - **前提**
-  - `router.put` / `router.post` / `router.delete` をモック化する。
+  - `router.put` / `router.delete` をモック化する。
   - 認証・各サービスは有効な依存を注入する。
 - **操作**
   - `setRouterApiFavoriteAndQueue` を実行する。
 - **結果**
-  - `PUT` が2回、`POST` が1回、`DELETE` が2回呼ばれる。
+  - `PUT` が2回、`DELETE` が2回呼ばれる。
   - それぞれに認証ハンドラーと実処理ハンドラーが設定される。
 
 ---
@@ -32,14 +32,14 @@
 
 ---
 
-### queue の PUT / POST / DELETE で対応サービスが呼ばれる
+### queue の PUT / DELETE で対応サービスが呼ばれる
 - **前提**
   - `authResolver.execute` は `userId` を返す。
   - `addQueueService.execute` / `removeQueueService.execute` は成功する。
 - **操作**
   - 登録済みの queue 用ハンドラーを順に実行する。
 - **結果**
-  - `PUT` / `POST` は `addQueueService.execute` を呼ぶ。
+  - `PUT` は `addQueueService.execute` を呼ぶ。
   - `DELETE` は `removeQueueService.execute` を呼ぶ。
   - いずれも `200` + `code: 0` が返る。
 

--- a/src/controller/router/user/setRouterApiFavoriteAndQueue.js
+++ b/src/controller/router/user/setRouterApiFavoriteAndQueue.js
@@ -42,15 +42,6 @@ const setRouterApiFavoriteAndQueue = ({
     }
   });
 
-  router.post('/api/queue/:mediaId', auth.execute.bind(auth), async (req, res, next) => {
-    try {
-      await addQueueService.execute(new AddQueueQuery({ mediaId: req.params.mediaId, userId: getUserId(req) }));
-      res.status(200).json({ code: 0 });
-    } catch (error) {
-      next(error);
-    }
-  });
-
   router.delete('/api/queue/:mediaId', auth.execute.bind(auth), async (req, res, next) => {
     try {
       await removeQueueService.execute(new RemoveQueueQuery({ mediaId: req.params.mediaId, userId: getUserId(req) }));


### PR DESCRIPTION
### Motivation
- OpenAPI および UI/sequence 文書では `/api/queue/{mediaId}` の追加は `PUT` で定義されており、router 実装だけが `POST` を受け付けていたため API 契約と実装が不整合になっていた。
- 実装側の余分な受け口を残すと仕様の正本が曖昧になるため、契約（OpenAPI）に合わせる方針を採用した。 

### Description
- `src/controller/router/user/setRouterApiFavoriteAndQueue.js` から `POST /api/queue/:mediaId` のハンドラを削除し、`PUT` / `DELETE` のみを受け付けるように変更しました。 
- `__tests__/small/controller/router/user/setRouterApiFavoriteAndQueue.test.js` を修正し、`POST` に関するモック・検証・実行を削除して 4 ルート構成（`PUT` x2 / `DELETE` x2）に合わせました。 
- `doc/5_api/controller/router/user/setRouterApiFavoriteAndQueue/readme.md` と `doc/5_api/controller/router/user/setRouterApiFavoriteAndQueue/testcase.md` の記述から `POST /api/queue/:mediaId` を削除し、ドキュメントを実装・契約に一致させました。 

### Testing
- 実装ファイルの静的チェックとして `node --check src/controller/router/user/setRouterApiFavoriteAndQueue.js` を実行して問題ないことを確認しました（成功）。
- テストコードの静的チェックとして `node --check __tests__/small/controller/router/user/setRouterApiFavoriteAndQueue.test.js` を実行して問題ないことを確認しました（成功）。
- 単体テスト実行の試行として `npx jest __tests__/small/controller/router/user/setRouterApiFavoriteAndQueue.test.js` を実行しようとしましたが、環境の npm レジストリアクセス制限により依存が取得できず実行できませんでした（未実行）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c12cb0b0a0832b972907be0433c532)