### PR TITLE
docs: /screen/queue と /screen/viewer ルーター設計書を追加

### DIFF
--- a/doc/5_api/controller/router/screen/setRouterScreenQueueGet/readme.md
+++ b/doc/5_api/controller/router/screen/setRouterScreenQueueGet/readme.md
@@ -1,0 +1,50 @@
+# router (GET /screen/queue)
+
+## 概要
+- あとで見る一覧画面表示用のルーティング定義を担当する。
+- セッション認証後にキュー一覧取得サービスを呼び出し、`screen/queue` を描画する。
+- Node.js / Express の `router.get` に対して、`SessionAuthMiddleware` と非同期描画ハンドラーを設定する。
+
+## 対象
+- `GET /screen/queue`
+
+## 認証
+- 必須。
+- `SessionAuthMiddleware` により `req.session.session_token` を検証し、`req.context.userId` を設定する。
+
+## 依存
+- [SessionAuthMiddleware](/doc/5_api/controller/middleware/SessionAuthMiddleware/readme.md)
+- [GetQueueService](/doc/4_application/user/query/GetQueueService/readme.md)
+
+## 依存注入
+- `router`
+  - Express Router。
+  - `get(path, ...handlers)` を持つ。
+- `authResolver`
+  - セッショントークンから `userId` を解決するアダプタ。
+  - `execute(token)` を持つ。
+- `getQueueService`
+  - あとで見る一覧取得アプリケーションサービス。
+  - `execute(input)` を持つ。
+
+## ルーティングフロー
+1. `SessionAuthMiddleware`
+   - `req.session.session_token` を検証し、`req.context.userId` を設定する。
+2. 非同期描画ハンドラー
+   - `req.context.userId` を使って `GetQueueService` を実行する。
+   - 取得した `mediaOverviews` を `screen/queue` に渡して描画する。
+
+## レスポンス / 描画先
+- 正常系
+  - HTTP ステータス `200` を返す。
+  - `screen/queue` を描画する。
+  - 描画データとして以下を渡す。
+    - `pageTitle`: `あとで見る一覧`
+    - `mediaOverviews`: サービスが返した一覧
+
+## エラーハンドリング
+- 認証失敗時は `401` を返す（SessionAuthMiddleware）。
+- 一覧取得失敗時は `next(error)` に委譲する。
+
+## 関連ドキュメント
+- [routerテストケース](/doc/5_api/controller/router/screen/setRouterScreenQueueGet/testcase.md)

--- a/doc/5_api/controller/router/screen/setRouterScreenQueueGet/testcase.md
+++ b/doc/5_api/controller/router/screen/setRouterScreenQueueGet/testcase.md
@@ -1,0 +1,48 @@
+# router (GET /screen/queue) テストケース
+
+## テストケース一覧
+- [GET /screen/queue に認証・描画の2ハンドラーを登録する](#get-screenqueue-に認証描画の2ハンドラーを登録する)
+- [登録済みハンドラーを順に実行するとあとで見る一覧画面を描画する](#登録済みハンドラーを順に実行するとあとで見る一覧画面を描画する)
+- [一覧取得で例外が発生した場合は next に委譲する](#一覧取得で例外が発生した場合は-next-に委譲する)
+
+---
+
+### GET /screen/queue に認証・描画の2ハンドラーを登録する
+- **前提**
+  - `router.get` をモック化する。
+  - `authResolver` / `getQueueService` は有効な依存を注入する。
+- **操作**
+  - `setRouterScreenQueueGet` を実行する。
+- **結果**
+  - `router.get` が1回呼ばれる。
+  - 第1引数が `/screen/queue` である。
+  - 第2引数以降に2つのハンドラーが設定される。
+  - 第1ハンドラーに認証ミドルウェアが適用される。
+
+---
+
+### 登録済みハンドラーを順に実行するとあとで見る一覧画面を描画する
+- **前提**
+  - `authResolver.execute` は `userId` を返す。
+  - `getQueueService.execute` は `mediaOverviews` を含む結果を返す。
+- **操作**
+  - 登録済みの2ハンドラーを順に実行する。
+- **結果**
+  - 認証処理が `session_token` で呼ばれる。
+  - 一覧取得処理が `req.context.userId` を使って実行される。
+  - `screen/queue` が `pageTitle` と `mediaOverviews` を含む表示データで描画される。
+
+---
+
+### 一覧取得で例外が発生した場合は next に委譲する
+- **前提**
+  - `getQueueService.execute` が例外を送出する。
+- **操作**
+  - 描画ハンドラーを実行する。
+- **結果**
+  - `next(error)` が呼ばれる。
+
+## medium テストで担保する観点
+- `__tests__/medium/controller/router/screen/setRouterScreenQueueGet.test.js` では、Express アプリへ当該ルーターを登録した状態で `GET /screen/queue` を実行し、認証済みセッションから HTML を返せることを担保する。
+- medium テストでは `SessionStateAuthAdapter` により `x-session-token` から `userId` を解決し、認証ミドルウェアが実際に適用されることを担保する。
+- medium テストでは `GetQueueService` 相当の依存が返した `mediaOverviews` 件数を描画結果へ反映し、`screen/queue` テンプレートが応答に使われることを担保する。

--- a/doc/5_api/controller/router/screen/setRouterScreenViewerGet/readme.md
+++ b/doc/5_api/controller/router/screen/setRouterScreenViewerGet/readme.md
@@ -1,0 +1,57 @@
+# router (GET /screen/viewer/:mediaId/:mediaPage)
+
+## 概要
+- ビューアー画面表示用のルーティング定義を担当する。
+- セッション認証後にビューアー画面コントローラーを呼び出し、`screen/viewer` を描画する。
+- Node.js / Express の `router.get` に対して、`SessionAuthMiddleware` → `ScreenViewerGetController` の順でハンドラーを設定する。
+
+## 対象
+- `GET /screen/viewer/:mediaId/:mediaPage`
+
+## 認証
+- 必須。
+- `SessionAuthMiddleware` により `req.session.session_token` を検証し、`req.context.userId` を設定する。
+
+## 依存
+- [SessionAuthMiddleware](/doc/5_api/controller/middleware/SessionAuthMiddleware/readme.md)
+- [ScreenViewerGetController](/doc/5_api/controller/screen/ScreenViewerGetController/readme.md)
+- [GetMediaContentWithNavigationService](/doc/4_application/media/query/GetMediaContentWithNavigationService/readme.md)
+
+## 依存注入
+- `router`
+  - Express Router。
+  - `get(path, ...handlers)` を持つ。
+- `authResolver`
+  - セッショントークンから `userId` を解決するアダプタ。
+  - `execute(token)` を持つ。
+- `getMediaContentWithNavigationService`
+  - 対象ページと前後ページのコンテンツを取得するアプリケーションサービス。
+  - `execute(input)` を持つ。
+
+## ルーティングフロー
+1. `SessionAuthMiddleware`
+   - `req.session.session_token` を検証し、`req.context.userId` を設定する。
+2. `ScreenViewerGetController`
+   - `req.params.mediaId` / `req.params.mediaPage` を使って `GetMediaContentWithNavigationService` を実行する。
+   - 正常時は `screen/viewer` を描画し、異常時は `/screen/error` へリダイレクトする。
+
+## レスポンス / 描画先
+- 正常系
+  - HTTP ステータス `200` を返す。
+  - `screen/viewer` を描画する。
+  - 描画データとして以下を渡す。
+    - `pageTitle`: `ビューアー {mediaId} - {mediaPage}ページ`
+    - `mediaId`
+    - `mediaPage`
+    - `content`
+    - `previousPage`
+    - `nextPage`
+- 異常系
+  - メディア未存在・ページ未存在・予期しない例外時は `/screen/error` へ `301` リダイレクトする。
+
+## エラーハンドリング
+- 認証失敗時は `401` を返す（SessionAuthMiddleware）。
+- ビューアー表示処理中のエラー制御は `ScreenViewerGetController` 側に委譲する。
+
+## 関連ドキュメント
+- [routerテストケース](/doc/5_api/controller/router/screen/setRouterScreenViewerGet/testcase.md)

--- a/doc/5_api/controller/router/screen/setRouterScreenViewerGet/testcase.md
+++ b/doc/5_api/controller/router/screen/setRouterScreenViewerGet/testcase.md
@@ -1,0 +1,49 @@
+# router (GET /screen/viewer/:mediaId/:mediaPage) テストケース
+
+## テストケース一覧
+- [GET /screen/viewer/:mediaId/:mediaPage に認証・描画の2ハンドラーを登録する](#get-screenviewermediaidmediapage-に認証描画の2ハンドラーを登録する)
+- [登録済みハンドラーを順に実行するとビューアー画面を描画する](#登録済みハンドラーを順に実行するとビューアー画面を描画する)
+- [コントローラーで異常系結果を受けた場合はエラー画面へ遷移する](#コントローラーで異常系結果を受けた場合はエラー画面へ遷移する)
+
+---
+
+### GET /screen/viewer/:mediaId/:mediaPage に認証・描画の2ハンドラーを登録する
+- **前提**
+  - `router.get` をモック化する。
+  - `authResolver` / `getMediaContentWithNavigationService` は有効な依存を注入する。
+- **操作**
+  - `setRouterScreenViewerGet` を実行する。
+- **結果**
+  - `router.get` が1回呼ばれる。
+  - 第1引数が `/screen/viewer/:mediaId/:mediaPage` である。
+  - 第2引数以降に2つのハンドラーが設定される。
+  - 第1ハンドラーに認証ミドルウェアが適用される。
+
+---
+
+### 登録済みハンドラーを順に実行するとビューアー画面を描画する
+- **前提**
+  - `authResolver.execute` は `userId` を返す。
+  - `getMediaContentWithNavigationService.execute` は表示対象コンテンツと前後ページ情報を返す。
+- **操作**
+  - 登録済みの2ハンドラーを順に実行する。
+- **結果**
+  - 認証処理が `session_token` で呼ばれる。
+  - ビューアー取得処理が `mediaId` / `mediaPage` を使って実行される。
+  - `screen/viewer` が `content` / `previousPage` / `nextPage` を含む表示データで描画される。
+
+---
+
+### コントローラーで異常系結果を受けた場合はエラー画面へ遷移する
+- **前提**
+  - `getMediaContentWithNavigationService.execute` がメディア未存在・ページ未存在、または例外送出となる結果を返す。
+- **操作**
+  - 描画ハンドラーを実行する。
+- **結果**
+  - `/screen/error` へのリダイレクトに委譲される。
+
+## medium テストで担保する観点
+- `__tests__/medium/controller/router/screen/setRouterScreenViewerGet.test.js` では、Express アプリへ当該ルーターを登録した状態で `GET /screen/viewer/:mediaId/:mediaPage` を実行し、認証済みセッションから HTML を返せることを担保する。
+- medium テストでは `FoundResult` を返した際に `screen/viewer` テンプレートが描画され、`pageTitle`、表示中コンテンツ、前後ページ導線がレスポンスへ反映されることを担保する。
+- medium テストでは先頭ページで `previousPage` が `null` になり、前ページ導線なしで描画されることを担保する。
+- medium テストでは `MediaNotFoundResult` と `ContentNotFoundResult` の双方で `/screen/error` へ `301` リダイレクトされることを担保する。


### PR DESCRIPTION
### Motivation
- `setRouterScreenQueueGet` と `setRouterScreenViewerGet` に対応する設計書が未整備で、ルート・認証・依存・描画先やテスト保証範囲の追跡が困難だったため。 
- 既存の `setRouterScreenDetailGet` / `setRouterScreenFavoriteGet` と文体・章立てを揃え、小・中規模テスト観点から保証内容を明文化することで保守性を高めるため。 

### Description
- `doc/5_api/controller/router/screen/setRouterScreenQueueGet/readme.md` を追加し、ルート、認証要否、依存サービス、ルーティングフロー、レスポンス/描画先、エラーハンドリングを明記しました。 
- `doc/5_api/controller/router/screen/setRouterScreenQueueGet/testcase.md` を追加し、small 観点（ルート登録・認証ミドルウェア適用・依存 service 呼び出し・エラー時の `next(error)` 委譲）と medium 観点の保証内容を記載しました。 
- `doc/5_api/controller/router/screen/setRouterScreenViewerGet/readme.md` を追加し、ルート、認証要否、依存コントローラー/サービス、正常/異常時の挙動（`screen/viewer` 描画・`/screen/error` リダイレクト）を明記しました。 
- `doc/5_api/controller/router/screen/setRouterScreenViewerGet/testcase.md` を追加し、small/medium テスト観点（HTML 描画・前後ページ導線・エラー時リダイレクト等）を整理しました。 

### Testing
- ファイル作成の存在確認を `node -e` によるチェックで実行し、全ファイルのアクセス確認が成功しました。 
- リポジトリ操作として `git commit` により変更をコミットし、最新コミットが作成されることを `git log -1 --stat --oneline` で確認しました。 
- 既存の自動テストスイート（unit/medium 等）は今回実行しておらず、設計書の追加のみを行っています。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1617ae198832b8bd59fb082b12fa4)