### PR TITLE
Screen系controllerの設計書追加とScreenViewerGetControllerのsmallテスト追加

### DIFF
--- a/__tests__/small/controller/screen/ScreenViewerGetController.test.js
+++ b/__tests__/small/controller/screen/ScreenViewerGetController.test.js
@@ -1,0 +1,121 @@
+const ScreenViewerGetController = require('../../../../src/controller/screen/ScreenViewerGetController');
+const {
+  FoundResult,
+  MediaNotFoundResult,
+  ContentNotFoundResult,
+} = require('../../../../src/application/media/query/GetMediaContentWithNavigationService');
+
+describe('ScreenViewerGetController', () => {
+  const createRes = () => {
+    const res = {
+      status: jest.fn(),
+      render: jest.fn(),
+      redirect: jest.fn(),
+    };
+    res.status.mockReturnValue(res);
+    return res;
+  };
+
+  test('FoundResult の場合は viewer 描画モデルを生成して描画する', async () => {
+    const getMediaContentWithNavigationService = {
+      execute: jest.fn().mockResolvedValue(new FoundResult({
+        contentId: '/contents/page-2.jpg',
+        previousContentId: '/contents/page-1.jpg',
+        nextContentId: '/contents/page-3.jpg',
+      })),
+    };
+    const controller = new ScreenViewerGetController({ getMediaContentWithNavigationService });
+    const req = { params: { mediaId: 'media-1', mediaPage: '2' } };
+    const res = createRes();
+
+    await controller.execute(req, res);
+
+    expect(getMediaContentWithNavigationService.execute).toHaveBeenCalledWith(expect.objectContaining({
+      mediaId: 'media-1',
+      contentPosition: 2,
+    }));
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.render).toHaveBeenCalledWith('screen/viewer', {
+      pageTitle: 'ビューアー media-1 - 2ページ',
+      mediaId: 'media-1',
+      mediaPage: 2,
+      content: {
+        id: '/contents/page-2.jpg',
+        type: 'image',
+      },
+      previousPage: {
+        mediaId: 'media-1',
+        mediaPage: 1,
+        contentId: '/contents/page-1.jpg',
+        href: '/screen/viewer/media-1/1',
+      },
+      nextPage: {
+        mediaId: 'media-1',
+        mediaPage: 3,
+        contentId: '/contents/page-3.jpg',
+        href: '/screen/viewer/media-1/3',
+      },
+    });
+  });
+
+  test('動画 contentId は type=video として先頭/末尾導線なしを描画する', async () => {
+    const getMediaContentWithNavigationService = {
+      execute: jest.fn().mockResolvedValue(new FoundResult({
+        contentId: '/contents/page-10.mp4',
+        previousContentId: null,
+        nextContentId: null,
+      })),
+    };
+    const controller = new ScreenViewerGetController({ getMediaContentWithNavigationService });
+    const res = createRes();
+
+    await controller.execute({ params: { mediaId: 'media-video', mediaPage: '10' } }, res);
+
+    expect(res.render).toHaveBeenCalledWith('screen/viewer', expect.objectContaining({
+      content: {
+        id: '/contents/page-10.mp4',
+        type: 'video',
+      },
+      previousPage: null,
+      nextPage: null,
+    }));
+  });
+
+  test.each([
+    ['MediaNotFoundResult', new MediaNotFoundResult()],
+    ['ContentNotFoundResult', new ContentNotFoundResult()],
+  ])('%s の場合はエラー画面へ 301 リダイレクトする', async (_name, serviceResult) => {
+    const getMediaContentWithNavigationService = {
+      execute: jest.fn().mockResolvedValue(serviceResult),
+    };
+    const controller = new ScreenViewerGetController({ getMediaContentWithNavigationService });
+    const res = createRes();
+
+    await controller.execute({ params: { mediaId: 'media-404', mediaPage: '99' } }, res);
+
+    expect(res.redirect).toHaveBeenCalledWith(301, '/screen/error');
+  });
+
+  test('想定外の戻り値や service 例外時はエラー画面へ 301 リダイレクトする', async () => {
+    const unexpectedService = {
+      execute: jest.fn().mockResolvedValue({ kind: 'unexpected' }),
+    };
+    const rejectedService = {
+      execute: jest.fn().mockRejectedValue(new Error('failed')),
+    };
+    const unexpectedController = new ScreenViewerGetController({
+      getMediaContentWithNavigationService: unexpectedService,
+    });
+    const rejectedController = new ScreenViewerGetController({
+      getMediaContentWithNavigationService: rejectedService,
+    });
+    const unexpectedRes = createRes();
+    const rejectedRes = createRes();
+
+    await unexpectedController.execute({ params: { mediaId: 'media-1', mediaPage: '1' } }, unexpectedRes);
+    await rejectedController.execute({ params: { mediaId: 'media-1', mediaPage: '1' } }, rejectedRes);
+
+    expect(unexpectedRes.redirect).toHaveBeenCalledWith(301, '/screen/error');
+    expect(rejectedRes.redirect).toHaveBeenCalledWith(301, '/screen/error');
+  });
+});

--- a/doc/5_api/controller/screen/ScreenDetailGetController/readme.md
+++ b/doc/5_api/controller/screen/ScreenDetailGetController/readme.md
@@ -1,0 +1,50 @@
+# ScreenDetailGetController
+
+## 概要
+- `GET /screen/detail/:mediaId` の画面描画責務を持つ controller。
+- `req.params.mediaId` を `GetMediaDetailService` の `Input` に変換して実行し、取得した `mediaDetail` を `screen/detail` テンプレートへ渡す。
+- not found を含む service 実行失敗時は詳細画面固有の分岐を持たず、`/screen/error` へ `301` リダイレクトする。
+
+## 配置
+- 実装: `src/controller/screen/ScreenDetailGetController.js`
+- 対応 route: `GET /screen/detail/:mediaId`
+- 描画テンプレート: `src/views/screen/detail.ejs`
+
+## 入力
+- `req.params.mediaId`
+  - 型: `string`
+  - 用途: `GetMediaDetailService.Input.mediaId`
+- `res`
+  - `status(code)` と `render(view, model)`、`redirect(status, url)` を持つこと。
+
+## 依存
+- [GetMediaDetailService](/doc/4_application/media/query/GetMediaDetailService/readme.md)
+  - `execute(input)` を提供する。
+  - controller は `new Input({ mediaId })` を生成して渡す。
+
+## 処理フロー
+1. `req.params.mediaId` から `GetMediaDetailService.Input` を生成する。
+2. `getMediaDetailService.execute(input)` を await する。
+3. 成功時は `res.status(200).render('screen/detail', model)` を返す。
+4. service が例外を送出した場合は `res.redirect(301, '/screen/error')` を返す。
+
+## 描画モデル
+- `pageTitle`
+  - `${result.mediaDetail.title} の詳細`
+- `mediaDetail`
+  - service から受け取った `result.mediaDetail` をそのまま引き渡す。
+
+## not found / エラー時の振る舞い
+- service 側で not found を例外として通知した場合を含め、controller は例外を一律で捕捉する。
+- 捕捉した例外の種別やメッセージはレスポンスへ反映せず、`/screen/error` へ `301` リダイレクトする。
+
+## テスト方針
+- controller 単体の small テストでは以下に絞る。
+  - `mediaId` の入力変換
+  - 成功時の描画モデル生成
+  - 失敗時の `/screen/error` へのリダイレクト
+- 認証や route 登録順序、Express 統合は router テストに委譲する。
+
+## 関連ドキュメント
+- [controllerテストケース](/doc/5_api/controller/screen/ScreenDetailGetController/testcase.md)
+- [router設計書](/doc/5_api/controller/router/screen/setRouterScreenDetailGet/readme.md)

--- a/doc/5_api/controller/screen/ScreenDetailGetController/testcase.md
+++ b/doc/5_api/controller/screen/ScreenDetailGetController/testcase.md
@@ -1,0 +1,33 @@
+# ScreenDetailGetController テストケース
+
+## テストケース一覧
+- [mediaId を service に渡して詳細画面を描画する](#mediaid-を-service-に渡して詳細画面を描画する)
+- [service 取得に失敗した場合はエラー画面へ 301 リダイレクトする](#service-取得に失敗した場合はエラー画面へ-301-リダイレクトする)
+
+---
+
+### mediaId を service に渡して詳細画面を描画する
+- **前提**
+  - `req.params.mediaId` に文字列のメディアIDが設定されている。
+  - `getMediaDetailService.execute` は `mediaDetail` を含む結果を返す。
+- **操作**
+  - `execute(req, res)` を呼び出す。
+- **結果**
+  - service が `Input.mediaId = req.params.mediaId` で呼び出される。
+  - `screen/detail` が `200` で描画される。
+  - `pageTitle` と `mediaDetail` が描画モデルへ設定される。
+
+---
+
+### service 取得に失敗した場合はエラー画面へ 301 リダイレクトする
+- **前提**
+  - `getMediaDetailService.execute` が例外を送出する。
+- **操作**
+  - `execute(req, res)` を呼び出す。
+- **結果**
+  - `res.redirect(301, '/screen/error')` が呼ばれる。
+  - 例外内容に依存した分岐は持たない。
+
+## テスト責務の境界
+- 認証ミドルウェアとの接続、route path、実際の HTTP レスポンスは router / medium テストで担保する。
+- controller 単体では入力変換・分岐・描画モデル生成のみを確認する。

--- a/doc/5_api/controller/screen/ScreenViewerGetController/readme.md
+++ b/doc/5_api/controller/screen/ScreenViewerGetController/readme.md
@@ -1,0 +1,76 @@
+# ScreenViewerGetController
+
+## 概要
+- `GET /screen/viewer/:mediaId/:mediaPage` の画面描画責務を持つ controller。
+- `req.params.mediaId` と `req.params.mediaPage` を `GetMediaContentWithNavigationService.Input` に変換し、戻り値の種別に応じて viewer 描画またはエラー画面遷移を決定する。
+- `FoundResult` のときのみ `screen/viewer` を描画し、前後ページ導線とコンテンツ種別を含む描画モデルを生成する。
+
+## 配置
+- 実装: `src/controller/screen/ScreenViewerGetController.js`
+- 対応 route: `GET /screen/viewer/:mediaId/:mediaPage`
+- 描画テンプレート: `src/views/screen/viewer.ejs`
+
+## 入力
+- `req.params.mediaId`
+  - 型: `string`
+  - 用途: `GetMediaContentWithNavigationService.Input.mediaId`
+- `req.params.mediaPage`
+  - 型: `string`
+  - controller 内で `Number.parseInt(..., 10)` して `contentPosition` に渡す。
+- `res`
+  - `status(code)` と `render(view, model)`、`redirect(status, url)` を持つこと。
+
+## 依存
+- [GetMediaContentWithNavigationService](/doc/4_application/media/query/GetMediaContentWithNavigationService/readme.md)
+  - `execute(input)` を提供する。
+  - 戻り値は `FoundResult` / `MediaNotFoundResult` / `ContentNotFoundResult` のいずれかを想定する。
+
+## 処理フロー
+1. `req.params.mediaPage` を 10 進数で整数変換する。
+2. `new Input({ mediaId: req.params.mediaId, contentPosition: mediaPage })` を生成する。
+3. `getMediaContentWithNavigationService.execute(input)` を await する。
+4. `MediaNotFoundResult` または `ContentNotFoundResult` の場合は `res.redirect(301, '/screen/error')` を返す。
+5. `FoundResult` 以外の戻り値は想定外として例外化し、catch 節で `res.redirect(301, '/screen/error')` を返す。
+6. `FoundResult` の場合は viewer 描画モデルを組み立て、`res.status(200).render('screen/viewer', model)` を返す。
+
+## 戻り値種別ごとの分岐
+- `FoundResult`
+  - 画面描画を実行する唯一の正常系。
+- `MediaNotFoundResult`
+  - メディア自体が存在しないため、`/screen/error` に `301` リダイレクトする。
+- `ContentNotFoundResult`
+  - 対象ページが存在しないため、`/screen/error` に `301` リダイレクトする。
+- 上記以外
+  - 想定外結果として例外化し、catch 節で `301` リダイレクトする。
+
+## 描画モデル
+- `pageTitle`
+  - `ビューアー ${mediaId} - ${mediaPage}ページ`
+- `mediaId`
+  - `req.params.mediaId` をそのまま使用する。
+- `mediaPage`
+  - 整数変換後のページ番号。
+- `content`
+  - `id`: `result.contentId`
+  - `type`: `contentId` の拡張子が `mp4|webm|ogg|mov|m4v` のとき `video`、それ以外は `image`
+- `previousPage`
+  - `result.previousContentId === null` のとき `null`
+  - それ以外は `{ mediaId, mediaPage: mediaPage - 1, contentId, href }`
+- `nextPage`
+  - `result.nextContentId === null` のとき `null`
+  - それ以外は `{ mediaId, mediaPage: mediaPage + 1, contentId, href }`
+
+## not found / エラー時の振る舞い
+- service が not found を結果オブジェクトで返した場合は controller が明示的に `301` リダイレクトする。
+- `Input` 生成失敗、service 実行失敗、想定外戻り値などの例外は catch 節で一括して `301` リダイレクトする。
+- 例外の詳細はレスポンスへ露出しない。
+
+## テスト方針
+- controller 単体の small テストでは以下を確認する。
+  - 戻り値種別ごとの分岐
+  - 描画モデル生成（前後ページ導線、content type 判定）
+  - 例外時の `/screen/error` リダイレクト
+- route path・認証ミドルウェア接続・実 HTTP 応答は router テストに委譲し、責務重複を避ける。
+
+## 関連ドキュメント
+- [controllerテストケース](/doc/5_api/controller/screen/ScreenViewerGetController/testcase.md)

--- a/doc/5_api/controller/screen/ScreenViewerGetController/testcase.md
+++ b/doc/5_api/controller/screen/ScreenViewerGetController/testcase.md
@@ -1,0 +1,66 @@
+# ScreenViewerGetController テストケース
+
+## テストケース一覧
+- [FoundResult の場合は viewer 画面を描画する](#foundresult-の場合は-viewer-画面を描画する)
+- [動画拡張子の contentId は content.type を video にする](#動画拡張子の-contentid-は-contenttype-を-video-にする)
+- [MediaNotFoundResult の場合はエラー画面へ 301 リダイレクトする](#medianotfoundresult-の場合はエラー画面へ-301-リダイレクトする)
+- [ContentNotFoundResult の場合はエラー画面へ 301 リダイレクトする](#contentnotfoundresult-の場合はエラー画面へ-301-リダイレクトする)
+- [想定外の戻り値や例外時はエラー画面へ 301 リダイレクトする](#想定外の戻り値や例外時はエラー画面へ-301-リダイレクトする)
+
+---
+
+### FoundResult の場合は viewer 画面を描画する
+- **前提**
+  - service が `FoundResult` を返す。
+  - `previousContentId` / `nextContentId` の有無で導線を構築できる。
+- **操作**
+  - `execute(req, res)` を呼び出す。
+- **結果**
+  - service が整数化した `contentPosition` で呼び出される。
+  - `screen/viewer` が `200` で描画される。
+  - `pageTitle`、`content`、`previousPage`、`nextPage` が描画モデルに設定される。
+
+---
+
+### 動画拡張子の contentId は content.type を video にする
+- **前提**
+  - service が `contentId` に動画拡張子を持つ `FoundResult` を返す。
+- **操作**
+  - `execute(req, res)` を呼び出す。
+- **結果**
+  - 描画モデルの `content.type` が `video` になる。
+  - `previousPage` / `nextPage` が `null` のときはそのまま `null` で描画される。
+
+---
+
+### MediaNotFoundResult の場合はエラー画面へ 301 リダイレクトする
+- **前提**
+  - service が `MediaNotFoundResult` を返す。
+- **操作**
+  - `execute(req, res)` を呼び出す。
+- **結果**
+  - `res.redirect(301, '/screen/error')` が呼ばれる。
+
+---
+
+### ContentNotFoundResult の場合はエラー画面へ 301 リダイレクトする
+- **前提**
+  - service が `ContentNotFoundResult` を返す。
+- **操作**
+  - `execute(req, res)` を呼び出す。
+- **結果**
+  - `res.redirect(301, '/screen/error')` が呼ばれる。
+
+---
+
+### 想定外の戻り値や例外時はエラー画面へ 301 リダイレクトする
+- **前提**
+  - service が `FoundResult` 以外の未知オブジェクトを返す、または例外を送出する。
+- **操作**
+  - `execute(req, res)` を呼び出す。
+- **結果**
+  - controller が想定外結果を例外化し、最終的に `res.redirect(301, '/screen/error')` を呼び出す。
+
+## テスト責務の境界
+- 認証ミドルウェアや route 登録の正しさは router テストで担保する。
+- controller 単体では service 戻り値の分岐と viewer 描画モデル生成に限定して確認する。


### PR DESCRIPTION
### Motivation
- `ScreenDetailGetController` と `ScreenViewerGetController` の controller 単体責務（入力変換、service 呼び出し、描画モデル、not found/エラー時の振る舞い）がドキュメントで追えなかったため設計書を追加しました。 
- `ScreenViewerGetController` の戻り値種別ごとの分岐は既存の route テストだけでは controller 単体での回帰検知が弱かったため、small テストを追加して直接検証できるようにしました。 
- controller と router のテスト責務が重複しないよう設計書で境界を明記し、router 側の統合テストへ影響を出さない方針にしました。 

### Description
- `doc/5_api/controller/screen/ScreenDetailGetController/readme.md` と `doc/5_api/controller/screen/ScreenDetailGetController/testcase.md` を追加し、入力、依存、処理フロー、描画モデル、エラー振る舞い、テスト方針を明記しました. 
- `doc/5_api/controller/screen/ScreenViewerGetController/readme.md` と `doc/5_api/controller/screen/ScreenViewerGetController/testcase.md` を追加し、`GetMediaContentWithNavigationService` の戻り値種別ごとの分岐と描画モデル（前後導線・content type 判定）を定義しました. 
- `__tests__/small/controller/screen/ScreenViewerGetController.test.js` を追加して `FoundResult` / 動画拡張子判定 / `MediaNotFoundResult` / `ContentNotFoundResult` / 想定外戻り値や例外時のフォールバックを controller 単体で検証する small テストを実装しました。 

### Testing
- small テスト実行を試みるために `npm test -- --runInBand __tests__/small/controller/screen/ScreenDetailGetController.test.js __tests__/small/controller/screen/ScreenViewerGetController.test.js` を実行しましたが、この環境では `jest: not found` により実行できませんでした。 
- 依存解決のため `npm ci --include=dev` を試行しましたが、この実行環境では完了確認が得られずテスト実行には至りませんでした。 
- ドキュメントとテストファイルはコミット済みです（コミットハッシュ `3edccac`）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c16181623c832bb7756cf95a9ad424)