### PR TITLE
feat: お気に入り一覧で並び順変更とページングに対応する

### DIFF
--- a/__tests__/medium/application/user/userQueryServices.test.js
+++ b/__tests__/medium/application/user/userQueryServices.test.js
@@ -66,18 +66,21 @@ describe('user query services (middle)', () => {
       const service = new GetFavoriteSummariesService({ userRepository, mediaQueryRepository });
       const result = await service.execute(new FavoriteInput({ userId: 'user001' }));
 
-      expect(result.mediaOverviews).toEqual([
-        {
-          mediaId: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-          title: 'お気に入り作品',
-          thumbnail: 'favorite-thumb',
-          tags: [
-            { category: 'シリーズ', label: '注目作' },
-            { category: '作者', label: '山田' },
-          ],
-          priorityCategories: ['シリーズ', '作者'],
-        },
-      ]);
+      expect(result).toEqual({
+        mediaOverviews: [
+          {
+            mediaId: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            title: 'お気に入り作品',
+            thumbnail: 'favorite-thumb',
+            tags: [
+              { category: 'シリーズ', label: '注目作' },
+              { category: '作者', label: '山田' },
+            ],
+            priorityCategories: ['シリーズ', '作者'],
+          },
+        ],
+        totalCount: 1,
+      });
     });
 
     test('business: user が存在しない場合は空配列を返す', async () => {
@@ -85,6 +88,7 @@ describe('user query services (middle)', () => {
 
       await expect(service.execute(new FavoriteInput({ userId: 'missinguser' }))).resolves.toEqual({
         mediaOverviews: [],
+        totalCount: 0,
       });
     });
   });

--- a/__tests__/medium/controller/router/screen/setRouterScreenFavoriteGet.test.js
+++ b/__tests__/medium/controller/router/screen/setRouterScreenFavoriteGet.test.js
@@ -67,15 +67,33 @@ describe('setRouterScreenFavoriteGet (middle)', () => {
     await mediaRepository.sync();
 
     const user = new User(new UserId('user001'));
-    user.addFavorite(new MediaId('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'));
+    [
+      'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      'cccccccccccccccccccccccccccccccc',
+    ].forEach(mediaId => user.addFavorite(new MediaId(mediaId)));
 
     await unitOfWork.run(async () => {
       await mediaRepository.save(new Media(
         new MediaId('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
-        new MediaTitle('お気に入り作品'),
+        new MediaTitle('あいうえお'),
         [new ContentId('content-001')],
         [new Tag(new Category('作者'), new Label('山田'))],
         [new Category('作者')],
+      ));
+      await mediaRepository.save(new Media(
+        new MediaId('bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'),
+        new MediaTitle('かきくけこ'),
+        [new ContentId('content-002')],
+        [new Tag(new Category('作者'), new Label('佐藤'))],
+        [new Category('作者')],
+      ));
+      await mediaRepository.save(new Media(
+        new MediaId('cccccccccccccccccccccccccccccccc'),
+        new MediaTitle('さしすせそ'),
+        [new ContentId('content-003')],
+        [new Tag(new Category('ジャンル'), new Label('冒険'))],
+        [new Category('ジャンル')],
       ));
       await userRepository.save(user);
     });
@@ -92,7 +110,10 @@ describe('setRouterScreenFavoriteGet (middle)', () => {
     app.set('views', path.join(process.cwd(), 'src', 'views'));
     app.set('view engine', 'ejs');
     app.engine('ejs', (filePath, options, callback) => {
-      callback(null, `<!DOCTYPE html><html lang="ja"><head><title>${options.pageTitle}</title></head><body>${filePath}:${options.mediaOverviews[0]?.title ?? ''}</body></html>`);
+      callback(
+        null,
+        `<!DOCTYPE html><html lang="ja"><head><title>${options.pageTitle}</title></head><body>${filePath}:sort=${options.currentConditions.sort}:page=${options.pagination.currentPage}:titles=${options.mediaOverviews.map(media => media.title).join(',')}:pages=${options.pagination.items.join(',')}:tags=${options.mediaOverviews.flatMap(media => media.tags.map(tag => `/screen/summary?summaryPage=1&sort=${options.currentConditions.sort}&tags=${encodeURIComponent(`${tag.category}:${tag.label}`)}`)).join('|')}</body></html>`,
+      );
     });
 
     app.use((req, _res, next) => {
@@ -124,6 +145,57 @@ describe('setRouterScreenFavoriteGet (middle)', () => {
     expect(response.headers.get('content-type')).toContain('text/html');
     expect(response.bodyText).toContain('<title>お気に入り一覧</title>');
     expect(response.bodyText).toContain(path.join('src', 'views', 'screen', 'favorite.ejs'));
-    expect(response.bodyText).toContain('お気に入り作品');
+    expect(response.bodyText).toContain('sort=date_asc');
+    expect(response.bodyText).toContain('page=1');
+  });
+
+  test('sort を変更すると指定順で描画される', async () => {
+    const response = await requestApp({
+      app: createApp(),
+      targetPath: '/screen/favorite?sort=title_asc&page=1',
+      headers: { 'x-session-token': 'valid-token' },
+    });
+
+    expect(response.bodyText).toContain('titles=あいうえお,かきくけこ,さしすせそ');
+  });
+
+  test('page を移動すると該当ページと導線情報を保持する', async () => {
+    await unitOfWork.run(async () => {
+      const user = await userRepository.findByUserId(new UserId('user001'));
+      for (let index = 4; index <= 21; index += 1) {
+        const suffix = String(index).padStart(3, '0');
+        const mediaId = `ddddddddddddddddddddddddddddd${suffix}`.slice(0, 32);
+        if (!user.getFavorites().some(item => item.getId() === mediaId)) {
+          user.addFavorite(new MediaId(mediaId));
+          await mediaRepository.save(new Media(
+            new MediaId(mediaId),
+            new MediaTitle(`追加作品${suffix}`),
+            [new ContentId(`content-${suffix}`)],
+            [new Tag(new Category('作者'), new Label(`作家${suffix}`))],
+            [new Category('作者')],
+          ));
+        }
+      }
+      await userRepository.save(user);
+    });
+
+    const response = await requestApp({
+      app: createApp(),
+      targetPath: '/screen/favorite?sort=date_desc&page=2',
+      headers: { 'x-session-token': 'valid-token' },
+    });
+
+    expect(response.bodyText).toContain('page=2');
+    expect(response.bodyText).toContain('pages=1,2');
+  });
+
+  test('タグ導線が /screen/summary を向き並び順を保持する', async () => {
+    const response = await requestApp({
+      app: createApp(),
+      targetPath: '/screen/favorite?sort=title_desc&page=1',
+      headers: { 'x-session-token': 'valid-token' },
+    });
+
+    expect(response.bodyText).toContain('/screen/summary?summaryPage=1&sort=title_desc&tags=');
   });
 });

--- a/__tests__/small/applicationService/user/query/GetFavoriteSummariesService.test.js
+++ b/__tests__/small/applicationService/user/query/GetFavoriteSummariesService.test.js
@@ -5,8 +5,17 @@ const UserId = require('../../../../../src/domain/user/userId');
 const MediaId = require('../../../../../src/domain/media/mediaId');
 const {
   Input,
+  Output,
   GetFavoriteSummariesService,
 } = require('../../../../../src/application/user/query/GetFavoriteSummariesService');
+
+const createOverview = ({ mediaId, title }) => ({
+  mediaId,
+  title,
+  thumbnail: `/${mediaId}.jpg`,
+  tags: [],
+  priorityCategories: [],
+});
 
 describe('GetFavoriteSummariesService', () => {
   test('user の favorite を media overview 一覧へ変換して返す', async () => {
@@ -18,8 +27,8 @@ describe('GetFavoriteSummariesService', () => {
 
     userRepository.findByUserId.mockResolvedValue(user);
     mediaQueryRepository.findOverviewsByMediaIds.mockResolvedValue([
-      { mediaId: 'media-001', title: 'タイトル1', thumbnail: '/c1.jpg', tags: [], priorityCategories: [] },
-      { mediaId: 'media-002', title: 'タイトル2', thumbnail: '/c2.jpg', tags: [], priorityCategories: [] },
+      createOverview({ mediaId: 'media-001', title: 'タイトル1' }),
+      createOverview({ mediaId: 'media-002', title: 'タイトル2' }),
     ]);
 
     const service = new GetFavoriteSummariesService({ userRepository, mediaQueryRepository });
@@ -27,6 +36,56 @@ describe('GetFavoriteSummariesService', () => {
 
     expect(userRepository.findByUserId).toHaveBeenCalledWith(expect.objectContaining({}));
     expect(mediaQueryRepository.findOverviewsByMediaIds).toHaveBeenCalledWith(['media-001', 'media-002']);
-    expect(result.mediaOverviews).toHaveLength(2);
+    expect(result).toEqual(new Output({
+      mediaOverviews: [
+        createOverview({ mediaId: 'media-002', title: 'タイトル2' }),
+        createOverview({ mediaId: 'media-001', title: 'タイトル1' }),
+      ],
+      totalCount: 2,
+    }));
+  });
+
+  test('sort=title_asc でタイトル昇順へ並べ替える', async () => {
+    const userRepository = new MockUserRepository();
+    const mediaQueryRepository = new MockMediaQueryRepository();
+    const user = new User(new UserId('user001'));
+    user.addFavorite(new MediaId('media-c'));
+    user.addFavorite(new MediaId('media-a'));
+    user.addFavorite(new MediaId('media-b'));
+
+    userRepository.findByUserId.mockResolvedValue(user);
+    mediaQueryRepository.findOverviewsByMediaIds.mockResolvedValue([
+      createOverview({ mediaId: 'media-c', title: 'さくら' }),
+      createOverview({ mediaId: 'media-a', title: 'あお' }),
+      createOverview({ mediaId: 'media-b', title: 'たろう' }),
+    ]);
+
+    const service = new GetFavoriteSummariesService({ userRepository, mediaQueryRepository });
+    const result = await service.execute(new Input({ userId: 'user001', sort: 'title_asc', page: 1 }));
+
+    expect(result.mediaOverviews.map(media => media.title)).toEqual(['あお', 'さくら', 'たろう']);
+    expect(result.totalCount).toBe(3);
+  });
+
+  test('page=2 で 21 件目以降だけを返す', async () => {
+    const userRepository = new MockUserRepository();
+    const mediaQueryRepository = new MockMediaQueryRepository();
+    const user = new User(new UserId('user001'));
+    const overviews = Array.from({ length: 25 }, (_, index) => {
+      const mediaId = `media-${String(index + 1).padStart(3, '0')}`;
+      user.addFavorite(new MediaId(mediaId));
+      return createOverview({ mediaId, title: `タイトル${index + 1}` });
+    });
+
+    userRepository.findByUserId.mockResolvedValue(user);
+    mediaQueryRepository.findOverviewsByMediaIds.mockResolvedValue(overviews);
+
+    const service = new GetFavoriteSummariesService({ userRepository, mediaQueryRepository });
+    const result = await service.execute(new Input({ userId: 'user001', page: 2, sort: 'date_desc' }));
+
+    expect(result.mediaOverviews).toHaveLength(5);
+    expect(result.mediaOverviews[0].mediaId).toBe('media-021');
+    expect(result.mediaOverviews[4].mediaId).toBe('media-025');
+    expect(result.totalCount).toBe(25);
   });
 });

--- a/__tests__/small/controller/router/screen/setRouterScreenFavoriteGet.test.js
+++ b/__tests__/small/controller/router/screen/setRouterScreenFavoriteGet.test.js
@@ -27,6 +27,7 @@ describe('setRouterScreenFavoriteGet', () => {
           tags: [{ category: '作者', label: '山田' }],
           priorityCategories: ['作者'],
         }],
+        totalCount: 1,
       })),
     };
 
@@ -50,7 +51,7 @@ describe('setRouterScreenFavoriteGet', () => {
     const server = app.listen(0);
     await new Promise(resolve => server.once('listening', resolve));
     const { port } = server.address();
-    const response = await fetch(`http://127.0.0.1:${port}/screen/favorite`, {
+    const response = await fetch(`http://127.0.0.1:${port}/screen/favorite?sort=title_desc&page=2`, {
       headers: { 'x-session-token': 'valid-token' },
     });
     const bodyText = await response.text();
@@ -61,6 +62,49 @@ describe('setRouterScreenFavoriteGet', () => {
     expect(bodyText).toContain('タイトル1');
     expect(bodyText).toContain('/api/favorite/media-001');
     expect(bodyText).toContain('/api/queue/media-001');
-    expect(getFavoriteSummariesService.execute).toHaveBeenCalledWith(expect.objectContaining({ userId: 'user-001' }));
+    expect(bodyText).toContain('value="title_desc" selected');
+    expect(getFavoriteSummariesService.execute).toHaveBeenCalledWith(expect.objectContaining({
+      userId: 'user-001',
+      sort: 'title_desc',
+      page: 2,
+    }));
+  });
+
+  test('sort/page の不正値はデフォルトへ丸める', async () => {
+    const app = express();
+    const router = express.Router();
+    const getFavoriteSummariesService = {
+      execute: jest.fn().mockResolvedValue(new Output({ mediaOverviews: [], totalCount: 0 })),
+    };
+
+    app.set('views', path.join(process.cwd(), 'src', 'views'));
+    app.set('view engine', 'ejs');
+    app.use((req, _res, next) => {
+      req.session = { session_token: req.header('x-session-token') };
+      req.context = {};
+      next();
+    });
+
+    setRouterScreenFavoriteGet({
+      router,
+      authResolver: new SessionStateAuthAdapter({
+        sessionStateStore: new InMemorySessionStateStore([['valid-token', 'user-001']]),
+      }),
+      getFavoriteSummariesService,
+    });
+    app.use(router);
+
+    const server = app.listen(0);
+    await new Promise(resolve => server.once('listening', resolve));
+    const { port } = server.address();
+    await fetch(`http://127.0.0.1:${port}/screen/favorite?sort=invalid&page=0`, {
+      headers: { 'x-session-token': 'valid-token' },
+    });
+    await new Promise(resolve => server.close(resolve));
+
+    expect(getFavoriteSummariesService.execute).toHaveBeenCalledWith(expect.objectContaining({
+      sort: 'date_asc',
+      page: 1,
+    }));
   });
 });

--- a/doc/4_application/user/query/GetFavoriteSummariesService/testcase.md
+++ b/doc/4_application/user/query/GetFavoriteSummariesService/testcase.md
@@ -11,6 +11,33 @@
   - `userRepository.findByUserId` が `userId` で呼ばれる
   - `mediaQueryRepository.findOverviewsByMediaIds` が favorite の `mediaId` 配列で呼ばれる
   - `Output.mediaOverviews` に favorite 件数分のメディア概要が格納される
+  - `Output.totalCount` に favorite 総件数が格納される
+  - エラーは発生しない
+
+---
+
+## sort=title_asc を指定するとタイトル昇順で返す
+- **前提**
+  - 対象ユーザーが存在する
+  - favorite にタイトル順が不規則な複数件のメディアが登録されている
+- **操作**
+  - `Input` に `sort=title_asc` を指定して実行する
+- **結果**
+  - `Output.mediaOverviews` がタイトル昇順に並ぶ
+  - `Output.totalCount` は全件数を保持する
+  - エラーは発生しない
+
+---
+
+## page=2 を指定すると 21 件目以降のみ返す
+- **前提**
+  - 対象ユーザーが存在する
+  - favorite が 21 件以上登録されている
+- **操作**
+  - `Input` に `page=2` を指定して実行する
+- **結果**
+  - `Output.mediaOverviews` には 21 件目以降のページ分だけが格納される
+  - `Output.totalCount` は全件数を保持する
   - エラーは発生しない
 
 ---
@@ -23,6 +50,7 @@
   - `Input` に `userId` を指定して実行する
 - **結果**
   - `Output.mediaOverviews` として空配列が返る
+  - `Output.totalCount` は 0 になる
   - `mediaQueryRepository.findOverviewsByMediaIds` は呼ばれない
   - エラーは発生しない
 
@@ -35,6 +63,7 @@
   - `Input` に `userId` を指定して実行する
 - **結果**
   - `Output.mediaOverviews` として空配列が返る
+  - `Output.totalCount` は 0 になる
   - `mediaQueryRepository.findOverviewsByMediaIds` は呼ばれない
   - エラーは発生しない
 

--- a/doc/5_api/controller/router/screen/setRouterScreenFavoriteGet/testcase.md
+++ b/doc/5_api/controller/router/screen/setRouterScreenFavoriteGet/testcase.md
@@ -2,8 +2,12 @@
 
 ## テストケース一覧
 - [GET /screen/favorite に認証・描画の2ハンドラーを登録する](#get-screenfavorite-に認証描画の2ハンドラーを登録する)
-- [登録済みハンドラーを順に実行するとお気に入り一覧画面を描画する](#登録済みハンドラーを順に実行するとお気に入り一覧画面を描画する)
+- [sort/page クエリを解釈してお気に入り一覧画面を描画する](#sortpage-クエリを解釈してお気に入り一覧画面を描画する)
+- [sort/page の不正値をデフォルトへ丸める](#sortpage-の不正値をデフォルトへ丸める)
 - [一覧取得で例外が発生した場合は next に委譲する](#一覧取得で例外が発生した場合は-next-に委譲する)
+- [medium: 並び順変更で指定順に描画される](#medium-並び順変更で指定順に描画される)
+- [medium: ページ移動で現在ページ情報を保持して描画される](#medium-ページ移動で現在ページ情報を保持して描画される)
+- [medium: タグ導線が /screen/summary を向き並び順を保持する](#medium-タグ導線が-screensummary-を向き並び順を保持する)
 
 ---
 
@@ -20,14 +24,25 @@
 
 ---
 
-### 登録済みハンドラーを順に実行するとお気に入り一覧画面を描画する
+### sort/page クエリを解釈してお気に入り一覧画面を描画する
 - **前提**
   - `authResolver.execute` は `userId` を返す。
   - `getFavoriteSummariesService.execute` は一覧結果を返す。
 - **操作**
-  - 登録済みの2ハンドラーを順に実行する。
+  - `GET /screen/favorite?sort=title_desc&page=2` を実行する。
 - **結果**
-  - `screen/favorite` が `mediaOverviews` を含む表示データで描画される。
+  - `screen/favorite` が `mediaOverviews` / `totalCount` / `currentConditions` / `pagination` / `sortOptions` を含む表示データで描画される。
+  - `getFavoriteSummariesService.execute` が `sort=title_desc` / `page=2` を含む `Input` で呼ばれる。
+
+---
+
+### sort/page の不正値をデフォルトへ丸める
+- **前提**
+  - `getFavoriteSummariesService.execute` は有効な一覧結果を返す。
+- **操作**
+  - `GET /screen/favorite?sort=invalid&page=0` を実行する。
+- **結果**
+  - `getFavoriteSummariesService.execute` が `sort=date_asc` / `page=1` を含む `Input` で呼ばれる。
 
 ---
 
@@ -39,5 +54,36 @@
 - **結果**
   - `next(error)` が呼ばれる。
 
+---
+
+### medium: 並び順変更で指定順に描画される
+- **前提**
+  - 永続化済み favorite が複数存在する。
+- **操作**
+  - `GET /screen/favorite?sort=title_asc&page=1` を実行する。
+- **結果**
+  - タイトル昇順で描画される。
+
+---
+
+### medium: ページ移動で現在ページ情報を保持して描画される
+- **前提**
+  - 永続化済み favorite が 21 件以上存在する。
+- **操作**
+  - `GET /screen/favorite?sort=date_desc&page=2` を実行する。
+- **結果**
+  - 2 ページ目として描画される。
+  - ページネーション情報に 1, 2 ページが含まれる。
+
+---
+
+### medium: タグ導線が /screen/summary を向き並び順を保持する
+- **前提**
+  - タグ付き favorite が存在する。
+- **操作**
+  - `GET /screen/favorite?sort=title_desc&page=1` を実行する。
+- **結果**
+  - タグリンクが `/screen/summary?summaryPage=1&sort=title_desc&tags=...` を向く。
+
 ## medium テストで担保する観点
-- `GetFavoriteSummariesService` と永続化済み favorite データを接続し、画面描画に必要な `mediaOverviews` 生成を medium で確認する。
+- `GetFavoriteSummariesService` と永続化済み favorite データを接続し、並び順変更・ページ移動・タグ導線を含む画面描画を確認する。

--- a/src/application/user/query/GetFavoriteSummariesService.js
+++ b/src/application/user/query/GetFavoriteSummariesService.js
@@ -1,12 +1,29 @@
 const UserId = require('../../../domain/user/userId');
 
+const PAGE_SIZE = 20;
+const SORT_TYPES = Object.freeze({
+  DATE_ASC: 'date_asc',
+  DATE_DESC: 'date_desc',
+  TITLE_ASC: 'title_asc',
+  TITLE_DESC: 'title_desc',
+});
+const DEFAULT_SORT = SORT_TYPES.DATE_ASC;
+
 class Input {
-  constructor({ userId }) {
+  constructor({ userId, sort = DEFAULT_SORT, page = 1 } = {}) {
     if (typeof userId !== 'string' || userId.length === 0) {
+      throw new Error();
+    }
+    if (!Object.values(SORT_TYPES).includes(sort)) {
+      throw new Error();
+    }
+    if (typeof page !== 'number' || page <= 0 || !Number.isInteger(page)) {
       throw new Error();
     }
 
     this.userId = userId;
+    this.sort = sort;
+    this.page = page;
   }
 }
 
@@ -22,14 +39,41 @@ const isMediaOverviewLike = (obj) => {
 };
 
 class Output {
-  constructor({ mediaOverviews }) {
+  constructor({ mediaOverviews, totalCount }) {
     if (!(mediaOverviews instanceof Array) || !mediaOverviews.every(isMediaOverviewLike)) {
+      throw new Error();
+    }
+    if (typeof totalCount !== 'number' || totalCount < 0 || !Number.isInteger(totalCount)) {
       throw new Error();
     }
 
     this.mediaOverviews = mediaOverviews;
+    this.totalCount = totalCount;
   }
 }
+
+const compareByTitle = (direction) => (a, b) => {
+  const result = a.title.localeCompare(b.title, 'ja');
+  if (result !== 0) {
+    return direction === 'asc' ? result : result * -1;
+  }
+  return a.mediaId.localeCompare(b.mediaId, 'ja');
+};
+
+const sortMediaOverviews = ({ mediaOverviews, sort }) => {
+  switch (sort) {
+    case SORT_TYPES.DATE_ASC:
+      return [...mediaOverviews].reverse();
+    case SORT_TYPES.DATE_DESC:
+      return [...mediaOverviews];
+    case SORT_TYPES.TITLE_ASC:
+      return [...mediaOverviews].sort(compareByTitle('asc'));
+    case SORT_TYPES.TITLE_DESC:
+      return [...mediaOverviews].sort(compareByTitle('desc'));
+    default:
+      throw new Error();
+  }
+};
 
 class GetFavoriteSummariesService {
   #userRepository;
@@ -54,20 +98,29 @@ class GetFavoriteSummariesService {
 
     const user = await this.#userRepository.findByUserId(new UserId(input.userId));
     if (!user) {
-      return new Output({ mediaOverviews: [] });
+      return new Output({ mediaOverviews: [], totalCount: 0 });
     }
 
     const mediaIds = user.getFavorites().map(mediaId => mediaId.getId());
     if (mediaIds.length === 0) {
-      return new Output({ mediaOverviews: [] });
+      return new Output({ mediaOverviews: [], totalCount: 0 });
     }
 
     const mediaOverviews = await this.#mediaQueryRepository.findOverviewsByMediaIds(mediaIds);
-    return new Output({ mediaOverviews });
+    const sortedMediaOverviews = sortMediaOverviews({ mediaOverviews, sort: input.sort });
+    const totalCount = sortedMediaOverviews.length;
+    const start = (input.page - 1) * PAGE_SIZE;
+    return new Output({
+      mediaOverviews: sortedMediaOverviews.slice(start, start + PAGE_SIZE),
+      totalCount,
+    });
   }
 }
 
 module.exports = {
+  PAGE_SIZE,
+  SORT_TYPES,
+  DEFAULT_SORT,
   Input,
   Output,
   GetFavoriteSummariesService,

--- a/src/controller/router/screen/setRouterScreenFavoriteGet.js
+++ b/src/controller/router/screen/setRouterScreenFavoriteGet.js
@@ -1,5 +1,27 @@
 const SessionAuthMiddleware = require('../../middleware/SessionAuthMiddleware');
-const { Input } = require('../../../application/user/query/GetFavoriteSummariesService');
+const {
+  Input,
+  DEFAULT_SORT,
+  SORT_TYPES,
+  PAGE_SIZE,
+} = require('../../../application/user/query/GetFavoriteSummariesService');
+
+const SORT_OPTIONS = Object.freeze([
+  { value: SORT_TYPES.DATE_ASC, label: '追加の新しい順' },
+  { value: SORT_TYPES.DATE_DESC, label: '追加の古い順' },
+  { value: SORT_TYPES.TITLE_ASC, label: 'タイトル名の昇順' },
+  { value: SORT_TYPES.TITLE_DESC, label: 'タイトル名の降順' },
+]);
+
+const createPagination = ({ totalCount, page, pageSize }) => {
+  const totalPages = Math.max(1, Math.ceil(totalCount / pageSize));
+  const currentPage = Math.min(Math.max(page, 1), totalPages);
+  const items = [];
+  for (let value = 1; value <= totalPages; value += 1) {
+    items.push(value);
+  }
+  return { totalPages, currentPage, items };
+};
 
 const setRouterScreenFavoriteGet = ({ router, authResolver, getFavoriteSummariesService }) => {
   const auth = new SessionAuthMiddleware(authResolver);
@@ -8,13 +30,31 @@ const setRouterScreenFavoriteGet = ({ router, authResolver, getFavoriteSummaries
     auth.execute.bind(auth),
     async (req, res, next) => {
       try {
+        const sort = typeof req.query.sort === 'string' && Object.values(SORT_TYPES).includes(req.query.sort)
+          ? req.query.sort
+          : DEFAULT_SORT;
+        const page = Math.max(Number.parseInt(req.query.page ?? '1', 10) || 1, 1);
         const result = await getFavoriteSummariesService.execute(new Input({
           userId: req.context.userId,
+          sort,
+          page,
         }));
+        const pagination = createPagination({
+          totalCount: result.totalCount,
+          page,
+          pageSize: PAGE_SIZE,
+        });
 
         res.status(200).render('screen/favorite', {
           pageTitle: 'お気に入り一覧',
           mediaOverviews: result.mediaOverviews,
+          totalCount: result.totalCount,
+          currentConditions: {
+            sort,
+            page: pagination.currentPage,
+          },
+          pagination,
+          sortOptions: SORT_OPTIONS,
         });
       } catch (error) {
         next(error);
@@ -24,3 +64,5 @@ const setRouterScreenFavoriteGet = ({ router, authResolver, getFavoriteSummaries
 };
 
 module.exports = setRouterScreenFavoriteGet;
+module.exports.SORT_OPTIONS = SORT_OPTIONS;
+module.exports.createPagination = createPagination;

--- a/src/views/screen/favorite.ejs
+++ b/src/views/screen/favorite.ejs
@@ -13,18 +13,24 @@
       .page { max-width: 1080px; margin: 0 auto; padding: 32px 16px 64px; }
       .stack { display: grid; gap: 24px; }
       .card { background: #fff; border: 1px solid #d1d5db; border-radius: 16px; padding: 24px; box-shadow: 0 10px 30px rgba(15, 23, 42, 0.06); }
+      .toolbar { display:flex; justify-content:space-between; gap:16px; align-items:flex-end; flex-wrap:wrap; }
+      .summary { display:grid; gap:8px; }
+      .sort-form { display:flex; gap:12px; align-items:center; flex-wrap:wrap; }
+      .select-input { min-width:220px; border:1px solid #cbd5e1; border-radius:10px; padding:10px 12px; font-size:14px; background:#fff; }
       .media-grid { display: grid; gap: 16px; }
       .media-card { border: 1px solid #dbe3f0; border-radius: 16px; background: #f8fafc; padding: 16px; }
       .media-body { display: grid; grid-template-columns: 160px 1fr; gap: 16px; }
       .thumbnail { width: 160px; height: 120px; border-radius: 12px; background: #dbeafe; overflow: hidden; display:flex; align-items:center; justify-content:center; color:#1d4ed8; font-size:12px; }
       .thumbnail img { width:100%; height:100%; object-fit:cover; }
       .meta { display:grid; gap: 12px; }
-      .tag-list, .actions { display:flex; gap:12px; flex-wrap:wrap; }
+      .tag-list, .actions, .pagination { display:flex; gap:12px; flex-wrap:wrap; }
       .chip { background: #eff6ff; color: #1d4ed8; border-radius: 999px; padding: 6px 12px; font-size: 14px; }
       .button { border: 0; border-radius: 10px; padding: 10px 16px; font-size: 14px; font-weight: 700; cursor: pointer; background:#2563eb; color:#fff; }
       .button.secondary { background:#475569; }
       .status { min-height: 20px; font-size: 13px; color: #475569; }
       .empty { color: #64748b; }
+      .page-link, .page-current { min-width: 40px; height: 40px; display:inline-flex; align-items:center; justify-content:center; border-radius:999px; border:1px solid #cbd5e1; background:#fff; }
+      .page-current { background:#2563eb; color:#fff; border-color:#2563eb; }
       @media (max-width: 720px) { .media-body { grid-template-columns: 1fr; } .thumbnail { width: 100%; height: 200px; } }
     </style>
   </head>
@@ -34,6 +40,24 @@
         <section class="card">
           <h1><%= pageTitle %></h1>
           <p>お気に入りに登録したメディアを一覧表示します。</p>
+        </section>
+
+        <section class="card">
+          <div class="toolbar">
+            <div class="summary">
+              <strong><%= totalCount %></strong>
+              <span>ページ <%= pagination.currentPage %> / <%= pagination.totalPages %></span>
+            </div>
+            <form class="sort-form" method="get" action="/screen/favorite">
+              <input type="hidden" name="page" value="1" />
+              <label for="sort">並び順</label>
+              <select id="sort" name="sort" class="select-input" onchange="this.form.submit()">
+                <% sortOptions.forEach((option) => { %>
+                  <option value="<%= option.value %>" <%= currentConditions.sort === option.value ? 'selected' : '' %>><%= option.label %></option>
+                <% }) %>
+              </select>
+            </form>
+          </div>
         </section>
 
         <section class="card">
@@ -57,12 +81,12 @@
                       </div>
                       <div class="tag-list">
                         <% media.tags.forEach((tag) => { %>
-                          <span class="chip"><%= tag.category %>:<%= tag.label %></span>
+                          <a class="chip" href="/screen/summary?summaryPage=1&sort=<%= encodeURIComponent(currentConditions.sort) %>&tags=<%= encodeURIComponent(`${tag.category}:${tag.label}`) %>"><%= tag.category %>:<%= tag.label %></a>
                         <% }) %>
                       </div>
                       <div class="actions">
-                        <a href="/screen/detail/<%= media.mediaId %>">詳細画面へ</a>
-                        <a href="/screen/viewer/<%= media.mediaId %>/1">ビューアーへ</a>
+                        <a href="/screen/detail/<%= media.mediaId %>?page=<%= currentConditions.page %>&sort=<%= currentConditions.sort %>">詳細画面へ</a>
+                        <a href="/screen/viewer/<%= media.mediaId %>/1?page=<%= currentConditions.page %>&sort=<%= currentConditions.sort %>">ビューアーへ</a>
                         <button class="button secondary js-favorite-remove" type="button">お気に入り解除</button>
                         <button class="button js-queue-add" type="button">あとで見る追加</button>
                       </div>
@@ -74,6 +98,18 @@
             </div>
           <% } %>
         </section>
+
+        <% if (pagination.totalPages > 1) { %>
+          <nav class="pagination" aria-label="お気に入り一覧のページネーション">
+            <% pagination.items.forEach((item) => { %>
+              <% if (item === pagination.currentPage) { %>
+                <span class="page-current"><%= item %></span>
+              <% } else { %>
+                <a class="page-link" href="/screen/favorite?page=<%= item %>&sort=<%= currentConditions.sort %>"><%= item %></a>
+              <% } %>
+            <% }) %>
+          </nav>
+        <% } %>
       </div>
     </div>
 


### PR DESCRIPTION
### Motivation
- お気に入り一覧に対して並び替えやページ移動ができず、タグ導線や詳細遷移で一覧条件を保持できなかったため、UX を改善するための対応を行う。
- サービス層で総件数とページ単位取得を扱えるようにして、ルーター/ビューでクエリ処理・UI を統合することで一貫した実装にする。

### Description
- `src/application/user/query/GetFavoriteSummariesService.js` を拡張し、`Input` に `sort`/`page` を追加し、`Output` に `totalCount` を返すようにした; 並び替え（登録日時昇降・タイトル昇降）と 20 件ページングを実装した。
- `src/controller/router/screen/setRouterScreenFavoriteGet.js` を更新してクエリパラメータ `sort` と `page` を解釈し、不正値はデフォルトへ丸め、`currentConditions` / `pagination` / `sortOptions` をビューへ渡すようにした。
- `src/views/screen/favorite.ejs` を UI 設計に合わせて更新し、並び順ドロップダウン、件数表示、ページネーション、タグリンクを `/screen/summary` に変更し詳細/ビューアー遷移で現在の `page`/`sort` を保持する導線を追加した。
- テストとドキュメントを更新・追加した: small レイヤーのサービス/ルーター用テストに並び順・ページング・クエリ検証を追加し、medium の画面ルーターテストに並び順変更・ページ移動・タグ導線の検証を追加し、該当の `doc/.../testcase.md` を更新した。

### Testing
- `node --check` による構文チェックで `src/application/user/query/GetFavoriteSummariesService.js` / `src/controller/router/screen/setRouterScreenFavoriteGet.js` / 影響するテストファイルの構文は確認済み。 
- インラインの Node スクリプトで `GetFavoriteSummariesService` のページング動作（21件目以降の取得、`totalCount` の保持）を簡易検証し成功を確認した（ログ: `service-ok`）。
- ルーターの基本的な require/レンダリング引数の確認はローカル require や簡易サーバー実行で部分的に確認したが、環境でのフル自動実行は限定的に実施した。 
- Jest による自動テスト実行はこの環境で `jest: not found` のため完遂できていないが、関連の `__tests__` を追加・更新済みで、CI/ローカル環境で `npm test` が利用可能な場合は実行を推奨する。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c16af7df98832b8fb26805b91e9a5b)