### PR TITLE
test: エラー画面ルーターのmediumテストを追加する

### DIFF
--- a/__tests__/medium/controller/router/screen/setRouterScreenErrorGet.test.js
+++ b/__tests__/medium/controller/router/screen/setRouterScreenErrorGet.test.js
@@ -1,0 +1,76 @@
+const express = require('express');
+const path = require('path');
+
+const setRouterScreenErrorGet = require('../../../../../src/controller/router/screen/setRouterScreenErrorGet');
+
+const requestApp = async ({ app, method, targetPath } = {}) => {
+  const server = app.listen(0);
+
+  try {
+    await new Promise((resolve, reject) => {
+      server.once('listening', resolve);
+      server.once('error', reject);
+    });
+
+    const address = server.address();
+    const response = await fetch(`http://127.0.0.1:${address.port}${targetPath}`, {
+      method,
+    });
+
+    return {
+      status: response.status,
+      headers: response.headers,
+      bodyText: await response.text(),
+    };
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close(error => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    });
+  }
+};
+
+describe('setRouterScreenErrorGet (middle)', () => {
+  const createApp = () => {
+    const app = express();
+    const router = express.Router();
+
+    app.set('views', path.join(process.cwd(), 'src', 'views'));
+    app.set('view engine', 'ejs');
+
+    setRouterScreenErrorGet({ router });
+
+    app.use(router);
+    return app;
+  };
+
+  test('GET /screen/error で error.ejs を描画した HTML を返す', async () => {
+    const app = createApp();
+
+    const response = await requestApp({
+      app,
+      method: 'GET',
+      targetPath: '/screen/error',
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toContain('text/html');
+    expect(response.bodyText).toContain('<!DOCTYPE html>');
+    expect(response.bodyText).toContain('<title>エラーが発生しました</title>');
+    expect(response.bodyText).toContain('ページを表示できませんでした');
+    expect(response.bodyText).toContain('認証情報の確認が必要な場合や、対象のデータが見つからない場合、あるいは一時的な問題が発生した場合にこの画面が表示されます。時間をおいて再度お試しいただくか、別の画面へお戻りください。');
+    expect(response.bodyText).toContain('href="/screen/login"');
+    expect(response.bodyText).toContain('href="/screen/summary"');
+    expect(response.bodyText).toContain('href="/screen/entry"');
+    expect(response.bodyText).toContain('ログイン画面へ戻る');
+    expect(response.bodyText).toContain('一覧・サマリー画面へ戻る');
+    expect(response.bodyText).toContain('登録画面へ戻る');
+    expect(response.bodyText).toContain('認証失敗、対象データ未存在、予期しないエラーのいずれでも利用できる共通の案内ページです。');
+    expect(response.bodyText).not.toContain(path.join('src', 'views', 'screen', 'error.ejs'));
+  });
+});

--- a/doc/5_api/controller/router/screen/setRouterScreenErrorGet/testcase.md
+++ b/doc/5_api/controller/router/screen/setRouterScreenErrorGet/testcase.md
@@ -1,12 +1,21 @@
 # router (GET /screen/error) テストケース
 
 ## テストケース一覧
-- [GET /screen/error に描画ハンドラーを登録する](#get-screenerror-に描画ハンドラーを登録する)
-- [登録済みハンドラーを実行するとエラー画面を描画する](#登録済みハンドラーを実行するとエラー画面を描画する)
+- [small: GET /screen/error に描画ハンドラーを登録する](#small-get-screenerror-に描画ハンドラーを登録する)
+- [small: 登録済みハンドラーを実行すると描画データを組み立てる](#small-登録済みハンドラーを実行すると描画データを組み立てる)
+- [medium: Express アプリで GET /screen/error を実行すると error.ejs を描画した HTML を返す](#medium-express-アプリで-get-screenerror-を実行すると-errorejs-を描画した-html-を返す)
+
+## 責務分担
+- **small**
+  - `router.get` へ `/screen/error` とハンドラーが登録されることを確認する。
+  - ハンドラーが `screen/error` に対してページタイトル・案内文言・主要導線を描画データとして渡すことを確認する。
+- **medium**
+  - Express アプリへ実際にルーターを組み込み、`GET /screen/error` で HTTP 200 / `text/html` を返すことを確認する。
+  - `src/views/screen/error.ejs` が実際に描画され、案内文言と主要導線 (`/screen/login`、`/screen/summary`、`/screen/entry`) が HTML 応答本文へ出力されることを確認する。
 
 ---
 
-### GET /screen/error に描画ハンドラーを登録する
+### small: GET /screen/error に描画ハンドラーを登録する
 - **前提**
   - `router.get` をモック化する。
 - **操作**
@@ -18,10 +27,23 @@
 
 ---
 
-### 登録済みハンドラーを実行するとエラー画面を描画する
+### small: 登録済みハンドラーを実行すると描画データを組み立てる
 - **前提**
   - レスポンスオブジェクトで `status` / `render` をモック化する。
 - **操作**
   - 登録済みハンドラーを実行する。
 - **結果**
   - `screen/error` が案内メッセージと遷移リンクを含む表示データで描画される。
+
+---
+
+### medium: Express アプリで GET /screen/error を実行すると error.ejs を描画した HTML を返す
+- **前提**
+  - Express アプリに `setRouterScreenErrorGet` を登録する。
+  - ビュー設定を `src/views` / `ejs` に向け、実際の `src/views/screen/error.ejs` を利用できるようにする。
+- **操作**
+  - `GET /screen/error` を実行する。
+- **結果**
+  - HTTP ステータスが `200` である。
+  - `text/html` のレスポンスとして `src/views/screen/error.ejs` を描画した HTML が返る。
+  - 応答本文に案内文言と主要導線 (`/screen/login`、`/screen/summary`、`/screen/entry`) が含まれる。


### PR DESCRIPTION
### Motivation
- `GET /screen/error` の実際のテンプレート描画と HTML 応答を中間層（medium テスト）で検証し、テンプレート描画周りの回帰を検出可能にするため。 
- small と medium のテスト責務を明確化して、small が描画データの組み立てを担い、medium が実ビュー描画と HTTP 応答を担保することを文書化するため。

### Description
- `__tests__/medium/controller/router/screen/setRouterScreenErrorGet.test.js` を追加し、`setRouterScreenErrorGet` を Express アプリへ登録した状態で `GET /screen/error` が HTTP 200 と `text/html` を返し、タイトル・案内文言・主要導線（`/screen/login`、`/screen/summary`、`/screen/entry`）が HTML 応答に含まれることを検証するようにした。 
- `doc/5_api/controller/router/screen/setRouterScreenErrorGet/testcase.md` を更新して `medium` テストケースを追記し、`small` と `medium` の責務分担を明記した。

### Testing
- `node --check __tests__/medium/controller/router/screen/setRouterScreenErrorGet.test.js` を実行して構文チェックは成功した。 
- `npx jest __tests__/small/controller/router/screen/setRouterScreenErrorGet.test.js __tests__/medium/controller/router/screen/setRouterScreenErrorGet.test.js` を試行したが、環境の npm レジストリアクセス制限により `jest` の取得が `403 Forbidden` となり実行できなかった。 
- Express を直接立ち上げて `GET /screen/error` を手動で検証しようとしたが、当環境で `ejs` が見つからず `Cannot find module 'ejs'` となり実際のテンプレート描画までの確認は完了しなかった。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1750ef178832ba8c1f6d5c3a40bed)