### PR TITLE
test: LoginService の small/medium テストを追加

### DIFF
--- a/__tests__/medium/app/createDependencies.login.test.js
+++ b/__tests__/medium/app/createDependencies.login.test.js
@@ -1,0 +1,60 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const createDependencies = require('../../../src/app/createDependencies');
+const { Query, LoginSucceededResult } = require('../../../src/application/user/command/LoginService');
+
+describe('createDependencies login wiring', () => {
+  let dependencies;
+  let databaseRoot;
+  let contentRoot;
+
+  beforeEach(() => {
+    databaseRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'create-deps-login-db-'));
+    contentRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'create-deps-login-content-'));
+
+    dependencies = createDependencies({
+      databaseStoragePath: path.join(databaseRoot, 'data.sqlite'),
+      contentRootDirectory: path.join(contentRoot, 'contents'),
+      loginUsername: 'admin',
+      loginPassword: 'secret',
+      loginUserId: 'user-001',
+      loginSessionTtlMs: 60_000,
+    });
+  });
+
+  afterEach(async () => {
+    if (dependencies) {
+      await dependencies.close();
+      dependencies = undefined;
+    }
+
+    fs.rmSync(databaseRoot, { recursive: true, force: true });
+    fs.rmSync(contentRoot, { recursive: true, force: true });
+  });
+
+  test('依存性配線を通した loginService でログインが成立し認証状態を参照できる', async () => {
+    await dependencies.ready;
+
+    const session = {
+      regenerate: jest.fn((callback) => callback()),
+    };
+    const query = new Query({
+      username: 'admin',
+      password: 'secret',
+      session,
+    });
+
+    const result = await dependencies.loginService.execute(query);
+
+    expect(result).toBeInstanceOf(LoginSucceededResult);
+    expect(result.code).toBe(0);
+    expect(result.sessionToken).toEqual(expect.stringMatching(/^[0-9a-f]{32}$/));
+    expect(session.session_token).toBe(result.sessionToken);
+
+    await expect(dependencies.authResolver.execute({ sessionToken: result.sessionToken })).resolves.toEqual({
+      userId: 'user-001',
+    });
+  });
+});

--- a/__tests__/medium/app/createDependencies.login.test.js
+++ b/__tests__/medium/app/createDependencies.login.test.js
@@ -53,8 +53,6 @@ describe('createDependencies login wiring', () => {
     expect(result.sessionToken).toEqual(expect.stringMatching(/^[0-9a-f]{32}$/));
     expect(session.session_token).toBe(result.sessionToken);
 
-    await expect(dependencies.authResolver.execute({ sessionToken: result.sessionToken })).resolves.toEqual({
-      userId: 'user-001',
-    });
+    await expect(dependencies.authResolver.execute(result.sessionToken)).resolves.toBe('user-001');
   });
 });

--- a/__tests__/small/application/user/command/LoginService.test.js
+++ b/__tests__/small/application/user/command/LoginService.test.js
@@ -1,0 +1,128 @@
+const {
+  Query,
+  LoginService,
+  LoginSucceededResult,
+  LoginFailedResult,
+} = require('../../../../../src/application/user/command/LoginService');
+
+describe('LoginService', () => {
+  test('認証成功時は成功結果とセッショントークンを返す', async () => {
+    const loginAuthenticator = {
+      execute: jest.fn().mockResolvedValue('user-001'),
+    };
+    const sessionStateRegistrar = {
+      execute: jest.fn().mockResolvedValue({
+        sessionToken: 'token-001',
+        userId: 'user-001',
+      }),
+    };
+    const service = new LoginService({
+      loginAuthenticator,
+      sessionStateRegistrar,
+      sessionTtlMs: 60_000,
+    });
+    const query = new Query({
+      username: 'admin',
+      password: 'secret',
+      session: { regenerate: jest.fn() },
+    });
+
+    const result = await service.execute(query);
+
+    expect(loginAuthenticator.execute).toHaveBeenCalledWith({
+      username: 'admin',
+      password: 'secret',
+    });
+    expect(sessionStateRegistrar.execute).toHaveBeenCalledWith({
+      session: query.session,
+      userId: 'user-001',
+      ttlMs: 60_000,
+    });
+    expect(result).toBeInstanceOf(LoginSucceededResult);
+    expect(result.code).toBe(0);
+    expect(result.sessionToken).toBe('token-001');
+  });
+
+  test('認証失敗時は失敗結果を返しセッション発行しない', async () => {
+    const loginAuthenticator = {
+      execute: jest.fn().mockResolvedValue(null),
+    };
+    const sessionStateRegistrar = {
+      execute: jest.fn(),
+    };
+    const service = new LoginService({
+      loginAuthenticator,
+      sessionStateRegistrar,
+    });
+
+    const result = await service.execute(new Query({
+      username: 'admin',
+      password: 'wrong',
+      session: { regenerate: jest.fn() },
+    }));
+
+    expect(loginAuthenticator.execute).toHaveBeenCalledWith({
+      username: 'admin',
+      password: 'wrong',
+    });
+    expect(sessionStateRegistrar.execute).not.toHaveBeenCalled();
+    expect(result).toBeInstanceOf(LoginFailedResult);
+    expect(result.code).toBe(1);
+    expect(result.sessionToken).toBeNull();
+  });
+
+  test.each([
+    [{ username: '', password: 'secret', session: { regenerate: jest.fn() } }, 'username must be a non-empty string'],
+    [{ username: 'admin', password: '', session: { regenerate: jest.fn() } }, 'password must be a non-empty string'],
+    [{ username: 'admin', password: 'secret', session: null }, 'session must be an object'],
+  ])('入力が不正な場合は例外となる: %p', async (payload, expectedMessage) => {
+    const loginAuthenticator = {
+      execute: jest.fn(),
+    };
+    const sessionStateRegistrar = {
+      execute: jest.fn(),
+    };
+    const service = new LoginService({
+      loginAuthenticator,
+      sessionStateRegistrar,
+    });
+
+    expect(() => new Query(payload)).toThrow(expectedMessage);
+    expect(loginAuthenticator.execute).not.toHaveBeenCalled();
+    expect(sessionStateRegistrar.execute).not.toHaveBeenCalled();
+
+    await expect(service.execute(payload)).rejects.toThrow('query must be an instance of Query');
+    expect(loginAuthenticator.execute).not.toHaveBeenCalled();
+    expect(sessionStateRegistrar.execute).not.toHaveBeenCalled();
+  });
+
+  test('セッション発行失敗時は例外として扱う', async () => {
+    const loginAuthenticator = {
+      execute: jest.fn().mockResolvedValue('user-001'),
+    };
+    const sessionStateRegistrar = {
+      execute: jest.fn().mockRejectedValue(new Error('session store failed')),
+    };
+    const service = new LoginService({
+      loginAuthenticator,
+      sessionStateRegistrar,
+      sessionTtlMs: 120_000,
+    });
+    const query = new Query({
+      username: 'admin',
+      password: 'secret',
+      session: { regenerate: jest.fn() },
+    });
+
+    await expect(service.execute(query)).rejects.toThrow('session store failed');
+    expect(loginAuthenticator.execute).toHaveBeenCalledWith({
+      username: 'admin',
+      password: 'secret',
+    });
+    expect(sessionStateRegistrar.execute).toHaveBeenCalledWith({
+      session: query.session,
+      userId: 'user-001',
+      ttlMs: 120_000,
+    });
+  });
+});


### PR DESCRIPTION
### Motivation
- `doc/4_application/user/command/LoginService/testcase.md` に定義されたケースを `LoginService` に対応付けて自動検証できるようにするため。 
- サービス単体の動作保証（small）と依存性配線による統合的な動作確認（medium）を両方追加して回帰検知を強化するため。

### Description
- `__tests__/small/application/user/command/LoginService.test.js` を追加し、`loginAuthenticator` と `sessionStateRegistrar` をモックして成功・認証失敗・不正入力・セッション発行失敗を検証するようにしました。 
- `__tests__/medium/app/createDependencies.login.test.js` を追加し、`src/app/createDependencies.js` 経由で構築した `loginService` と `authResolver` を用いて実際にログインし認証状態を参照できることを確認するテストを追加しました。 
- small テストはサービス責務の単体検証に集中し、medium テストは既存の medium テスト構成に合わせて外部依存を増やさず配線確認する構成にしています。 

### Testing
- `node --check __tests__/small/application/user/command/LoginService.test.js` と `node --check __tests__/medium/app/createDependencies.login.test.js` は構文チェックを通過しました。 
- `node` による LoginService 単体の簡易実行チェックは成功し（内部アサーション通過）、small テストで想定する振る舞いを確認しました。 
- `jest` 実行はこの環境で直接実行できず（`jest: not found` または npx 経由での取得がネットワークポリシーにより失敗）、Jest を用いた自動実行は未実行です。 
- `createDependencies` を用いた実行確認は依存モジュール（`sequelize` 等）が解決できず一部実行できなかったため、medium テストの Jest 実行確認は環境依存で未完了です。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1315ffe80832b8b2c989b2c7ee7f2)