### PR TITLE
docs: 開発用固定セッション機能の専用設計書を追加する

### DIFF
--- a/doc/1_requirements/architecture.md
+++ b/doc/1_requirements/architecture.md
@@ -5,3 +5,10 @@
 - EJSを用いたテンプレートエンジン
 - SequelizeによるORM
 - DBは開発時SQLite3、本番はPostgreSQL
+- 開発支援として、対象パスへ固定 `session_token` を自動補完できる DevelopmentSession を備える
+
+## 開発支援機能
+- DevelopmentSession は、認証付き画面・API のローカル確認を容易にするための開発専用機能である。
+- `DEV_SESSION_TOKEN` / `DEV_SESSION_USER_ID` / `DEV_SESSION_TTL_MS` / `DEV_SESSION_PATHS` が揃った場合のみ有効化する。
+- 対象は `DEV_SESSION_PATHS` に列挙したパスに限定し、通常のヘッダ / Cookie によるセッション指定がある場合はそちらを優先する。
+- 本番環境や公開環境では利用しないことを前提とし、固定トークンを秘匿情報として扱う。

--- a/doc/5_api/controller/middleware/DevelopmentSession/readme.md
+++ b/doc/5_api/controller/middleware/DevelopmentSession/readme.md
@@ -1,0 +1,87 @@
+# DevelopmentSession
+
+## 概要
+- 開発環境でのみ利用する、固定セッショントークン注入機能。
+- `src/app/developmentSession.js` が有効条件判定（`hasDevelopmentSession` / `shouldApplyDevelopmentSession`）を担い、`src/app/setupMiddleware.js` が対象リクエストへ `req.session.session_token` を補完する。
+- `src/app/createDependencies.js` は有効化時に固定セッションを `sessionStateStore` へ事前登録し、`src/server.js` は環境変数の解釈と起動ログ出力を担当する。
+- 通常ログインを置き換える本番機能ではなく、画面確認・手動疎通・ローカル開発を支援する補助手段として位置づける。
+
+## 開発支援機能としての位置づけ
+- 認証付き画面やAPIの開発・動作確認時に、毎回ログイン操作を行わずに既知のユーザーとしてアクセスできるようにする。
+- `x-session-token` ヘッダや `session_token` Cookie が未設定のときだけ固定セッションを補完し、通常の認証導線を優先する。
+- 想定利用者は開発者・ローカル検証者に限定し、公開環境・本番環境・不特定多数が接続する環境では利用しない。
+
+## 環境変数
+
+| 名前 | 必須条件 | 役割 |
+| --- | --- | --- |
+| `DEV_SESSION_TOKEN` | `string` かつ空文字不可 | 開発用に固定注入する `session_token` 値 |
+| `DEV_SESSION_USER_ID` | `string` かつ空文字不可 | 固定セッションに紐づく利用者ID |
+| `DEV_SESSION_TTL_MS` | 正の整数 | 固定セッションをストアへ保持する有効期限（ミリ秒） |
+| `DEV_SESSION_PATHS` | カンマ区切り文字列 | 固定セッションを自動補完する対象パス一覧 |
+
+- `server.js` の `createEnv` では `DEV_SESSION_PATHS` をカンマ区切りで分割し、前後空白を除去した `devSessionPaths: string[]` に変換する。
+- `DEV_SESSION_TTL_MS` は `Number.parseInt(..., 10)` で整数化し、未設定や不正値は `0` 扱いとなる。
+
+## 有効条件
+
+### `hasDevelopmentSession`
+以下をすべて満たす場合のみ `true` と判定する。
+- `devSessionToken` が空文字ではない `string`
+- `devSessionUserId` が空文字ではない `string`
+- `devSessionTtlMs` が正の整数
+
+### `shouldApplyDevelopmentSession`
+以下をすべて満たす場合のみ `true` と判定する。
+- `hasDevelopmentSession(env)` が `true`
+- `env.devSessionPaths` が配列である
+- `requestPath` が `env.devSessionPaths` に完全一致で含まれる
+
+## 対象パス
+- `DEV_SESSION_PATHS` に列挙したパスに対してのみ固定セッションを補完する。
+- 判定は `req.path` の完全一致で行うため、前方一致・ワイルドカード・正規表現は扱わない。
+- 対象例
+  - `/screen/entry`
+  - `/api/media`
+- 非対象例
+  - `DEV_SESSION_PATHS` に未登録の `/unknown`
+  - `/screen/entry/subpath` のような部分一致のみのパス
+
+## セキュリティ上の前提
+- 固定トークンは認証回避のための開発補助機能であるため、秘密情報として扱い、リポジトリへハードコードしない。
+- 本機能は本番利用を想定しない。公開環境で有効化すると、対象パスに対して固定ユーザーへ成り代わり可能になるため禁止する。
+- 対象パスは最小限に限定し、開発に不要な管理系・更新系エンドポイントへ無制限に適用しない。
+- `x-session-token` ヘッダおよび `session_token` Cookie が優先されるため、明示的なログイン結果や検証用トークンを上書きしない。
+- `DEV_SESSION_TTL_MS` を有限値にすることで、開発用セッションも無期限に残置しない。
+
+## 配線
+
+### `server.js`
+- `process.env` から `DEV_SESSION_TOKEN` / `DEV_SESSION_USER_ID` / `DEV_SESSION_TTL_MS` / `DEV_SESSION_PATHS` を読み取り、`createEnv` でアプリケーション向けの `env` へ変換する。
+- `startServer` では `hasDevelopmentSession(env)` が `true` の場合に、起動ログへ固定セッション有効化状態（`userId` と `paths`）を出力する。
+
+### `createDependencies`
+- `InMemorySessionStateStore` 初期化後、`hasDevelopmentSession(env)` が `true` の場合は `sessionStateStore.save(...)` を実行する。
+- 登録内容は以下の3項目。
+  - `sessionToken: env.devSessionToken`
+  - `userId: env.devSessionUserId`
+  - `ttlMs: env.devSessionTtlMs`
+- これにより、後続の `SessionAuthMiddleware` が固定トークンから `userId` を解決できるようにする。
+
+### `setupMiddleware`
+- リクエストごとに `req.session` ヘルパーを初期化する。
+- `x-session-token` ヘッダが存在する場合は、その値を `req.session.session_token` へ設定する。
+- ヘッダがなく `session_token` Cookie が存在する場合は、その値を `req.session.session_token` へ設定する。
+- ヘッダ・Cookie のどちらも無い場合のみ、`shouldApplyDevelopmentSession({ env, requestPath: req.path })` を評価する。
+- `true` のとき `req.session.session_token = env.devSessionToken` を設定し、以降の認証ミドルウェアで通常セッションと同様に扱う。
+
+## 認証フロー上の扱い
+1. `server.js` が環境変数から開発用固定セッション設定を組み立てる。
+2. `createDependencies` が固定セッションをセッションストアへ保存する。
+3. `setupMiddleware` が対象パスへのリクエストに限り固定トークンを `req.session.session_token` へ補完する。
+4. `SessionAuthMiddleware` が通常セッションと同じ経路で `session_token` を検証し、`userId` を解決する。
+
+## 運用上の注意
+- CI やステージングで利用する場合も「開発者のみが閉域で利用する」ことを明文化した上で限定運用する。
+- ログに `userId` と対象パスが出力されるため、共有ログ基盤へ送る場合は閲覧権限を制御する。
+- 対象パス追加時は、認証要否と副作用の有無を確認してから `DEV_SESSION_PATHS` に追記する。

--- a/doc/5_api/controller/middleware/DevelopmentSession/testcase.md
+++ b/doc/5_api/controller/middleware/DevelopmentSession/testcase.md
@@ -1,0 +1,78 @@
+# DevelopmentSession テストケース
+
+## テストケース一覧
+- [固定セッション設定が揃っていると有効と判定する](#固定セッション設定が揃っていると有効と判定する)
+- [固定セッション設定のいずれかが欠けると無効と判定する](#固定セッション設定のいずれかが欠けると無効と判定する)
+- [対象パスのみ固定セッションを補完対象と判定する](#対象パスのみ固定セッションを補完対象と判定する)
+- [固定セッションが無効な場合は対象パスでも補完対象にしない](#固定セッションが無効な場合は対象パスでも補完対象にしない)
+
+---
+
+## 正常系
+
+### 固定セッション設定が揃っていると有効と判定する
+
+- **対応テスト**
+  - `__tests__/small/app/developmentSession.test.js`
+  - `固定セッション設定が揃っていると有効と判定する`
+- **前提**
+  - `devSessionToken` に空文字ではない `string` が設定されている。
+  - `devSessionUserId` に空文字ではない `string` が設定されている。
+  - `devSessionTtlMs` に正の整数が設定されている。
+- **操作**
+  - `hasDevelopmentSession(env)` を実行する。
+- **結果**
+  - 戻り値は `true` になる。
+
+---
+
+### 対象パスのみ固定セッションを補完対象と判定する
+
+- **対応テスト**
+  - `__tests__/small/app/developmentSession.test.js`
+  - `対象パスのみ固定セッションを補完対象と判定する`
+- **前提**
+  - `hasDevelopmentSession(env)` が `true` となる固定セッション設定が存在する。
+  - `devSessionPaths` に `/screen/entry` と `/api/media` が設定されている。
+- **操作**
+  - `shouldApplyDevelopmentSession({ env, requestPath })` を、`/screen/entry`、`/api/media`、`/unknown` でそれぞれ実行する。
+- **結果**
+  - `/screen/entry` は `true` になる。
+  - `/api/media` は `true` になる。
+  - `/unknown` は `false` になる。
+
+---
+
+## 準正常系 / 異常系
+
+### 固定セッション設定のいずれかが欠けると無効と判定する
+
+- **対応テスト**
+  - 未実装（追加候補）
+- **前提**
+  - 以下のいずれかが成り立つ。
+    - `devSessionToken` が未設定・空文字である。
+    - `devSessionUserId` が未設定・空文字である。
+    - `devSessionTtlMs` が未設定・`0`・負数・整数以外である。
+- **操作**
+  - `hasDevelopmentSession(env)` を実行する。
+- **結果**
+  - 戻り値は `false` になる。
+  - `createDependencies` は固定セッションを事前登録しない。
+  - `server.js` は固定セッション有効化ログを出力しない。
+
+---
+
+### 固定セッションが無効な場合は対象パスでも補完対象にしない
+
+- **対応テスト**
+  - 未実装（追加候補）
+- **前提**
+  - `requestPath` は `devSessionPaths` に含まれている。
+  - ただし `hasDevelopmentSession(env)` は `false` である。
+- **操作**
+  - `shouldApplyDevelopmentSession({ env, requestPath })` を実行する。
+- **結果**
+  - 戻り値は `false` になる。
+  - `setupMiddleware` は `req.session.session_token` を自動補完しない。
+


### PR DESCRIPTION
### Motivation
- 開発用固定セッションの責務や有効条件がコード内に分散しており、利用上の前提（開発専用・本番禁止・対象パス限定）を明文化する必要があった。 
- `setupMiddleware` / `createDependencies` / `server.js` にまたがる配線を設計書へ整理し、運用・テストの基準を統一するため。 
- 既存の small test（`__tests__/small/app/developmentSession.test.js`）と設計書の対応関係を残し、将来的なテスト追加の指針とするため。

### Description
- `doc/5_api/controller/middleware/DevelopmentSession/readme.md` を新規追加し、機能概要、環境変数仕様、`hasDevelopmentSession`／`shouldApplyDevelopmentSession` の判定条件、対象パス、セキュリティ前提、および `server.js` / `createDependencies` / `setupMiddleware` への配線を整理して記載した。 
- `doc/5_api/controller/middleware/DevelopmentSession/testcase.md` を新規追加し、既存の `__tests__/small/app/developmentSession.test.js` に対応するテストケース項目（正常系・準正常系）と未実装の追加候補を設計書へ落とし込んだ。 
- `doc/1_requirements/architecture.md` に DevelopmentSession の概要（開発支援機能である旨・対象パス限定・通常セッション優先・本番利用禁止の注意）を追記して、要件レベルでも追跡できるようにした。 
- 変更はコミット済み（コミットメッセージ: `docs: 開発用固定セッション機能の専用設計書を追加する`）。

### Testing
- `npm test -- --runTestsByPath __tests__/small/app/developmentSession.test.js` を試行したが、この実行環境では `jest: not found` により自動テストの実行は完了できなかった（依存解決が必要）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c16184fe9c832ba91dae33219d5799)