### PR TITLE
viewer 画面のルートと描画処理を追加

### DIFF
--- a/__tests__/medium/controller/router/screen/setRouterScreenViewerGet.test.js
+++ b/__tests__/medium/controller/router/screen/setRouterScreenViewerGet.test.js
@@ -1,0 +1,154 @@
+const express = require('express');
+const path = require('path');
+
+const setRouterScreenViewerGet = require('../../../../../src/controller/router/screen/setRouterScreenViewerGet');
+const SessionStateAuthAdapter = require('../../../../../src/infrastructure/SessionStateAuthAdapter');
+const {
+  FoundResult,
+  MediaNotFoundResult,
+  ContentNotFoundResult,
+} = require('../../../../../src/application/media/query/GetMediaContentWithNavigationService');
+
+class InMemorySessionStateStore {
+  constructor(entries = []) {
+    this.tokenToUserId = new Map(entries);
+  }
+
+  findUserIdBySessionToken(sessionToken) {
+    return this.tokenToUserId.get(sessionToken) ?? null;
+  }
+}
+
+const requestApp = async ({ app, method, targetPath, headers = {} } = {}) => {
+  const server = app.listen(0);
+
+  try {
+    await new Promise((resolve, reject) => {
+      server.once('listening', resolve);
+      server.once('error', reject);
+    });
+
+    const address = server.address();
+    const response = await fetch(`http://127.0.0.1:${address.port}${targetPath}`, {
+      method,
+      headers,
+      redirect: 'manual',
+    });
+
+    return {
+      status: response.status,
+      headers: response.headers,
+      bodyText: await response.text(),
+    };
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close(error => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    });
+  }
+};
+
+describe('setRouterScreenViewerGet (middle)', () => {
+  const createApp = ({ serviceResult }) => {
+    const app = express();
+    const router = express.Router();
+
+    app.set('views', path.join(process.cwd(), 'src', 'views'));
+    app.set('view engine', 'ejs');
+    app.engine('ejs', (filePath, options, callback) => {
+      callback(
+        null,
+        `<!DOCTYPE html><html lang="ja"><head><title>${options.pageTitle}</title></head><body>${filePath}:${options.mediaId}:${options.mediaPage}:${options.content.id}:${options.previousPage ? options.previousPage.href : 'prev-none'}:${options.nextPage ? options.nextPage.href : 'next-none'}</body></html>`
+      );
+    });
+
+    app.use((req, _res, next) => {
+      req.session = {
+        session_token: req.header('x-session-token'),
+      };
+      req.context = {};
+      next();
+    });
+
+    setRouterScreenViewerGet({
+      router,
+      authResolver: new SessionStateAuthAdapter({
+        sessionStateStore: new InMemorySessionStateStore([
+          ['valid-token', 'user-001'],
+        ]),
+      }),
+      getMediaContentWithNavigationService: {
+        execute: jest.fn().mockResolvedValue(serviceResult),
+      },
+    });
+
+    app.use(router);
+    return app;
+  };
+
+  test('GET /screen/viewer/:mediaId/:mediaPage で viewer HTML を返す', async () => {
+    const app = createApp({
+      serviceResult: new FoundResult({
+        contentId: '/contents/page-2.jpg',
+        previousContentId: '/contents/page-1.jpg',
+        nextContentId: '/contents/page-3.jpg',
+      }),
+    });
+
+    const response = await requestApp({
+      app,
+      method: 'GET',
+      targetPath: '/screen/viewer/media-001/2',
+      headers: { 'x-session-token': 'valid-token' },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toContain('text/html');
+    expect(response.bodyText).toContain('<!DOCTYPE html>');
+    expect(response.bodyText).toContain('<title>ビューアー media-001 - 2ページ</title>');
+    expect(response.bodyText).toContain(path.join('src', 'views', 'screen', 'viewer.ejs'));
+    expect(response.bodyText).toContain('media-001:2:/contents/page-2.jpg:/screen/viewer/media-001/1:/screen/viewer/media-001/3');
+  });
+
+  test('先頭ページでは前ページ導線なしで HTML を返す', async () => {
+    const app = createApp({
+      serviceResult: new FoundResult({
+        contentId: '/contents/page-1.jpg',
+        previousContentId: null,
+        nextContentId: '/contents/page-2.jpg',
+      }),
+    });
+
+    const response = await requestApp({
+      app,
+      method: 'GET',
+      targetPath: '/screen/viewer/media-001/1',
+      headers: { 'x-session-token': 'valid-token' },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.bodyText).toContain(':prev-none:/screen/viewer/media-001/2');
+  });
+
+  test.each([
+    ['未存在メディア', new MediaNotFoundResult()],
+    ['未存在ページ', new ContentNotFoundResult()],
+  ])('%s の場合はエラー画面へ 301 リダイレクトする', async (_name, serviceResult) => {
+    const app = createApp({ serviceResult });
+
+    const response = await requestApp({
+      app,
+      method: 'GET',
+      targetPath: '/screen/viewer/media-404/99',
+      headers: { 'x-session-token': 'valid-token' },
+    });
+
+    expect(response.status).toBe(301);
+    expect(response.headers.get('location')).toBe('/screen/error');
+  });
+});

--- a/__tests__/small/controller/router/screen/setRouterScreenViewerGet.test.js
+++ b/__tests__/small/controller/router/screen/setRouterScreenViewerGet.test.js
@@ -1,0 +1,88 @@
+const setRouterScreenViewerGet = require('../../../../../src/controller/router/screen/setRouterScreenViewerGet');
+const {
+  FoundResult,
+  MediaNotFoundResult,
+  ContentNotFoundResult,
+} = require('../../../../../src/application/media/query/GetMediaContentWithNavigationService');
+
+describe('setRouterScreenViewerGet', () => {
+  const createRes = () => {
+    const res = {
+      status: jest.fn(),
+      render: jest.fn(),
+      redirect: jest.fn(),
+      json: jest.fn(),
+    };
+    res.status.mockReturnValue(res);
+    return res;
+  };
+
+  it('GET /screen/viewer/:mediaId/:mediaPage に認証・描画ハンドラーを登録できる', async () => {
+    const router = { get: jest.fn() };
+    const authResolver = { execute: jest.fn().mockResolvedValue('u1') };
+    const getMediaContentWithNavigationService = {
+      execute: jest.fn().mockResolvedValue(new FoundResult({
+        contentId: '/contents/page-2.jpg',
+        previousContentId: '/contents/page-1.jpg',
+        nextContentId: '/contents/page-3.jpg',
+      })),
+    };
+
+    setRouterScreenViewerGet({ router, authResolver, getMediaContentWithNavigationService });
+
+    expect(router.get).toHaveBeenCalledTimes(1);
+    const [path, ...handlers] = router.get.mock.calls[0];
+    expect(path).toBe('/screen/viewer/:mediaId/:mediaPage');
+    expect(handlers).toHaveLength(2);
+
+    const req = {
+      params: { mediaId: 'media-1', mediaPage: '2' },
+      session: { session_token: 'token-1' },
+      context: {},
+    };
+    const res = createRes();
+
+    await handlers[0](req, res, async () => {
+      await handlers[1](req, res, jest.fn());
+    });
+
+    expect(authResolver.execute).toHaveBeenCalledWith('token-1');
+    expect(getMediaContentWithNavigationService.execute).toHaveBeenCalledWith(expect.objectContaining({
+      mediaId: 'media-1',
+      contentPosition: 2,
+    }));
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.render).toHaveBeenCalledWith('screen/viewer', expect.objectContaining({
+      mediaId: 'media-1',
+      mediaPage: 2,
+      content: { id: '/contents/page-2.jpg', type: 'image' },
+      previousPage: expect.objectContaining({ href: '/screen/viewer/media-1/1' }),
+      nextPage: expect.objectContaining({ href: '/screen/viewer/media-1/3' }),
+    }));
+  });
+
+  test.each([
+    ['未存在メディア', new MediaNotFoundResult()],
+    ['未存在ページ', new ContentNotFoundResult()],
+  ])('%s の場合はエラー画面へリダイレクトする', async (_name, serviceResult) => {
+    const router = { get: jest.fn() };
+    const authResolver = { execute: jest.fn().mockResolvedValue('u1') };
+    const getMediaContentWithNavigationService = {
+      execute: jest.fn().mockResolvedValue(serviceResult),
+    };
+
+    setRouterScreenViewerGet({ router, authResolver, getMediaContentWithNavigationService });
+
+    const [, , handler] = router.get.mock.calls[0];
+    const req = {
+      params: { mediaId: 'media-404', mediaPage: '9' },
+      session: { session_token: 'token-1' },
+      context: {},
+    };
+    const res = createRes();
+
+    await handler(req, res);
+
+    expect(res.redirect).toHaveBeenCalledWith(301, '/screen/error');
+  });
+});

--- a/src/app/createDependencies.js
+++ b/src/app/createDependencies.js
@@ -17,6 +17,7 @@ const setRouterScreenLoginGet = require('../controller/router/screen/setRouterSc
 const setRouterScreenQueueGet = require('../controller/router/screen/setRouterScreenQueueGet');
 const setRouterScreenSearchGet = require('../controller/router/screen/setRouterScreenSearchGet');
 const setRouterScreenSummaryGet = require('../controller/router/screen/setRouterScreenSummaryGet');
+const setRouterScreenViewerGet = require('../controller/router/screen/setRouterScreenViewerGet');
 const setRouterApiFavoriteAndQueue = require('../controller/router/user/setRouterApiFavoriteAndQueue');
 const InMemorySessionStateStore = require('../infrastructure/InMemorySessionStateStore');
 const MulterDiskStorageContentUploadAdapter = require('../infrastructure/MulterDiskStorageContentUploadAdapter');
@@ -31,6 +32,7 @@ const StaticLoginAuthenticator = require('../infrastructure/StaticLoginAuthentic
 const UUIDMediaIdValueGenerator = require('../infrastructure/UUIDMediaIdValueGenerator');
 const { SearchMediaService } = require('../application/media/query/SearchMediaService');
 const { GetMediaDetailService } = require('../application/media/query/GetMediaDetailService');
+const { GetMediaContentWithNavigationService } = require('../application/media/query/GetMediaContentWithNavigationService');
 const { GetFavoriteSummariesService } = require('../application/user/query/GetFavoriteSummariesService');
 const { GetQueueService } = require('../application/user/query/GetQueueService');
 const { AddFavoriteService } = require('../application/user/command/AddFavoriteService');
@@ -75,6 +77,7 @@ const createDependencies = (env = {}) => {
   });
   const searchMediaService = new SearchMediaService({ mediaQueryRepository });
   const getMediaDetailService = new GetMediaDetailService({ mediaRepository });
+  const getMediaContentWithNavigationService = new GetMediaContentWithNavigationService({ mediaRepository });
   const getFavoriteSummariesService = new GetFavoriteSummariesService({ userRepository, mediaQueryRepository });
   const getQueueService = new GetQueueService({ userRepository, mediaQueryRepository });
   const addFavoriteService = new AddFavoriteService({ mediaRepository, userRepository, unitOfWork });
@@ -115,6 +118,7 @@ const createDependencies = (env = {}) => {
     userRepository,
     searchMediaService,
     getMediaDetailService,
+    getMediaContentWithNavigationService,
     getFavoriteSummariesService,
     getQueueService,
     addFavoriteService,
@@ -151,6 +155,7 @@ const createDependencies = (env = {}) => {
       setRouterScreenQueueGet,
       setRouterScreenSearchGet,
       setRouterScreenSummaryGet,
+      setRouterScreenViewerGet,
       setRouterApiFavoriteAndQueue,
     },
   };

--- a/src/app/setupRoutes.js
+++ b/src/app/setupRoutes.js
@@ -43,6 +43,11 @@ const setupRoutes = (app, { env: _env, dependencies } = {}) => {
     authResolver: dependencies.authResolver,
     searchMediaService: dependencies.searchMediaService,
   });
+  dependencies.routeSetters.setRouterScreenViewerGet({
+    router,
+    authResolver: dependencies.authResolver,
+    getMediaContentWithNavigationService: dependencies.getMediaContentWithNavigationService,
+  });
 
   dependencies.routeSetters.setRouterApiLogin({
     router,

--- a/src/application/media/query/GetMediaContentWithNavigationService.js
+++ b/src/application/media/query/GetMediaContentWithNavigationService.js
@@ -69,7 +69,7 @@ class GetMediaContentWithNavigationService {
       throw new Error();
     }
 
-    const mediaId = new MediaId(input.id);
+    const mediaId = new MediaId(input.mediaId);
     const media = await this.#mediaRepository.findByMediaId(mediaId);
 
     if (!media) {

--- a/src/controller/router/screen/setRouterScreenViewerGet.js
+++ b/src/controller/router/screen/setRouterScreenViewerGet.js
@@ -1,0 +1,14 @@
+const SessionAuthMiddleware = require('../../middleware/SessionAuthMiddleware');
+const ScreenViewerGetController = require('../../screen/ScreenViewerGetController');
+
+const setRouterScreenViewerGet = ({ router, authResolver, getMediaContentWithNavigationService }) => {
+  const auth = new SessionAuthMiddleware(authResolver);
+  const controller = new ScreenViewerGetController({ getMediaContentWithNavigationService });
+
+  router.get('/screen/viewer/:mediaId/:mediaPage', ...[
+    auth.execute.bind(auth),
+    controller.execute.bind(controller),
+  ]);
+};
+
+module.exports = setRouterScreenViewerGet;

--- a/src/controller/screen/ScreenViewerGetController.js
+++ b/src/controller/screen/ScreenViewerGetController.js
@@ -1,0 +1,69 @@
+const {
+  Input,
+  FoundResult,
+  MediaNotFoundResult,
+  ContentNotFoundResult,
+} = require('../../application/media/query/GetMediaContentWithNavigationService');
+
+class ScreenViewerGetController {
+  #getMediaContentWithNavigationService;
+
+  constructor({ getMediaContentWithNavigationService }) {
+    if (!getMediaContentWithNavigationService || typeof getMediaContentWithNavigationService.execute !== 'function') {
+      throw new Error('getMediaContentWithNavigationService.execute must be a function');
+    }
+
+    this.#getMediaContentWithNavigationService = getMediaContentWithNavigationService;
+  }
+
+  async execute(req, res) {
+    try {
+      const mediaPage = Number.parseInt(req.params.mediaPage, 10);
+      const result = await this.#getMediaContentWithNavigationService.execute(new Input({
+        mediaId: req.params.mediaId,
+        contentPosition: mediaPage,
+      }));
+
+      if (result instanceof MediaNotFoundResult || result instanceof ContentNotFoundResult) {
+        return res.redirect(301, '/screen/error');
+      }
+      if (!(result instanceof FoundResult)) {
+        throw new Error('unexpected result');
+      }
+
+      return res.status(200).render('screen/viewer', {
+        pageTitle: `ビューアー ${req.params.mediaId} - ${mediaPage}ページ`,
+        mediaId: req.params.mediaId,
+        mediaPage,
+        content: {
+          id: result.contentId,
+          type: this.#detectContentType(result.contentId),
+        },
+        previousPage: result.previousContentId === null ? null : {
+          mediaId: req.params.mediaId,
+          mediaPage: mediaPage - 1,
+          contentId: result.previousContentId,
+          href: `/screen/viewer/${req.params.mediaId}/${mediaPage - 1}`,
+        },
+        nextPage: result.nextContentId === null ? null : {
+          mediaId: req.params.mediaId,
+          mediaPage: mediaPage + 1,
+          contentId: result.nextContentId,
+          href: `/screen/viewer/${req.params.mediaId}/${mediaPage + 1}`,
+        },
+      });
+    } catch (_error) {
+      return res.redirect(301, '/screen/error');
+    }
+  }
+
+  #detectContentType(contentId) {
+    if (/\.(mp4|webm|ogg|mov|m4v)$/i.test(contentId)) {
+      return 'video';
+    }
+
+    return 'image';
+  }
+}
+
+module.exports = ScreenViewerGetController;

--- a/src/views/screen/viewer.ejs
+++ b/src/views/screen/viewer.ejs
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title><%= pageTitle %></title>
+    <style>
+      :root {
+        color-scheme: light;
+        font-family: "Hiragino Sans", "Yu Gothic UI", sans-serif;
+        background: #0f172a;
+        color: #e2e8f0;
+      }
+      * { box-sizing: border-box; }
+      body { margin: 0; background: #020617; }
+      a { color: inherit; text-decoration: none; }
+      .viewer { min-height: 100vh; display: grid; grid-template-columns: minmax(96px, 1fr) minmax(320px, 5fr) minmax(96px, 1fr); }
+      .nav-area, .content-area { min-height: 100vh; }
+      .nav-area {
+        display: flex; align-items: center; justify-content: center; padding: 24px 12px;
+        background: rgba(15, 23, 42, 0.92); border: 1px solid rgba(148, 163, 184, 0.18);
+      }
+      .nav-area.disabled { color: #64748b; }
+      .nav-link, .nav-label { writing-mode: vertical-rl; text-orientation: mixed; letter-spacing: 0.12em; font-weight: 700; }
+      .content-area { display: grid; grid-template-rows: auto 1fr auto; gap: 16px; padding: 24px 16px 32px; }
+      .meta { display:flex; justify-content:space-between; gap:16px; align-items:center; flex-wrap:wrap; }
+      .meta-chip { background: rgba(37, 99, 235, 0.18); color: #bfdbfe; border-radius: 999px; padding: 8px 14px; }
+      .stage {
+        display:flex; align-items:center; justify-content:center; background:#111827; border: 1px solid rgba(148, 163, 184, 0.18);
+        border-radius: 18px; padding: 16px; overflow: hidden;
+      }
+      .stage img, .stage video { width: 100%; max-height: calc(100vh - 220px); object-fit: contain; border-radius: 12px; background: #000; }
+      .footer-nav { display:flex; justify-content:space-between; gap:12px; flex-wrap:wrap; }
+      .footer-nav a, .footer-nav span {
+        display:inline-flex; align-items:center; justify-content:center; min-width: 128px; min-height: 44px; padding: 10px 16px;
+        border-radius: 999px; background: #1e293b; border: 1px solid rgba(148, 163, 184, 0.18);
+      }
+      .footer-nav .disabled { color: #64748b; }
+      @media (max-width: 720px) {
+        .viewer { grid-template-columns: 1fr; grid-template-rows: auto 1fr auto; }
+        .nav-area { min-height: auto; padding: 12px 16px; }
+        .nav-link, .nav-label { writing-mode: initial; }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="viewer">
+      <section class="nav-area <%= nextPage ? '' : 'disabled' %>">
+        <% if (nextPage) { %>
+          <a class="nav-link" href="<%= nextPage.href %>">次ページ</a>
+        <% } else { %>
+          <span class="nav-label">次ページなし</span>
+        <% } %>
+      </section>
+
+      <section class="content-area">
+        <header class="meta">
+          <h1>ビューアー</h1>
+          <div class="meta-chip">mediaId: <%= mediaId %> / page: <%= mediaPage %></div>
+        </header>
+
+        <article class="stage">
+          <% if (content.type === 'video') { %>
+            <video src="<%= content.id %>" controls playsinline>
+              動画を再生できません。
+            </video>
+          <% } else { %>
+            <a href="<%= nextPage ? nextPage.href : '#' %>" <%= nextPage ? '' : 'aria-disabled="true"' %>>
+              <img src="<%= content.id %>" alt="<%= mediaId %> の <%= mediaPage %> ページ" />
+            </a>
+          <% } %>
+        </article>
+
+        <nav class="footer-nav" aria-label="ページ移動">
+          <% if (previousPage) { %>
+            <a href="<%= previousPage.href %>">前ページ</a>
+          <% } else { %>
+            <span class="disabled">前ページなし</span>
+          <% } %>
+
+          <% if (nextPage) { %>
+            <a href="<%= nextPage.href %>">次ページ</a>
+          <% } else { %>
+            <span class="disabled">次ページなし</span>
+          <% } %>
+        </nav>
+      </section>
+
+      <section class="nav-area <%= previousPage ? '' : 'disabled' %>">
+        <% if (previousPage) { %>
+          <a class="nav-link" href="<%= previousPage.href %>">前ページ</a>
+        <% } else { %>
+          <span class="nav-label">前ページなし</span>
+        <% } %>
+      </section>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
### Motivation
- API/OpenAPI と UI 仕様に従い、`mediaId` と `mediaPage` から対象コンテンツと前後ページナビゲーションを表示する viewer 画面の導線を実装するため。  
- 画面で利用するサービスを `createDependencies` / `setupRoutes` に配線してアプリから利用可能にするため。  
- 境界ページ・未存在メディア/ページ時の挙動をテストで固定し回帰を防ぐため。

### Description
- `src/controller/screen/ScreenViewerGetController.js` を追加し、`GetMediaContentWithNavigationService` を用いて対象コンテンツ取得・前後ナビを生成し、テンプレート `screen/viewer` をレンダリングまたはエラー時に `/screen/error` へリダイレクトする処理を実装しました。  
- `src/controller/router/screen/setRouterScreenViewerGet.js` を追加し、`/screen/viewer/:mediaId/:mediaPage` のルートを登録する route setter を追加しました。  
- `src/app/createDependencies.js` と `src/app/setupRoutes.js` に viewer 用サービスと route setter の配線を追加し、`GetMediaContentWithNavigationService` を生成して依存関係に含めました。  
- `src/application/media/query/GetMediaContentWithNavigationService.js` の `mediaId` 参照不整合 (`input.id` → `input.mediaId`) を修正しました。  
- 表示用テンプレート `src/views/screen/viewer.ejs` を追加し、画像・動画表示および前後ページ導線を描画する UI を実装しました。  
- viewer 到達・境界ページ・未存在メディア/ページの単体・中間テストを `__tests__/small/controller/router/screen/setRouterScreenViewerGet.test.js` と `__tests__/medium/controller/router/screen/setRouterScreenViewerGet.test.js` に追加しました。

### Testing
- モジュール読み込みのスモークテストとして `node -e "require(...)"` によるインポート確認は成功しました（コントローラ・route setter・サービスのモジュールが読み込めることを確認）。  
- 追加した Jest テスト群の実行を試みましたが、現在の環境では `jest` の取得ができずテスト実行はできませんでした（`jest: not found` / npm レジストリアクセス制限のため）。  
- EJS テンプレート描画の確認を試みましたが、実行環境に `ejs` が存在しないため完全なレンダリング検証は行えませんでした。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1557b5bf8832b86d60f6ac20b92f6)