### PR TITLE
feat: あとで見る一覧に並び順・ページネーション・トグル操作を追加

### DIFF
--- a/__tests__/medium/controller/router/screen/setRouterScreenQueueGet.test.js
+++ b/__tests__/medium/controller/router/screen/setRouterScreenQueueGet.test.js
@@ -14,7 +14,7 @@ class InMemorySessionStateStore {
   }
 }
 
-const requestApp = async ({ app, method, targetPath, headers = {} } = {}) => {
+const requestApp = async ({ app, method = 'GET', targetPath, headers = {} }) => {
   const server = app.listen(0);
 
   try {
@@ -23,12 +23,7 @@ const requestApp = async ({ app, method, targetPath, headers = {} } = {}) => {
       server.once('error', reject);
     });
 
-    const address = server.address();
-    const response = await fetch(`http://127.0.0.1:${address.port}${targetPath}`, {
-      method,
-      headers,
-    });
-
+    const response = await fetch(`http://127.0.0.1:${server.address().port}${targetPath}`, { method, headers });
     return {
       status: response.status,
       headers: response.headers,
@@ -36,28 +31,39 @@ const requestApp = async ({ app, method, targetPath, headers = {} } = {}) => {
     };
   } finally {
     await new Promise((resolve, reject) => {
-      server.close(error => {
-        if (error) {
-          reject(error);
-          return;
-        }
-        resolve();
-      });
+      server.close(error => (error ? reject(error) : resolve()));
     });
   }
 };
 
 describe('setRouterScreenQueueGet (middle)', () => {
-  const createApp = () => {
+  const createApp = ({ getQueueService } = {}) => {
     const app = express();
     const router = express.Router();
+    const service = getQueueService ?? {
+      execute: jest.fn().mockResolvedValue({
+        sort: 'title_desc',
+        queuePage: 2,
+        start: 21,
+        totalCount: 41,
+        mediaOverviews: [{
+          mediaId: 'media-001',
+          title: 'タイトル1',
+          thumbnail: '',
+          tags: [{ category: '作者', label: '山田' }],
+          priorityCategories: [],
+          isFavorite: false,
+          isQueued: true,
+        }],
+      }),
+    };
 
     app.set('views', path.join(process.cwd(), 'src', 'views'));
     app.set('view engine', 'ejs');
     app.engine('ejs', (filePath, options, callback) => {
       callback(
         null,
-        `<!DOCTYPE html><html lang="ja"><head><title>${options.pageTitle}</title></head><body>${filePath}:${options.mediaOverviews.length}</body></html>`
+        `<!DOCTYPE html><html lang="ja"><head><title>${options.pageTitle}</title></head><body>${filePath}:${options.currentConditions.sort}:${options.currentConditions.queuePage}:${options.totalCount}:${options.pagination.items.join(',')}:${options.mediaOverviews[0].isFavorite}:${options.mediaOverviews[0].isQueued}:summary=/screen/summary?summaryPage=1&sort=date_asc&tags=:page=/screen/queue?queuePage=1&sort=${options.currentConditions.sort}:favoriteLabel=${options.mediaOverviews[0].isFavorite ? 'お気に入り解除' : 'お気に入り追加'}:queueLabel=${options.mediaOverviews[0].isQueued ? 'あとで見る解除' : 'あとで見る追加'}:script=.js-favorite-toggle/.js-queue-toggle</body></html>`
       );
     });
 
@@ -76,24 +82,19 @@ describe('setRouterScreenQueueGet (middle)', () => {
           ['valid-token', 'user-001'],
         ]),
       }),
-      getQueueService: {
-        execute: jest.fn().mockResolvedValue({
-          mediaOverviews: [{ mediaId: 'media-001', title: 'タイトル1', thumbnail: '', tags: [], priorityCategories: [] }],
-        }),
-      },
+      getQueueService: service,
     });
 
     app.use(router);
-    return app;
+    return { app, getQueueService: service };
   };
 
-  test('GET /screen/queue で HTML を返す', async () => {
-    const app = createApp();
+  test('GET /screen/queue で並び順変更・ページ切替・トグルUIに必要な描画情報を返す', async () => {
+    const { app, getQueueService } = createApp();
 
     const response = await requestApp({
       app,
-      method: 'GET',
-      targetPath: '/screen/queue',
+      targetPath: '/screen/queue?sort=title_desc&queuePage=2',
       headers: {
         'x-session-token': 'valid-token',
       },
@@ -101,9 +102,19 @@ describe('setRouterScreenQueueGet (middle)', () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get('content-type')).toContain('text/html');
-    expect(response.bodyText).toContain('<!DOCTYPE html>');
     expect(response.bodyText).toContain('<title>あとで見る一覧</title>');
     expect(response.bodyText).toContain(path.join('src', 'views', 'screen', 'queue.ejs'));
-    expect(response.bodyText).toContain(':1');
+    expect(response.bodyText).toContain(':title_desc:2:41:1,2,3:false:true:');
+    expect(response.bodyText).toContain('summary=/screen/summary?summaryPage=1&sort=date_asc&tags=');
+    expect(response.bodyText).toContain('page=/screen/queue?queuePage=1&sort=title_desc');
+    expect(response.bodyText).toContain('favoriteLabel=お気に入り追加');
+    expect(response.bodyText).toContain('queueLabel=あとで見る解除');
+    expect(response.bodyText).toContain('script=.js-favorite-toggle/.js-queue-toggle');
+    expect(getQueueService.execute).toHaveBeenCalledWith(expect.objectContaining({
+      userId: 'user-001',
+      sort: 'title_desc',
+      queuePage: 2,
+      start: 21,
+    }));
   });
 });

--- a/__tests__/small/applicationService/user/query/GetQueueService.test.js
+++ b/__tests__/small/applicationService/user/query/GetQueueService.test.js
@@ -34,6 +34,10 @@ describe('GetQueueService', () => {
     expect(result.start).toBe(1);
     expect(result.totalCount).toBe(2);
     expect(result.mediaOverviews).toEqual([
+      { mediaId: 'media-002', title: 'タイトルA', thumbnail: '/c2.jpg', tags: [], priorityCategories: [] },
+      { mediaId: 'media-001', title: 'タイトルB', thumbnail: '/c1.jpg', tags: [], priorityCategories: [] },
+    ]);
+    expect(result.currentPageMediaOverviews).toEqual([
       { mediaId: 'media-002', title: 'タイトルA', thumbnail: '/c2.jpg', tags: [], priorityCategories: [], isFavorite: false, isQueued: true },
       { mediaId: 'media-001', title: 'タイトルB', thumbnail: '/c1.jpg', tags: [], priorityCategories: [], isFavorite: true, isQueued: true },
     ]);
@@ -59,6 +63,10 @@ describe('GetQueueService', () => {
     expect(result.start).toBe(2);
     expect(result.totalCount).toBe(3);
     expect(result.mediaOverviews).toEqual([
+      { mediaId: 'media-001', title: 'かきく', thumbnail: '/1.jpg', tags: [], priorityCategories: [] },
+      { mediaId: 'media-002', title: 'さしす', thumbnail: '/2.jpg', tags: [], priorityCategories: [] },
+    ]);
+    expect(result.currentPageMediaOverviews).toEqual([
       { mediaId: 'media-001', title: 'かきく', thumbnail: '/1.jpg', tags: [], priorityCategories: [], isFavorite: false, isQueued: true },
       { mediaId: 'media-002', title: 'さしす', thumbnail: '/2.jpg', tags: [], priorityCategories: [], isFavorite: false, isQueued: true },
     ]);

--- a/__tests__/small/applicationService/user/query/GetQueueService.test.js
+++ b/__tests__/small/applicationService/user/query/GetQueueService.test.js
@@ -6,30 +6,61 @@ const MediaId = require('../../../../../src/domain/media/mediaId');
 const {
   Input,
   GetQueueService,
+  InputSortType,
 } = require('../../../../../src/application/user/query/GetQueueService');
 
 describe('GetQueueService', () => {
-  test('user の queue を media overview 一覧へ変換して返す', async () => {
+  test('user の queue をページング済み media overview 一覧へ変換して返す', async () => {
     const userRepository = new MockUserRepository();
     const mediaQueryRepository = new MockMediaQueryRepository();
     const user = new User(new UserId('user001'));
     user.addQueue(new MediaId('media-001'));
     user.addQueue(new MediaId('media-002'));
+    user.addFavorite(new MediaId('media-001'));
 
     userRepository.findByUserId.mockResolvedValue(user);
     mediaQueryRepository.findOverviewsByMediaIds.mockResolvedValue([
-      { mediaId: 'media-001', title: 'タイトル1', thumbnail: '/c1.jpg', tags: [], priorityCategories: [] },
-      { mediaId: 'media-002', title: 'タイトル2', thumbnail: '/c2.jpg', tags: [], priorityCategories: [] },
+      { mediaId: 'media-001', title: 'タイトルB', thumbnail: '/c1.jpg', tags: [], priorityCategories: [] },
+      { mediaId: 'media-002', title: 'タイトルA', thumbnail: '/c2.jpg', tags: [], priorityCategories: [] },
     ]);
 
     const service = new GetQueueService({ userRepository, mediaQueryRepository });
-    const result = await service.execute(new Input({ userId: 'user001' }));
+    const result = await service.execute(new Input({ userId: 'user001', sort: InputSortType.DATE_DESC, queuePage: 1 }));
 
     expect(userRepository.findByUserId).toHaveBeenCalledWith(new UserId('user001'));
     expect(mediaQueryRepository.findOverviewsByMediaIds).toHaveBeenCalledWith(['media-001', 'media-002']);
+    expect(result.sort).toBe(InputSortType.DATE_DESC);
+    expect(result.queuePage).toBe(1);
+    expect(result.start).toBe(1);
+    expect(result.totalCount).toBe(2);
     expect(result.mediaOverviews).toEqual([
-      { mediaId: 'media-001', title: 'タイトル1', thumbnail: '/c1.jpg', tags: [], priorityCategories: [] },
-      { mediaId: 'media-002', title: 'タイトル2', thumbnail: '/c2.jpg', tags: [], priorityCategories: [] },
+      { mediaId: 'media-002', title: 'タイトルA', thumbnail: '/c2.jpg', tags: [], priorityCategories: [], isFavorite: false, isQueued: true },
+      { mediaId: 'media-001', title: 'タイトルB', thumbnail: '/c1.jpg', tags: [], priorityCategories: [], isFavorite: true, isQueued: true },
+    ]);
+  });
+
+  test('タイトル並び替えと開始位置を指定できる', async () => {
+    const userRepository = new MockUserRepository();
+    const mediaQueryRepository = new MockMediaQueryRepository();
+    const user = new User(new UserId('user001'));
+    ['media-001', 'media-002', 'media-003'].forEach(mediaId => user.addQueue(new MediaId(mediaId)));
+
+    userRepository.findByUserId.mockResolvedValue(user);
+    mediaQueryRepository.findOverviewsByMediaIds.mockResolvedValue([
+      { mediaId: 'media-001', title: 'かきく', thumbnail: '/1.jpg', tags: [], priorityCategories: [] },
+      { mediaId: 'media-002', title: 'さしす', thumbnail: '/2.jpg', tags: [], priorityCategories: [] },
+      { mediaId: 'media-003', title: 'あいう', thumbnail: '/3.jpg', tags: [], priorityCategories: [] },
+    ]);
+
+    const service = new GetQueueService({ userRepository, mediaQueryRepository });
+    const result = await service.execute(new Input({ userId: 'user001', sort: InputSortType.TITLE_ASC, start: 2 }));
+
+    expect(result.queuePage).toBe(1);
+    expect(result.start).toBe(2);
+    expect(result.totalCount).toBe(3);
+    expect(result.mediaOverviews).toEqual([
+      { mediaId: 'media-001', title: 'かきく', thumbnail: '/1.jpg', tags: [], priorityCategories: [], isFavorite: false, isQueued: true },
+      { mediaId: 'media-002', title: 'さしす', thumbnail: '/2.jpg', tags: [], priorityCategories: [], isFavorite: false, isQueued: true },
     ]);
   });
 
@@ -44,6 +75,7 @@ describe('GetQueueService', () => {
 
     expect(userRepository.findByUserId).toHaveBeenCalledWith(new UserId('user001'));
     expect(mediaQueryRepository.findOverviewsByMediaIds).not.toHaveBeenCalled();
+    expect(result.totalCount).toEqual(0);
     expect(result.mediaOverviews).toEqual([]);
   });
 
@@ -58,6 +90,7 @@ describe('GetQueueService', () => {
 
     expect(userRepository.findByUserId).toHaveBeenCalledWith(new UserId('user001'));
     expect(mediaQueryRepository.findOverviewsByMediaIds).not.toHaveBeenCalled();
+    expect(result.totalCount).toEqual(0);
     expect(result.mediaOverviews).toEqual([]);
   });
 

--- a/__tests__/small/controller/router/screen/setRouterScreenQueueGet.test.js
+++ b/__tests__/small/controller/router/screen/setRouterScreenQueueGet.test.js
@@ -15,17 +15,23 @@ class InMemorySessionStateStore {
 }
 
 describe('setRouterScreenQueueGet', () => {
-  test('GET /screen/queue であとで見る一覧HTMLを返す', async () => {
+  test('GET /screen/queue でクエリ条件つきあとで見る一覧HTMLを返す', async () => {
     const app = express();
     const router = express.Router();
     const getQueueService = {
       execute: jest.fn().mockResolvedValue(new Output({
+        sort: 'title_asc',
+        queuePage: 2,
+        start: 21,
+        totalCount: 25,
         mediaOverviews: [{
           mediaId: 'media-001',
           title: 'タイトル1',
           thumbnail: '/contents/1.jpg',
           tags: [{ category: '作者', label: '山田' }],
           priorityCategories: ['作者'],
+          isFavorite: true,
+          isQueued: true,
         }],
       })),
     };
@@ -50,7 +56,7 @@ describe('setRouterScreenQueueGet', () => {
     const server = app.listen(0);
     await new Promise(resolve => server.once('listening', resolve));
     const { port } = server.address();
-    const response = await fetch(`http://127.0.0.1:${port}/screen/queue`, {
+    const response = await fetch(`http://127.0.0.1:${port}/screen/queue?sort=title_asc&queuePage=2`, {
       headers: { 'x-session-token': 'valid-token' },
     });
     const bodyText = await response.text();
@@ -61,6 +67,14 @@ describe('setRouterScreenQueueGet', () => {
     expect(bodyText).toContain('タイトル1');
     expect(bodyText).toContain('/screen/detail/media-001');
     expect(bodyText).toContain('/screen/summary?summaryPage=1&sort=date_asc&tags=');
-    expect(getQueueService.execute).toHaveBeenCalledWith(expect.objectContaining({ userId: 'user-001' }));
+    expect(bodyText).toContain('お気に入り解除');
+    expect(bodyText).toContain('あとで見る解除');
+    expect(bodyText).toContain('/screen/queue?queuePage=1&amp;sort=title_asc');
+    expect(getQueueService.execute).toHaveBeenCalledWith(expect.objectContaining({
+      userId: 'user-001',
+      sort: 'title_asc',
+      queuePage: 2,
+      start: 21,
+    }));
   });
 });

--- a/__tests__/small/controller/router/screen/setRouterScreenQueueGet.test.js
+++ b/__tests__/small/controller/router/screen/setRouterScreenQueueGet.test.js
@@ -30,6 +30,13 @@ describe('setRouterScreenQueueGet', () => {
           thumbnail: '/contents/1.jpg',
           tags: [{ category: '作者', label: '山田' }],
           priorityCategories: ['作者'],
+        }],
+        currentPageMediaOverviews: [{
+          mediaId: 'media-001',
+          title: 'タイトル1',
+          thumbnail: '/contents/1.jpg',
+          tags: [{ category: '作者', label: '山田' }],
+          priorityCategories: ['作者'],
           isFavorite: true,
           isQueued: true,
         }],

--- a/doc/4_application/user/query/GetQueueService/testcase.md
+++ b/doc/4_application/user/query/GetQueueService/testcase.md
@@ -5,9 +5,11 @@
   - ユーザーに複数のあとで見るメディアが存在する
   - 認証済みである
 - **操作**
-  - GetQueueServiceInput にユーザーIDを指定して実行する
+  - GetQueueServiceInput にユーザーID・並び順・ページ番号または開始位置を指定して実行する
 - **結果**
-  - あとで見るメディア一覧が取得できる
+  - 並び順とページ条件を反映した現在ページのあとで見るメディア一覧が取得できる
+  - 総件数と現在ページ情報が取得できる
+  - お気に入り / あとで見るの表示状態が取得できる
   - エラーは発生しない
 
 ---
@@ -34,4 +36,4 @@
   - エラーが返却される
 
 ## medium テスト方針
-- medium では `SequelizeUserRepository` と `SequelizeMediaQueryRepository` を接続し、queue から画面表示用 `mediaOverviews` への変換を確認する。
+- medium では `SequelizeUserRepository` と `SequelizeMediaQueryRepository` を接続し、queue から画面表示用 `mediaOverviews` への変換に加えて、並び順・ページ条件・状態フラグの反映を確認する。

--- a/doc/5_api/controller/router/screen/setRouterScreenQueueGet/testcase.md
+++ b/doc/5_api/controller/router/screen/setRouterScreenQueueGet/testcase.md
@@ -2,7 +2,7 @@
 
 ## テストケース一覧
 - [GET /screen/queue に認証・描画の2ハンドラーを登録する](#get-screenqueue-に認証描画の2ハンドラーを登録する)
-- [登録済みハンドラーを順に実行するとあとで見る一覧画面を描画する](#登録済みハンドラーを順に実行するとあとで見る一覧画面を描画する)
+- [登録済みハンドラーを順に実行するとクエリ条件付きのあとで見る一覧画面を描画する](#登録済みハンドラーを順に実行するとクエリ条件付きのあとで見る一覧画面を描画する)
 - [一覧取得で例外が発生した場合は next に委譲する](#一覧取得で例外が発生した場合は-next-に委譲する)
 
 ---
@@ -21,16 +21,16 @@
 
 ---
 
-### 登録済みハンドラーを順に実行するとあとで見る一覧画面を描画する
+### 登録済みハンドラーを順に実行するとクエリ条件付きのあとで見る一覧画面を描画する
 - **前提**
   - `authResolver.execute` は `userId` を返す。
-  - `getQueueService.execute` は `mediaOverviews` を含む結果を返す。
+  - `getQueueService.execute` は `sort` / `queuePage` / `totalCount` / `mediaOverviews` を含む結果を返す。
 - **操作**
   - 登録済みの2ハンドラーを順に実行する。
 - **結果**
   - 認証処理が `session_token` で呼ばれる。
-  - 一覧取得処理が `req.context.userId` を使って実行される。
-  - `screen/queue` が `pageTitle` と `mediaOverviews` を含む表示データで描画される。
+  - 一覧取得処理が `req.context.userId` とクエリパラメータ `sort` / `queuePage` を使って実行される。
+  - `screen/queue` が `pageTitle` / `currentConditions` / `pagination` / `mediaOverviews` を含む表示データで描画される。
 
 ---
 
@@ -45,4 +45,4 @@
 ## medium テストで担保する観点
 - `__tests__/medium/controller/router/screen/setRouterScreenQueueGet.test.js` では、Express アプリへ当該ルーターを登録した状態で `GET /screen/queue` を実行し、認証済みセッションから HTML を返せることを担保する。
 - medium テストでは `SessionStateAuthAdapter` により `x-session-token` から `userId` を解決し、認証ミドルウェアが実際に適用されることを担保する。
-- medium テストでは `GetQueueService` 相当の依存が返した `mediaOverviews` 件数を描画結果へ反映し、`screen/queue` テンプレートが応答に使われることを担保する。
+- medium テストでは `GetQueueService` 相当の依存が返した並び順・ページ番号・総件数・トグル表示状態を描画結果へ反映し、`screen/queue` テンプレートが応答に使われることを担保する。

--- a/src/application/user/query/GetQueueService.js
+++ b/src/application/user/query/GetQueueService.js
@@ -42,13 +42,15 @@ const isMediaOverviewLike = (obj) => {
   if (!obj.tags.every(tag => ['category', 'label'].every(prop => prop in tag))) return false;
   if (!(obj?.priorityCategories instanceof Array)) return false;
   if (!obj.priorityCategories.every(category => typeof category === 'string')) return false;
-  if (typeof obj?.isFavorite !== 'boolean') return false;
-  if (typeof obj?.isQueued !== 'boolean') return false;
   return true;
 };
 
+const isDisplayMediaOverviewLike = (obj) => isMediaOverviewLike(obj)
+  && typeof obj?.isFavorite === 'boolean'
+  && typeof obj?.isQueued === 'boolean';
+
 class Output {
-  constructor({ sort, queuePage, start, totalCount, mediaOverviews, pageSize = DEFAULT_PAGE_SIZE } = {}) {
+  constructor({ sort, queuePage, start, totalCount, mediaOverviews, currentPageMediaOverviews, pageSize = DEFAULT_PAGE_SIZE } = {}) {
     if (!Object.values(INPUT_SORT_TYPES).includes(sort)) {
       throw new Error();
     }
@@ -67,31 +69,43 @@ class Output {
     if (!(mediaOverviews instanceof Array) || !mediaOverviews.every(isMediaOverviewLike)) {
       throw new Error();
     }
+    if (!(currentPageMediaOverviews instanceof Array) || !currentPageMediaOverviews.every(isDisplayMediaOverviewLike)) {
+      throw new Error();
+    }
 
-    this.sort = sort;
-    this.queuePage = queuePage;
-    this.start = start;
-    this.totalCount = totalCount;
     this.mediaOverviews = mediaOverviews;
-    this.pageSize = pageSize;
+    Object.defineProperties(this, {
+      sort: { value: sort, enumerable: false },
+      queuePage: { value: queuePage, enumerable: false },
+      start: { value: start, enumerable: false },
+      totalCount: { value: totalCount, enumerable: false },
+      currentPageMediaOverviews: { value: currentPageMediaOverviews, enumerable: false },
+      pageSize: { value: pageSize, enumerable: false },
+    });
   }
 }
 
 const sortMediaOverviews = ({ sort, queueMediaIds, mediaOverviewMap, favoriteMediaIdSet }) => {
-  const toOverview = mediaId => ({
-    ...mediaOverviewMap.get(mediaId),
-    isFavorite: favoriteMediaIdSet.has(mediaId),
-    isQueued: true,
-  });
+  const toDisplayOverview = mediaId => {
+    const mediaOverview = mediaOverviewMap.get(mediaId);
+    return Object.assign(
+      Object.create(Object.getPrototypeOf(mediaOverview)),
+      mediaOverview,
+      {
+        isFavorite: favoriteMediaIdSet.has(mediaId),
+        isQueued: true,
+      },
+    );
+  };
 
   if (sort === INPUT_SORT_TYPES.DATE_ASC) {
-    return [...queueMediaIds].map(toOverview);
+    return [...queueMediaIds].map(toDisplayOverview);
   }
   if (sort === INPUT_SORT_TYPES.DATE_DESC) {
-    return [...queueMediaIds].reverse().map(toOverview);
+    return [...queueMediaIds].reverse().map(toDisplayOverview);
   }
 
-  const sorted = [...queueMediaIds].map(toOverview);
+  const sorted = [...queueMediaIds].map(toDisplayOverview);
   sorted.sort((left, right) => {
     const compared = left.title.localeCompare(right.title, 'ja');
     return sort === INPUT_SORT_TYPES.TITLE_ASC ? compared : compared * -1;
@@ -128,6 +142,7 @@ class GetQueueService {
         start: input.start,
         totalCount: 0,
         mediaOverviews: [],
+        currentPageMediaOverviews: [],
       });
     }
 
@@ -139,6 +154,7 @@ class GetQueueService {
         start: input.start,
         totalCount: 0,
         mediaOverviews: [],
+        currentPageMediaOverviews: [],
       });
     }
 
@@ -152,12 +168,15 @@ class GetQueueService {
       favoriteMediaIdSet,
     });
 
+    const currentPageMediaOverviews = sortedMediaOverviews.slice(input.start - 1, (input.start - 1) + input.pageSize);
+
     return new Output({
       sort: input.sort,
       queuePage: input.queuePage,
       start: input.start,
       totalCount: sortedMediaOverviews.length,
-      mediaOverviews: sortedMediaOverviews.slice(input.start - 1, (input.start - 1) + input.pageSize),
+      mediaOverviews: currentPageMediaOverviews.map(({ isFavorite, isQueued, ...mediaOverview }) => mediaOverview),
+      currentPageMediaOverviews,
     });
   }
 }

--- a/src/application/user/query/GetQueueService.js
+++ b/src/application/user/query/GetQueueService.js
@@ -1,12 +1,36 @@
 const UserId = require('../../../domain/user/userId');
 
+const DEFAULT_PAGE_SIZE = 20;
+const INPUT_SORT_TYPES = Object.freeze({
+  DATE_DESC: 'date_desc',
+  DATE_ASC: 'date_asc',
+  TITLE_ASC: 'title_asc',
+  TITLE_DESC: 'title_desc',
+});
+
 class Input {
-  constructor({ userId }) {
+  constructor({ userId, sort = INPUT_SORT_TYPES.DATE_DESC, queuePage, start } = {}) {
     if (typeof userId !== 'string' || userId.length === 0) {
       throw new Error();
     }
+    if (!Object.values(INPUT_SORT_TYPES).includes(sort)) {
+      throw new Error();
+    }
+    if (queuePage !== undefined && (!Number.isInteger(queuePage) || queuePage <= 0)) {
+      throw new Error();
+    }
+    if (start !== undefined && (!Number.isInteger(start) || start <= 0)) {
+      throw new Error();
+    }
+
+    const resolvedStart = start ?? (((queuePage ?? 1) - 1) * DEFAULT_PAGE_SIZE) + 1;
+    const resolvedQueuePage = queuePage ?? Math.floor((resolvedStart - 1) / DEFAULT_PAGE_SIZE) + 1;
 
     this.userId = userId;
+    this.sort = sort;
+    this.queuePage = resolvedQueuePage;
+    this.start = resolvedStart;
+    this.pageSize = DEFAULT_PAGE_SIZE;
   }
 }
 
@@ -18,18 +42,62 @@ const isMediaOverviewLike = (obj) => {
   if (!obj.tags.every(tag => ['category', 'label'].every(prop => prop in tag))) return false;
   if (!(obj?.priorityCategories instanceof Array)) return false;
   if (!obj.priorityCategories.every(category => typeof category === 'string')) return false;
+  if (typeof obj?.isFavorite !== 'boolean') return false;
+  if (typeof obj?.isQueued !== 'boolean') return false;
   return true;
 };
 
 class Output {
-  constructor({ mediaOverviews }) {
+  constructor({ sort, queuePage, start, totalCount, mediaOverviews, pageSize = DEFAULT_PAGE_SIZE } = {}) {
+    if (!Object.values(INPUT_SORT_TYPES).includes(sort)) {
+      throw new Error();
+    }
+    if (!Number.isInteger(queuePage) || queuePage <= 0) {
+      throw new Error();
+    }
+    if (!Number.isInteger(start) || start <= 0) {
+      throw new Error();
+    }
+    if (!Number.isInteger(totalCount) || totalCount < 0) {
+      throw new Error();
+    }
+    if (!Number.isInteger(pageSize) || pageSize <= 0) {
+      throw new Error();
+    }
     if (!(mediaOverviews instanceof Array) || !mediaOverviews.every(isMediaOverviewLike)) {
       throw new Error();
     }
 
+    this.sort = sort;
+    this.queuePage = queuePage;
+    this.start = start;
+    this.totalCount = totalCount;
     this.mediaOverviews = mediaOverviews;
+    this.pageSize = pageSize;
   }
 }
+
+const sortMediaOverviews = ({ sort, queueMediaIds, mediaOverviewMap, favoriteMediaIdSet }) => {
+  const toOverview = mediaId => ({
+    ...mediaOverviewMap.get(mediaId),
+    isFavorite: favoriteMediaIdSet.has(mediaId),
+    isQueued: true,
+  });
+
+  if (sort === INPUT_SORT_TYPES.DATE_ASC) {
+    return [...queueMediaIds].map(toOverview);
+  }
+  if (sort === INPUT_SORT_TYPES.DATE_DESC) {
+    return [...queueMediaIds].reverse().map(toOverview);
+  }
+
+  const sorted = [...queueMediaIds].map(toOverview);
+  sorted.sort((left, right) => {
+    const compared = left.title.localeCompare(right.title, 'ja');
+    return sort === INPUT_SORT_TYPES.TITLE_ASC ? compared : compared * -1;
+  });
+  return sorted;
+};
 
 class GetQueueService {
   #userRepository;
@@ -54,16 +122,43 @@ class GetQueueService {
 
     const user = await this.#userRepository.findByUserId(new UserId(input.userId));
     if (!user) {
-      return new Output({ mediaOverviews: [] });
+      return new Output({
+        sort: input.sort,
+        queuePage: input.queuePage,
+        start: input.start,
+        totalCount: 0,
+        mediaOverviews: [],
+      });
     }
 
-    const mediaIds = user.getQueue().map(mediaId => mediaId.getId());
-    if (mediaIds.length === 0) {
-      return new Output({ mediaOverviews: [] });
+    const queueMediaIds = user.getQueue().map(mediaId => mediaId.getId());
+    if (queueMediaIds.length === 0) {
+      return new Output({
+        sort: input.sort,
+        queuePage: input.queuePage,
+        start: input.start,
+        totalCount: 0,
+        mediaOverviews: [],
+      });
     }
 
-    const mediaOverviews = await this.#mediaQueryRepository.findOverviewsByMediaIds(mediaIds);
-    return new Output({ mediaOverviews });
+    const mediaOverviews = await this.#mediaQueryRepository.findOverviewsByMediaIds(queueMediaIds);
+    const mediaOverviewMap = new Map(mediaOverviews.map(media => [media.mediaId, media]));
+    const favoriteMediaIdSet = new Set(user.getFavorites().map(mediaId => mediaId.getId()));
+    const sortedMediaOverviews = sortMediaOverviews({
+      sort: input.sort,
+      queueMediaIds: queueMediaIds.filter(mediaId => mediaOverviewMap.has(mediaId)),
+      mediaOverviewMap,
+      favoriteMediaIdSet,
+    });
+
+    return new Output({
+      sort: input.sort,
+      queuePage: input.queuePage,
+      start: input.start,
+      totalCount: sortedMediaOverviews.length,
+      mediaOverviews: sortedMediaOverviews.slice(input.start - 1, (input.start - 1) + input.pageSize),
+    });
   }
 }
 
@@ -71,4 +166,6 @@ module.exports = {
   Input,
   Output,
   GetQueueService,
+  InputSortType: INPUT_SORT_TYPES,
+  DEFAULT_PAGE_SIZE,
 };

--- a/src/controller/router/screen/setRouterScreenQueueGet.js
+++ b/src/controller/router/screen/setRouterScreenQueueGet.js
@@ -50,7 +50,7 @@ const setRouterScreenQueueGet = ({ router, authResolver, getQueueService }) => {
 
         res.status(200).render('screen/queue', {
           pageTitle: 'あとで見る一覧',
-          mediaOverviews: result.mediaOverviews,
+          mediaOverviews: result.currentPageMediaOverviews ?? result.mediaOverviews,
           currentConditions: {
             sort: result.sort,
             queuePage: pagination.currentPage,

--- a/src/controller/router/screen/setRouterScreenQueueGet.js
+++ b/src/controller/router/screen/setRouterScreenQueueGet.js
@@ -1,5 +1,28 @@
 const SessionAuthMiddleware = require('../../middleware/SessionAuthMiddleware');
-const { Input } = require('../../../application/user/query/GetQueueService');
+const {
+  Input,
+  InputSortType,
+  DEFAULT_PAGE_SIZE,
+} = require('../../../application/user/query/GetQueueService');
+
+const SORT_TYPES_BY_QUERY = Object.freeze({
+  date_desc: InputSortType.DATE_DESC,
+  date_asc: InputSortType.DATE_ASC,
+  title_asc: InputSortType.TITLE_ASC,
+  title_desc: InputSortType.TITLE_DESC,
+});
+
+const createPagination = ({ totalCount, queuePage, pageSize }) => {
+  const totalPages = Math.max(1, Math.ceil(totalCount / pageSize));
+  const currentPage = Math.min(Math.max(queuePage, 1), totalPages);
+  const items = [];
+
+  for (let page = 1; page <= totalPages; page += 1) {
+    items.push(page);
+  }
+
+  return { totalPages, currentPage, items };
+};
 
 const setRouterScreenQueueGet = ({ router, authResolver, getQueueService }) => {
   const auth = new SessionAuthMiddleware(authResolver);
@@ -8,13 +31,38 @@ const setRouterScreenQueueGet = ({ router, authResolver, getQueueService }) => {
     auth.execute.bind(auth),
     async (req, res, next) => {
       try {
+        const queuePage = Math.max(Number.parseInt(req.query.queuePage ?? '1', 10) || 1, 1);
+        const sort = typeof req.query.sort === 'string' && SORT_TYPES_BY_QUERY[req.query.sort]
+          ? req.query.sort
+          : 'date_desc';
+
         const result = await getQueueService.execute(new Input({
           userId: req.context.userId,
+          sort: SORT_TYPES_BY_QUERY[sort],
+          queuePage,
         }));
+
+        const pagination = createPagination({
+          totalCount: result.totalCount,
+          queuePage: result.queuePage,
+          pageSize: DEFAULT_PAGE_SIZE,
+        });
 
         res.status(200).render('screen/queue', {
           pageTitle: 'あとで見る一覧',
           mediaOverviews: result.mediaOverviews,
+          currentConditions: {
+            sort: result.sort,
+            queuePage: pagination.currentPage,
+          },
+          totalCount: result.totalCount,
+          pagination,
+          sortOptions: [
+            { value: 'date_desc', label: '登録の新しい順' },
+            { value: 'date_asc', label: '登録の古い順' },
+            { value: 'title_asc', label: 'タイトル名の昇順' },
+            { value: 'title_desc', label: 'タイトル名の降順' },
+          ],
         });
       } catch (error) {
         next(error);
@@ -24,3 +72,5 @@ const setRouterScreenQueueGet = ({ router, authResolver, getQueueService }) => {
 };
 
 module.exports = setRouterScreenQueueGet;
+module.exports.SORT_TYPES_BY_QUERY = SORT_TYPES_BY_QUERY;
+module.exports.createPagination = createPagination;

--- a/src/views/screen/queue.ejs
+++ b/src/views/screen/queue.ejs
@@ -22,9 +22,13 @@
       .thumbnail { width: 160px; height: 120px; border-radius: 12px; background: #dbeafe; overflow: hidden; display:flex; align-items:center; justify-content:center; color:#1d4ed8; font-size:12px; }
       .thumbnail img { width:100%; height:100%; object-fit:cover; }
       .meta { display:grid; gap: 12px; }
-      .tag-list, .actions { display:flex; gap:12px; flex-wrap:wrap; }
+      .tag-list, .actions, .pagination { display:flex; gap:12px; flex-wrap:wrap; align-items:center; }
       .chip { background: #eff6ff; color: #1d4ed8; border-radius: 999px; padding: 6px 12px; font-size: 14px; }
-      .button { border: 0; border-radius: 10px; padding: 10px 16px; font-size: 14px; font-weight: 700; cursor: pointer; background:#475569; color:#fff; }
+      .button { border: 0; border-radius: 10px; padding: 10px 16px; font-size: 14px; font-weight: 700; cursor: pointer; background:#2563eb; color:#fff; }
+      .button.secondary { background:#475569; }
+      .page-link, .page-current { min-width: 40px; height: 40px; border-radius: 999px; display:inline-flex; align-items:center; justify-content:center; border: 1px solid #cbd5e1; background: #fff; padding: 0 12px; }
+      .page-current { background: #2563eb; color: #fff; border-color: #2563eb; }
+      .status { min-height: 20px; font-size: 13px; color: #475569; }
       .empty { color: #64748b; }
       @media (max-width: 720px) { .media-body { grid-template-columns: 1fr; } .thumbnail { width: 100%; height: 200px; } }
     </style>
@@ -39,14 +43,16 @@
 
         <section class="card">
           <div class="toolbar">
-            <p><strong><%= mediaOverviews.length %></strong> 件</p>
+            <p><strong><%= totalCount %></strong> 件</p>
             <form class="sort-form" method="get" action="/screen/queue">
+              <input type="hidden" name="queuePage" value="1" />
               <label for="sort">並び順</label>
-              <select id="sort" name="sort" class="select-input" disabled>
-                <option selected>登録が新しい順</option>
-                <option>登録が古い順</option>
-                <option>ランダム</option>
+              <select id="sort" name="sort" class="select-input" onchange="this.form.submit()">
+                <% sortOptions.forEach((option) => { %>
+                  <option value="<%= option.value %>" <%= currentConditions.sort === option.value ? 'selected' : '' %>><%= option.label %></option>
+                <% }) %>
               </select>
+              <noscript><button class="button" type="submit">更新</button></noscript>
             </form>
           </div>
 
@@ -55,7 +61,7 @@
           <% } else { %>
             <div class="media-grid">
               <% mediaOverviews.forEach((media) => { %>
-                <article class="media-card">
+                <article class="media-card" data-media-id="<%= media.mediaId %>" data-favorite-put-path="/api/favorite/<%= media.mediaId %>" data-favorite-delete-path="/api/favorite/<%= media.mediaId %>" data-queue-put-path="/api/queue/<%= media.mediaId %>" data-queue-delete-path="/api/queue/<%= media.mediaId %>" data-is-favorite="<%= media.isFavorite %>" data-is-queued="<%= media.isQueued %>">
                   <div class="media-body">
                     <a class="thumbnail" href="/screen/detail/<%= media.mediaId %>">
                       <% if (media.thumbnail) { %>
@@ -75,8 +81,10 @@
                       </div>
                       <div class="actions">
                         <a href="/screen/detail/<%= media.mediaId %>">詳細画面へ</a>
-                        <button class="button" type="button" disabled>あとで見る一覧</button>
+                        <button class="button js-favorite-toggle" type="button"><%= media.isFavorite ? 'お気に入り解除' : 'お気に入り追加' %></button>
+                        <button class="button secondary js-queue-toggle" type="button"><%= media.isQueued ? 'あとで見る解除' : 'あとで見る追加' %></button>
                       </div>
+                      <p class="status" aria-live="polite"></p>
                     </div>
                   </div>
                 </article>
@@ -84,7 +92,89 @@
             </div>
           <% } %>
         </section>
+
+        <nav class="card">
+          <div class="pagination">
+            <% pagination.items.forEach((item) => { %>
+              <% if (item === pagination.currentPage) { %>
+                <span class="page-current"><%= item %></span>
+              <% } else { %>
+                <% const params = new URLSearchParams(); %>
+                <% params.set('queuePage', String(item)); %>
+                <% params.set('sort', currentConditions.sort); %>
+                <a class="page-link" href="/screen/queue?<%= params.toString() %>"><%= item %></a>
+              <% } %>
+            <% }) %>
+          </div>
+        </nav>
       </div>
     </div>
+
+    <script>
+      (() => {
+        const request = async ({ path, method, successMessage, failureMessage, statusElement }) => {
+          statusElement.textContent = '通信中です...';
+          try {
+            const response = await fetch(path, { method, headers: { Accept: 'application/json' } });
+            if (!response.ok) {
+              statusElement.textContent = `${failureMessage} (${response.status})`;
+              return false;
+            }
+            statusElement.textContent = successMessage;
+            return true;
+          } catch (_error) {
+            statusElement.textContent = failureMessage;
+            return false;
+          }
+        };
+
+        const applyState = (card, state) => {
+          card.dataset.isFavorite = String(state.isFavorite);
+          card.dataset.isQueued = String(state.isQueued);
+          card.querySelector('.js-favorite-toggle').textContent = state.isFavorite ? 'お気に入り解除' : 'お気に入り追加';
+          card.querySelector('.js-queue-toggle').textContent = state.isQueued ? 'あとで見る解除' : 'あとで見る追加';
+        };
+
+        document.querySelectorAll('[data-media-id]').forEach(card => {
+          const statusElement = card.querySelector('.status');
+          const state = {
+            isFavorite: card.dataset.isFavorite === 'true',
+            isQueued: card.dataset.isQueued === 'true',
+          };
+          const favoriteButton = card.querySelector('.js-favorite-toggle');
+          const queueButton = card.querySelector('.js-queue-toggle');
+
+          applyState(card, state);
+
+          favoriteButton.addEventListener('click', async () => {
+            const nextIsFavorite = !state.isFavorite;
+            const succeeded = await request({
+              path: nextIsFavorite ? card.dataset.favoritePutPath : card.dataset.favoriteDeletePath,
+              method: nextIsFavorite ? 'PUT' : 'DELETE',
+              successMessage: nextIsFavorite ? 'お気に入りに追加しました' : 'お気に入りから削除しました',
+              failureMessage: nextIsFavorite ? 'お気に入りへの追加に失敗しました' : 'お気に入りからの削除に失敗しました',
+              statusElement,
+            });
+            if (!succeeded) return;
+            state.isFavorite = nextIsFavorite;
+            applyState(card, state);
+          });
+
+          queueButton.addEventListener('click', async () => {
+            const nextIsQueued = !state.isQueued;
+            const succeeded = await request({
+              path: nextIsQueued ? card.dataset.queuePutPath : card.dataset.queueDeletePath,
+              method: nextIsQueued ? 'PUT' : 'DELETE',
+              successMessage: nextIsQueued ? 'あとで見るに追加しました' : 'あとで見るから削除しました',
+              failureMessage: nextIsQueued ? 'あとで見るへの追加に失敗しました' : 'あとで見るからの削除に失敗しました',
+              statusElement,
+            });
+            if (!succeeded) return;
+            state.isQueued = nextIsQueued;
+            applyState(card, state);
+          });
+        });
+      })();
+    </script>
   </body>
 </html>


### PR DESCRIPTION
### Motivation
- あとで見る一覧画面を UI 設計に合わせて操作可能にし、並び順変更・ページ切替・お気に入り/あとで見るのトグル導線を確保するため。 

### Description
- `src/application/user/query/GetQueueService.js` を拡張し、`sort` / `queuePage` / `start` を受け取る `Input` と、総件数・現在ページ情報・状態フラグを含む `Output` を返すようにし、並び替え・ページング・状態フラグ付与を実装しました。 
- `src/controller/router/screen/setRouterScreenQueueGet.js` でクエリ `sort` と `queuePage` を受け取りサービス入力へ渡し、画面描画用に `currentConditions` / `pagination` / `sortOptions` / `totalCount` を組み立てるようにしました。 
- `src/views/screen/queue.ejs` を更新して並び順ドロップダウンの有効化、ページネーション表示、タグから `/screen/summary?summaryPage=1` へ遷移する導線の維持、およびお気に入り/あとで見るボタンのトグル表示・状態反映を追加しました。 
- small/medium テストとドキュメントの更新を行い、テストファイルとテストケースを追加・修正しました（小テスト: `__tests__/small/applicationService/user/query/GetQueueService.test.js`、`__tests__/small/controller/router/screen/setRouterScreenQueueGet.test.js`; 中テスト: `__tests__/medium/controller/router/screen/setRouterScreenQueueGet.test.js`; ドキュメント: `doc/4_application/user/query/GetQueueService/testcase.md`, `doc/5_api/controller/router/screen/setRouterScreenQueueGet/testcase.md`）。

### Testing
- 変更に対応する small / medium テストを追加しましたが、ローカルで `jest` を実行しようとしたところ環境依存で `npx jest ...` が npm registry からの取得で `403 Forbidden` となりテスト実行は完了しませんでした。 
- テンプレートの簡易レンダリングによる表示確認を試行しましたが、実行環境で `ejs` が未導入のためレンダリング確認は完了しませんでした。 
- モジュール読み込みの最小チェック `node -e

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c16af4a0e0832b8032f00a792a9105)