### PR TITLE
feat: メディア詳細画面にカテゴリー表示用プロパティを追加する

### DIFF
--- a/__tests__/medium/application/media/mediaServices.test.js
+++ b/__tests__/medium/application/media/mediaServices.test.js
@@ -344,6 +344,7 @@ describe('media application services (middle)', () => {
           { category: '作者', label: '詳細作者' },
           { category: 'ジャンル', label: '詳細ジャンル' },
         ],
+        categories: ['作者', 'ジャンル'],
         priorityCategories: ['ジャンル', '作者'],
       });
     });

--- a/__tests__/medium/application/media/mediaServices.test.js
+++ b/__tests__/medium/application/media/mediaServices.test.js
@@ -88,6 +88,7 @@ describe('media application services (middle)', () => {
           { category: '作者', label: '山田太郎' },
           { category: 'ジャンル', label: '冒険' },
         ],
+        categories: ['作者', 'ジャンル'],
         priorityCategories: ['作者', 'ジャンル'],
       });
     });

--- a/__tests__/medium/controller/router/screen/setRouterScreenDetailGet.test.js
+++ b/__tests__/medium/controller/router/screen/setRouterScreenDetailGet.test.js
@@ -98,7 +98,7 @@ describe('setRouterScreenDetailGet (middle)', () => {
     return app;
   };
 
-  test('GET /screen/detail/:mediaId で主要表示を描画する', async () => {
+  test('GET /screen/detail/:mediaId でカテゴリーを含む主要表示を描画する', async () => {
     const response = await requestApp({
       app: createApp(),
       targetPath: '/screen/detail/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
@@ -109,6 +109,7 @@ describe('setRouterScreenDetailGet (middle)', () => {
     expect(response.headers.get('content-type')).toContain('text/html');
     expect(response.bodyText).toContain('<title>作品A の詳細</title>');
     expect(response.bodyText).toContain('登録日:');
+    expect(response.bodyText).toContain('カテゴリー一覧');
     expect(response.bodyText).toContain('/screen/summary?summaryPage=1&sort=date_asc&tags=%E4%BD%9C%E8%80%85%3A%E5%B1%B1%E7%94%B0%20%E5%A4%AA%E9%83%8E');
     expect(response.bodyText).toContain('/screen/viewer/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/1');
     expect(response.bodyText).toContain('src="content-001"');

--- a/__tests__/small/applicationService/media/query/GetMediaDetailService.test.js
+++ b/__tests__/small/applicationService/media/query/GetMediaDetailService.test.js
@@ -48,6 +48,7 @@ describe("GetMediaDetailService", () => {
         registeredAt: '2026-03-20 12:34 UTC',
         contents: [{ id: 'CID', thumbnail: 'CID', position: 1 }],
         tags: [{ category: 'C', label: 'L' }],
+        categories: ['C'],
         priorityCategories: ['C'],
       },
     }));
@@ -68,6 +69,7 @@ describe("GetMediaDetailService", () => {
     const result = await service.execute(input);
 
     expect(result.mediaDetail.registeredAt).toBe('');
+    expect(result.mediaDetail.categories).toEqual(['作者']);
     expect(result.mediaDetail.contents).toEqual([
       { id: 'CID1', thumbnail: 'CID1', position: 1 },
       { id: 'CID2', thumbnail: 'CID2', position: 2 },

--- a/__tests__/small/controller/router/screen/setRouterScreenDetailGet.test.js
+++ b/__tests__/small/controller/router/screen/setRouterScreenDetailGet.test.js
@@ -29,6 +29,7 @@ describe('setRouterScreenDetailGet', () => {
           registeredAt: '2026-03-20 12:34 UTC',
           contents: [{ id: 'content-1', thumbnail: 'content-1', position: 1 }],
           tags: [{ category: '作者', label: '山田' }],
+          categories: ['作者'],
           priorityCategories: ['作者'],
         },
       }),
@@ -64,7 +65,7 @@ describe('setRouterScreenDetailGet', () => {
     }));
   });
 
-  it('詳細テンプレートにタグリンク・登録日・サムネイル導線を渡せる', async () => {
+  it('詳細テンプレートにカテゴリー・タグリンク・登録日・サムネイル導線を渡せる', async () => {
     const templatePath = path.join(process.cwd(), 'src', 'views', 'screen', 'detail.ejs');
     const html = await ejs.renderFile(templatePath, {
       pageTitle: '作品タイトル の詳細',
@@ -76,13 +77,17 @@ describe('setRouterScreenDetailGet', () => {
           { id: 'content-1', thumbnail: 'content-1', position: 1 },
           { id: '', thumbnail: '', position: 2 },
         ],
-        tags: [{ category: '作者', label: '山田 太郎' }],
+        tags: [{ category: '作者', label: '山田 太郎' }, { category: '作者', label: '別名' }, { category: 'シリーズ', label: '作品群' }],
+        categories: ['作者', 'シリーズ'],
         priorityCategories: ['作者'],
       },
     });
 
     expect(html).toContain('登録日:');
     expect(html).toContain('2026-03-20 12:34 UTC');
+    expect(html).toContain('カテゴリー一覧');
+    expect(html).toContain('<span class="chip">作者</span>');
+    expect(html).toContain('<span class="chip">シリーズ</span>');
     expect(html).toContain('/screen/summary?summaryPage=1&sort=date_asc&tags=%E4%BD%9C%E8%80%85%3A%E5%B1%B1%E7%94%B0%20%E5%A4%AA%E9%83%8E');
     expect(html).toContain('/screen/viewer/media-1/1');
     expect(html).toContain('alt="作品タイトル 1 枚目のサムネイル"');

--- a/__tests__/small/controller/screen/ScreenDetailGetController.test.js
+++ b/__tests__/small/controller/screen/ScreenDetailGetController.test.js
@@ -18,6 +18,7 @@ describe('ScreenDetailGetController', () => {
       registeredAt: '2026-03-20 12:34 UTC',
       contents: [{ id: 'content-1', thumbnail: 'content-1', position: 1 }],
       tags: [{ category: '作者', label: '山田' }],
+      categories: ['作者'],
       priorityCategories: ['作者'],
     };
     const getMediaDetailService = {

--- a/doc/5_api/controller/screen/ScreenDetailGetController/testcase.md
+++ b/doc/5_api/controller/screen/ScreenDetailGetController/testcase.md
@@ -16,6 +16,7 @@
   - service が `Input.mediaId = req.params.mediaId` で呼び出される。
   - `screen/detail` が `200` で描画される。
   - `pageTitle` と `mediaDetail` が描画モデルへ設定される。
+  - `mediaDetail.categories` に詳細画面で表示するカテゴリー一覧が含まれる。
 
 ---
 
@@ -36,4 +37,5 @@
 ## 今回の更新反映
 - 追加出力/表示の確認対象に `登録日時` を追加する。
 - 追加出力/表示の確認対象に `サムネイル表示用の contents(id / thumbnail / position)` を追加する。
+- 追加出力/表示の確認対象に `カテゴリー一覧` を追加する。
 - 追加出力/表示の確認対象に `タグ検索リンク` と既存の `優先カテゴリ` を追加する。

--- a/src/application/media/query/GetMediaDetailService.js
+++ b/src/application/media/query/GetMediaDetailService.js
@@ -33,6 +33,9 @@ class Output {
     if (!(mediaDetail.tags instanceof Array) || !mediaDetail.tags.every(tag => ['category', 'label'].every(prop => prop in tag))) {
       throw new Error();
     }
+    if (!(mediaDetail.categories instanceof Array) || !mediaDetail.categories.every(category => typeof category === 'string')) {
+      throw new Error();
+    }
     if (!(mediaDetail.priorityCategories instanceof Array) || !mediaDetail.priorityCategories.every(pc => typeof pc === 'string')) {
       throw new Error();
     }
@@ -40,6 +43,8 @@ class Output {
     this.mediaDetail = mediaDetail;
   }
 }
+
+const createCategories = tags => [...new Set(tags.map(tag => tag.category))];
 
 const formatRegisteredAt = registeredAt => {
   if (!(registeredAt instanceof Date) || Number.isNaN(registeredAt.getTime())) {
@@ -77,6 +82,11 @@ class GetMediaDetailService {
       throw new Error();
     }
 
+    const tags = media.getTags().map(tag => ({
+      category: tag.getCategory().getValue(),
+      label: tag.getLabel().getLabel(),
+    }));
+
     const output = new Output({
       mediaDetail: {
         id: media.getId().getId(),
@@ -87,10 +97,8 @@ class GetMediaDetailService {
           thumbnail: content.getId(),
           position: index + 1,
         })),
-        tags: media.getTags().map(tag => ({
-          category: tag.getCategory().getValue(),
-          label: tag.getLabel().getLabel(),
-        })),
+        tags,
+        categories: createCategories(tags),
         priorityCategories: media.getPriorityCategories().map(pc => pc.getValue()),
       },
     });

--- a/src/views/screen/detail.ejs
+++ b/src/views/screen/detail.ejs
@@ -91,6 +91,19 @@
         </section>
 
         <section class="card">
+          <h2>カテゴリー一覧</h2>
+          <% if (mediaDetail.categories.length === 0) { %>
+            <p class="empty">カテゴリーはありません。</p>
+          <% } else { %>
+            <div class="chip-list">
+              <% mediaDetail.categories.forEach((category) => { %>
+                <span class="chip"><%= category %></span>
+              <% }) %>
+            </div>
+          <% } %>
+        </section>
+
+        <section class="card">
           <h2>タグ一覧</h2>
           <% if (mediaDetail.tags.length === 0) { %>
             <p class="empty">タグはありません。</p>


### PR DESCRIPTION
### Motivation
- 詳細画面の表示項目仕様に合わせて「カテゴリー一覧」を追加し、テンプレート側で `tags` の重複除去を行うのではなくアプリケーション層で表示用プロパティを明示的に渡す方針に統一するため。 
- 表示契約を `controller` / `view` / `application` / `test` で固定化して、タグ構造の変更時に影響範囲を追いやすくするため。

### Description
- `GetMediaDetailService` に `createCategories` を導入し、`media.getTags()` から順序を保った重複除去を行って `mediaDetail.categories` を生成するようにした（`src/application/media/query/GetMediaDetailService.js`）。
- `Output` の検証に `categories` を追加し、返却モデルに `categories` を含めるようにした（`src/application/media/query/GetMediaDetailService.js`）。
- 詳細画面テンプレート `src/views/screen/detail.ejs` に「カテゴリー一覧」セクションを追加し、空の場合の文言とチップ表示を実装した。 
- テスト/ドキュメントの期待値を更新して、`mediaDetail.categories` を含めるようにした（各種 `__tests__/*` と `doc/5_api/controller/screen/ScreenDetailGetController/testcase.md` を更新）。

### Testing
- `node --check src/application/media/query/GetMediaDetailService.js` は成功した（構文チェック）。
- `node --check src/controller/screen/ScreenDetailGetController.js` は成功した（構文チェック）。
- `node` による手動実行で `GetMediaDetailService` の `categories` 生成（重複除去、順序保持）と `registeredAt` 整形を確認した（成功）。
- `python` によるテンプレート静的チェックで `detail.ejs` に `カテゴリー一覧` セクションと `mediaDetail.categories` の出力が存在することを確認した（成功）。
- 統合/単体の `jest` 実行は試みたが、ワークスペースの `jest` 実行環境が利用不可のため自動テストは実行できなかった（`jest: not found` / `npm install` がレジストリ 403 により失敗）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1750aacf8832ba1417263e94bdfdf)