### PR TITLE
test: DevelopmentSession 無効設定のテストを追加する

### DIFF
--- a/__tests__/medium/app/developmentSession.integration.test.js
+++ b/__tests__/medium/app/developmentSession.integration.test.js
@@ -45,7 +45,7 @@ describe('developmentSession wiring', () => {
 
     await dependencies.ready;
 
-    await expect(dependencies.authResolver.execute('dev-token')).resolves.toBeNull();
+    await expect(dependencies.authResolver.execute('dev-token')).resolves.toBeUndefined();
   });
 
   test('setupMiddleware は固定セッション設定が無効な場合は req.session.session_token を補完しない', async () => {

--- a/__tests__/medium/app/developmentSession.integration.test.js
+++ b/__tests__/medium/app/developmentSession.integration.test.js
@@ -1,0 +1,109 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const express = require('express');
+const request = require('supertest');
+
+const createDependencies = require('../../../src/app/createDependencies');
+const setupMiddleware = require('../../../src/app/setupMiddleware');
+
+describe('developmentSession wiring', () => {
+  let dependencies;
+  let databaseRoot;
+  let contentRoot;
+  let originalEnv;
+
+  beforeEach(() => {
+    jest.resetModules();
+    originalEnv = { ...process.env };
+    databaseRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'create-deps-devsession-db-'));
+    contentRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'create-deps-devsession-content-'));
+  });
+
+  afterEach(async () => {
+    if (dependencies) {
+      await dependencies.close();
+      dependencies = undefined;
+    }
+
+    fs.rmSync(databaseRoot, { recursive: true, force: true });
+    fs.rmSync(contentRoot, { recursive: true, force: true });
+    process.env = originalEnv;
+    jest.restoreAllMocks();
+    jest.resetModules();
+  });
+
+  test('createDependencies は固定セッション設定が無効な場合はセッションを事前登録しない', async () => {
+    dependencies = createDependencies({
+      databaseStoragePath: path.join(databaseRoot, 'data.sqlite'),
+      contentRootDirectory: path.join(contentRoot, 'contents'),
+      devSessionToken: '',
+      devSessionUserId: 'admin-dev',
+      devSessionTtlMs: 60_000,
+    });
+
+    await dependencies.ready;
+
+    await expect(dependencies.authResolver.execute('dev-token')).resolves.toBeNull();
+  });
+
+  test('setupMiddleware は固定セッション設定が無効な場合は req.session.session_token を補完しない', async () => {
+    const app = express();
+    setupMiddleware(app, {
+      env: {
+        devSessionToken: '',
+        devSessionUserId: 'admin-dev',
+        devSessionTtlMs: 60_000,
+        devSessionPaths: ['/screen/entry'],
+      },
+      dependencies: {},
+    });
+
+    app.get('/screen/entry', (req, res) => {
+      res.status(200).json({
+        sessionToken: req.session.session_token ?? null,
+      });
+    });
+
+    const response = await request(app).get('/screen/entry');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      sessionToken: null,
+    });
+  });
+
+  test('server.js 相当の初期化では固定セッション設定が無効な場合に有効化ログを出力しない', async () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit should not be called');
+    });
+    const listenMock = jest.fn((port, callback) => {
+      callback();
+      return { on: jest.fn() };
+    });
+
+    process.env.PORT = '3456';
+    process.env.DEV_SESSION_TOKEN = '';
+    process.env.DEV_SESSION_USER_ID = 'admin-dev';
+    process.env.DEV_SESSION_TTL_MS = '60000';
+    process.env.DEV_SESSION_PATHS = '/screen/entry,/api/media';
+
+    jest.doMock('../../../src/app', () => jest.fn(() => ({
+      locals: {
+        ready: Promise.resolve(),
+      },
+      listen: listenMock,
+    })));
+
+    require('../../../src/server');
+    await Promise.resolve();
+
+    expect(listenMock).toHaveBeenCalledWith(3456, expect.any(Function));
+    expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining('開発用固定セッションを有効化しました'));
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/small/app/createApp.test.js
+++ b/__tests__/small/app/createApp.test.js
@@ -72,6 +72,39 @@ describe('createApp', () => {
     });
   });
 
+
+  test('固定セッション設定が無効な場合は対象パスでも自動補完されず認証エラーになる', async () => {
+    app = createApp({
+      databaseStoragePath: databasePath,
+      contentRootDirectory,
+      devSessionToken: '',
+      devSessionUserId: 'admin-dev',
+      devSessionTtlMs: 60_000,
+      devSessionPaths: ['/screen/entry', '/api/media'],
+    });
+
+    await app.locals.ready;
+
+    const screenResponse = await request(app).get('/screen/entry');
+    expect(screenResponse.status).toBe(401);
+    expect(screenResponse.body).toEqual({
+      message: '認証に失敗しました',
+    });
+
+    const mediaResponse = await request(app)
+      .post('/api/media')
+      .field('title', 'sample title')
+      .field('tags[0][category]', '作者')
+      .field('tags[0][label]', '山田')
+      .field('contents[0][position]', '1')
+      .attach('contents[0][file]', Buffer.from('a'), 'first.jpg');
+
+    expect(mediaResponse.status).toBe(401);
+    expect(mediaResponse.body).toEqual({
+      message: '認証に失敗しました',
+    });
+  });
+
   test('固定セッション設定がある場合は /screen/entry と /screen/search と /screen/summary と /api/media で認証を補完し、/screen/login を表示できる', async () => {
     app = createApp({
       databaseStoragePath: databasePath,

--- a/__tests__/small/app/developmentSession.test.js
+++ b/__tests__/small/app/developmentSession.test.js
@@ -12,6 +12,32 @@ describe('developmentSession', () => {
     })).toBe(true);
   });
 
+  test('devSessionToken が欠落している場合は固定セッションを無効と判定する', () => {
+    expect(hasDevelopmentSession({
+      devSessionUserId: 'admin-dev',
+      devSessionTtlMs: 60_000,
+    })).toBe(false);
+  });
+
+  test('devSessionUserId が欠落している場合は固定セッションを無効と判定する', () => {
+    expect(hasDevelopmentSession({
+      devSessionToken: 'dev-token',
+      devSessionTtlMs: 60_000,
+    })).toBe(false);
+  });
+
+  test.each([
+    ['0', 0],
+    ['負数', -1],
+    ['非整数', 0.5],
+  ])('devSessionTtlMs が %s の場合は固定セッションを無効と判定する', (_name, devSessionTtlMs) => {
+    expect(hasDevelopmentSession({
+      devSessionToken: 'dev-token',
+      devSessionUserId: 'admin-dev',
+      devSessionTtlMs,
+    })).toBe(false);
+  });
+
   test('対象パスのみ固定セッションを補完対象と判定する', () => {
     const env = {
       devSessionToken: 'dev-token',
@@ -23,5 +49,16 @@ describe('developmentSession', () => {
     expect(shouldApplyDevelopmentSession({ env, requestPath: '/screen/entry' })).toBe(true);
     expect(shouldApplyDevelopmentSession({ env, requestPath: '/api/media' })).toBe(true);
     expect(shouldApplyDevelopmentSession({ env, requestPath: '/unknown' })).toBe(false);
+  });
+
+  test('固定セッションが無効な場合は対象パスでも補完対象にしない', () => {
+    const env = {
+      devSessionToken: '',
+      devSessionUserId: 'admin-dev',
+      devSessionTtlMs: 60_000,
+      devSessionPaths: ['/screen/entry'],
+    };
+
+    expect(shouldApplyDevelopmentSession({ env, requestPath: '/screen/entry' })).toBe(false);
   });
 });

--- a/doc/5_api/controller/middleware/DevelopmentSession/testcase.md
+++ b/doc/5_api/controller/middleware/DevelopmentSession/testcase.md
@@ -48,7 +48,15 @@
 ### 固定セッション設定のいずれかが欠けると無効と判定する
 
 - **対応テスト**
-  - 未実装（追加候補）
+  - `__tests__/small/app/developmentSession.test.js`
+  - `devSessionToken が欠落している場合は固定セッションを無効と判定する`
+  - `devSessionUserId が欠落している場合は固定セッションを無効と判定する`
+  - `devSessionTtlMs が 0 の場合は固定セッションを無効と判定する`
+  - `devSessionTtlMs が 負数 の場合は固定セッションを無効と判定する`
+  - `devSessionTtlMs が 非整数 の場合は固定セッションを無効と判定する`
+  - `__tests__/medium/app/developmentSession.integration.test.js`
+  - `createDependencies は固定セッション設定が無効な場合はセッションを事前登録しない`
+  - `server.js 相当の初期化では固定セッション設定が無効な場合に有効化ログを出力しない`
 - **前提**
   - 以下のいずれかが成り立つ。
     - `devSessionToken` が未設定・空文字である。
@@ -66,7 +74,12 @@
 ### 固定セッションが無効な場合は対象パスでも補完対象にしない
 
 - **対応テスト**
-  - 未実装（追加候補）
+  - `__tests__/small/app/developmentSession.test.js`
+  - `固定セッションが無効な場合は対象パスでも補完対象にしない`
+  - `__tests__/small/app/createApp.test.js`
+  - `固定セッション設定が無効な場合は対象パスでも自動補完されず認証エラーになる`
+  - `__tests__/medium/app/developmentSession.integration.test.js`
+  - `setupMiddleware は固定セッション設定が無効な場合は req.session.session_token を補完しない`
 - **前提**
   - `requestPath` は `devSessionPaths` に含まれている。
   - ただし `hasDevelopmentSession(env)` は `false` である。


### PR DESCRIPTION
### Motivation
- 開発用固定セッション（DevelopmentSession）が設定欠落や不正値で誤って有効扱いされると認証挙動に影響が出るため回帰防止が必要です。 
- 小さなユニットレベルからミドルウェア／初期化処理まで横断して「無効設定時に自動補完や事前登録・有効化ログが発生しない」ことを保証したいです。 
- ドキュメントの未実装扱いだったテストケースを実装済みの具体的なテスト名へ反映してテスト仕様を明確にします。 

### Description
- `__tests__/small/app/developmentSession.test.js` に `devSessionToken` 欠落、`devSessionUserId` 欠落、`devSessionTtlMs` が 0/負数/非整数 の場合に `hasDevelopmentSession` が `false` となるケースと、無効時に `shouldApplyDevelopmentSession` が `false` になるケースを追加しました。 
- `__tests__/small/app/createApp.test.js` に無効な固定セッション設定で対象パスでも自動補完が行われず `401` になることを確認する静的なケースを追加しました。 
- `__tests__/medium/app/developmentSession.integration.test.js` を新規追加し、`createDependencies`（事前登録しない）、`setupMiddleware`（`req.session.session_token` を補完しない）、および `server.js` 相当の初期化（有効化ログを出力しない）を検証する medium レベルの統合的なテストを実装しました。 
- `doc/5_api/controller/middleware/DevelopmentSession/testcase.md` の「未実装（追加候補）」箇所を今回追加した具体的なテストファイル名・テスト名へ更新しました。 

### Testing
- `node -c __tests__/small/app/developmentSession.test.js`、`node -c __tests__/small/app/createApp.test.js`、`node -c __tests__/medium/app/developmentSession.integration.test.js` の構文チェックは成功しました。 
- `git diff --check` を実行し問題が無いことを確認しました。 
- `npx jest __tests__/small/app/developmentSession.test.js __tests__/small/app/createApp.test.js __tests__/medium/app/developmentSession.integration.test.js --runInBand` の実行は試みましたが、環境の npm レジストリアクセス制限により `403` が発生して実行できませんでした。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c16b0783dc832b9ca12f0f09398aa0)