### PR TITLE
docs: アプリ起動・ミドルウェア・ルーティング周辺の設計書を新規追加

### DIFF
--- a/doc/4_application/app/createApp/readme.md
+++ b/doc/4_application/app/createApp/readme.md
@@ -1,0 +1,65 @@
+# createApp 設計書
+
+## 概要
+- `src/app.js` の `createApp(env)` は、Express アプリケーションの生成とアプリ全体の初期配線を担当する。
+- アプリケーション起動時に `createDependencies`・`setupMiddleware`・`setupRoutes` を順に呼び出し、HTTP 受け付け前に必要な依存関係とルーティングをまとめて束ねる。
+- `DevelopmentSession` を含む起動時設定は `env` 経由で下位モジュールへ引き渡し、`createApp` 自身は判定ロジックを持たない。
+
+## 対象実装
+- 実装: `src/app.js`
+- 関連: `src/app/createDependencies.js`
+- 関連: `src/app/setupMiddleware.js`
+- 関連: `src/app/setupRoutes.js`
+
+## 入力
+
+### `env`
+`createApp(env)` は、少なくとも以下の起動設定をそのまま下位モジュールへ中継する。
+
+| 項目 | 用途 | 主な利用先 |
+| --- | --- | --- |
+| `databaseStoragePath` | SQLite ファイル格納先 | `createDependencies` |
+| `contentRootDirectory` | コンテンツ保存先ディレクトリ | `createDependencies` |
+| `loginUsername` | 固定ログイン認証のユーザー名 | `createDependencies` |
+| `loginPassword` | 固定ログイン認証のパスワード | `createDependencies` |
+| `loginUserId` | ログイン成功時に採用するユーザーID | `createDependencies` |
+| `loginSessionTtlMs` | 通常ログインセッションの TTL | `createDependencies` |
+| `devSessionToken` | 開発用固定セッションのトークン | `createDependencies` / `setupMiddleware` |
+| `devSessionUserId` | 開発用固定セッションのユーザーID | `createDependencies` |
+| `devSessionTtlMs` | 開発用固定セッションの TTL | `createDependencies` |
+| `devSessionPaths` | 開発用固定セッションを自動適用するパス一覧 | `setupMiddleware` |
+
+- `port` は `server.js` が `listen` にだけ利用するため、`createApp` 自体では参照しない。
+- `env` は `app.locals.env` に保存し、起動後の参照元として残す。
+
+## 依存オブジェクト生成責務との関係
+- 依存オブジェクトの実生成責務は `createDependencies(env)` に委譲する。
+- `createApp` 自身は各依存を個別生成せず、生成済みオブジェクトを `app.locals.dependencies` として公開する。
+- これにより、依存構築・ミドルウェア設定・ルート設定の責務を分離し、設計書もモジュール単位で保守できる。
+
+## 処理フロー
+1. `express()` で `app` を生成する。
+2. `createDependencies(env)` を呼び、永続化・アプリケーションサービス・ルートセッター群を束ねた `dependencies` を生成する。
+3. `app.locals.env` に起動設定を保存する。
+4. `app.locals.dependencies` に依存オブジェクト群を保存する。
+5. `app.locals.ready` / `app.locals.close` を `dependencies` から転写する。
+6. `setupMiddleware(app, { env, dependencies })` を実行する。
+7. `setupRoutes(app, { env, dependencies })` を実行する。
+8. 初期化済み `app` を返す。
+
+## `app.locals.ready` / `app.locals.close` の扱い
+- `app.locals.ready` は、依存生成側で用意した初期化完了 Promise をそのまま保持する。
+- `server.js` は `listen` 前に `await app.locals.ready` を実行し、DB スキーマ同期失敗時に起動を中断する。
+- `app.locals.close` は、`ready` 完了後に接続クローズを実行する非同期関数として保持する。
+- `createApp` は `ready` / `close` を再定義せず、アプリ利用者が `app.locals` 経由で一貫したライフサイクル API を扱えるようにする。
+
+## `DevelopmentSession` との関連
+- 開発用固定セッションの事前登録責務は `createDependencies`、リクエスト単位の適用判定は `setupMiddleware` が担う。
+- `createApp` は `env` と `dependencies` を両モジュールへ渡す接続点として機能する。
+- 詳細は [DevelopmentSession 設計書](/doc/5_api/controller/middleware/DevelopmentSession/readme.md) を参照する。
+
+## 関連ドキュメント
+- [createDependencies 設計書](/doc/4_application/app/createDependencies/readme.md)
+- [setupMiddleware 設計書](/doc/5_api/controller/middleware/setupMiddleware/readme.md)
+- [setupRoutes 設計書](/doc/5_api/controller/router/setupRoutes/readme.md)
+- [server 設計書](/doc/4_application/app/server/readme.md)

--- a/doc/4_application/app/createDependencies/readme.md
+++ b/doc/4_application/app/createDependencies/readme.md
@@ -1,0 +1,89 @@
+# createDependencies 設計書
+
+## 概要
+- `src/app/createDependencies.js` は、アプリケーション起動時に必要な永続化アダプター・アプリケーションサービス・ルートセッター群をまとめて生成する。
+- SQLite / Sequelize 初期化、コンテンツ保存先ディレクトリ準備、ログイン認証、セッションストア、各種サービス組み立てを 1 箇所へ集約する。
+- 開発用固定セッションが有効な場合は、`DevelopmentSession` 用のセッションレコードを起動時に事前登録する。
+
+## 対象実装
+- 実装: `src/app/createDependencies.js`
+
+## 入力
+
+### `env`
+| 項目 | 必須性 | 用途 |
+| --- | --- | --- |
+| `databaseStoragePath` | 必須 | SQLite ファイルの保存先。親ディレクトリを自動生成する。 |
+| `contentRootDirectory` | 必須 | メディアコンテンツ保存先。ディレクトリを自動生成する。 |
+| `loginUsername` | 任意 | `StaticLoginAuthenticator` のユーザー名。未指定時は `admin`。 |
+| `loginPassword` | 任意 | `StaticLoginAuthenticator` のパスワード。未指定時は `admin`。 |
+| `loginUserId` | 任意 | ログイン成功時の利用者 ID。未指定時は `admin`。 |
+| `loginSessionTtlMs` | 任意 | 通常ログインセッションの TTL。未指定時は `86400000`。 |
+| `devSessionToken` | 条件付き | 開発用固定セッションのトークン。 |
+| `devSessionUserId` | 条件付き | 開発用固定セッションの利用者 ID。 |
+| `devSessionTtlMs` | 条件付き | 開発用固定セッションの TTL。正の整数時のみ有効。 |
+| `devSessionPaths` | 任意 | 開発用固定セッションの適用対象パス一覧。生成処理では判定に使わず、他モジュールが参照する。 |
+
+## 依存オブジェクトの生成責務
+
+### 基盤層の生成
+- `Sequelize` を SQLite 設定で生成する。
+- `SequelizeUnitOfWork` を生成する。
+- `SequelizeMediaRepository` / `SequelizeMediaQueryRepository` / `SequelizeUserRepository` を生成する。
+- `InMemorySessionStateStore` を生成する。
+- `MulterDiskStorageContentUploadAdapter` と `UUIDMediaIdValueGenerator` を生成する。
+- `StaticLoginAuthenticator` を `env.loginUsername` / `env.loginPassword` / `env.loginUserId` から生成する。
+- `SessionStateRegistrar` / `SessionTerminator` / `SessionStateAuthAdapter` を生成する。
+
+### アプリケーションサービスの生成
+- メディア系
+  - `SearchMediaService`
+  - `GetMediaDetailService`
+  - `GetMediaContentWithNavigationService`
+  - `UpdateMediaService`
+  - `DeleteMediaService`
+- ユーザー系
+  - `GetFavoriteSummariesService`
+  - `GetQueueService`
+  - `AddFavoriteService`
+  - `RemoveFavoriteService`
+  - `AddQueueService`
+  - `RemoveQueueService`
+  - `LoginService`
+  - `LogoutService`
+
+### ルートセッターの集約
+- 画面系・API 系のルート定義関数を `dependencies.routeSetters` に束ねる。
+- `setupRoutes` はここで集約されたルートセッターのみを参照し、各モジュールの import を重複しない。
+
+## 起動時ディレクトリ準備
+- `databaseStoragePath` の親ディレクトリは `ensureParentDirectory` で再帰的に生成する。
+- `contentRootDirectory` は `ensureDirectory` で再帰的に生成する。
+- これにより、初回起動時でも保存先未作成を理由に初期化失敗しにくくする。
+
+## `DevelopmentSession` の事前登録
+- `hasDevelopmentSession(env)` が `true` の場合のみ、起動直後に `sessionStateStore.save(...)` を 1 回実行する。
+- 登録内容は以下の通り。
+  - `sessionToken: env.devSessionToken`
+  - `userId: env.devSessionUserId`
+  - `ttlMs: env.devSessionTtlMs`
+- この事前登録により、`setupMiddleware` が注入した固定トークンを `SessionStateAuthAdapter` が通常セッションと同様に解決できる。
+- 開発用固定セッションの有効条件そのものは [DevelopmentSession 設計書](/doc/5_api/controller/middleware/DevelopmentSession/readme.md) を参照する。
+
+## `app.locals.ready` / `app.locals.close` の供給責務
+- `dependencies.ready` は `mediaRepository.sync()` の Promise を保持する。
+- `createApp` はこの Promise を `app.locals.ready` として公開する。
+- `dependencies.close` は以下の順序で終了処理を行う。
+  1. `await dependencies.ready`
+  2. `await sequelize.close()`
+- これにより、初期化未完了状態で DB 接続だけを閉じる不整合を避ける。
+
+## 返却オブジェクト
+- 返却値は、基盤アダプター・アプリケーションサービス・`routeSetters`・`ready`・`close` をまとめた `dependencies` オブジェクトである。
+- `setupMiddleware` は主に `env` を使うが、`setupRoutes` は `dependencies` を使って各ルートへ必要サービスを注入する。
+
+## 関連ドキュメント
+- [createApp 設計書](/doc/4_application/app/createApp/readme.md)
+- [setupMiddleware 設計書](/doc/5_api/controller/middleware/setupMiddleware/readme.md)
+- [setupRoutes 設計書](/doc/5_api/controller/router/setupRoutes/readme.md)
+- [DevelopmentSession 設計書](/doc/5_api/controller/middleware/DevelopmentSession/readme.md)

--- a/doc/4_application/app/server/readme.md
+++ b/doc/4_application/app/server/readme.md
@@ -1,0 +1,61 @@
+# server.js 起動設計書
+
+## 概要
+- `src/server.js` は、プロセス環境変数から起動設定 `env` を生成し、`createApp(env)` を経由して HTTP サーバーを起動するエントリーポイントである。
+- 起動前に `app.locals.ready` を待機し、初期化失敗時は `listen` せずに終了する。
+- 開発用固定セッションが有効な場合は、起動ログへ有効化情報を出力する。
+
+## 対象実装
+- 実装: `src/server.js`
+
+## 入力となる環境変数
+
+| 環境変数 | `env` 項目 | 既定値 / 変換 | 用途 |
+| --- | --- | --- | --- |
+| `PORT` | `port` | `parseInt(..., 10) || 3000` | HTTP listen ポート |
+| `DATABASE_STORAGE_PATH` | `databaseStoragePath` | `var/data/mangaviewer.sqlite` | SQLite 保存先 |
+| `CONTENT_ROOT_DIRECTORY` | `contentRootDirectory` | `var/contents` | コンテンツ保存先 |
+| `DEV_SESSION_TOKEN` | `devSessionToken` | 空文字 | 開発用固定セッショントークン |
+| `DEV_SESSION_USER_ID` | `devSessionUserId` | 空文字 | 開発用固定セッションの利用者ID |
+| `DEV_SESSION_TTL_MS` | `devSessionTtlMs` | `parseInt(..., 10) || 0` | 開発用固定セッションの TTL |
+| `DEV_SESSION_PATHS` | `devSessionPaths` | カンマ区切り分解後の配列 | 固定セッションを適用するパス一覧 |
+| `LOGIN_USERNAME` | `loginUsername` | `admin` | 固定ログイン認証のユーザー名 |
+| `LOGIN_PASSWORD` | `loginPassword` | `admin` | 固定ログイン認証のパスワード |
+| `LOGIN_USER_ID` | `loginUserId` | `admin` | ログイン成功時の利用者ID |
+| `LOGIN_SESSION_TTL_MS` | `loginSessionTtlMs` | `parseInt(..., 10) || 86400000` | 通常ログインセッション TTL |
+
+## `createEnv` の仕様
+- `process.env` から文字列値を読み取り、アプリ内部で扱いやすい `env` オブジェクトへ変換する。
+- `DEV_SESSION_PATHS` は `parseSessionPaths` により、以下の規則で `string[]` へ変換する。
+  - カンマ区切りで分割する。
+  - 各要素の前後空白を除去する。
+  - 空文字要素は除外する。
+- `PORT` / `DEV_SESSION_TTL_MS` / `LOGIN_SESSION_TTL_MS` は 10 進整数へ変換し、不正値・未設定時は既定値へフォールバックする。
+
+## 起動シーケンス
+1. `createEnv(process.env)` で `env` を構築する。
+2. `createApp(env)` で Express アプリを生成する。
+3. `await app.locals.ready` で初期化完了を待機する。
+4. 初期化失敗時は `console.error('アプリケーションの初期化に失敗しました', error)` を出力し、`process.exit(1)` で終了する。
+5. 初期化成功時のみ `app.listen(env.port, ...)` を実行する。
+6. listen 成功コールバックで `サーバーを起動しました: port=...` を出力する。
+7. `hasDevelopmentSession(env)` が `true` の場合は、固定セッション有効化ログも追加出力する。
+8. `server.on('error', ...)` で起動失敗を監視し、失敗時は `process.exit(1)` で終了する。
+
+## `app.locals.ready` / `app.locals.close` の扱い
+- `server.js` が直接利用するのは `app.locals.ready` のみである。
+- `app.locals.ready` は、DB 同期など初期化処理が完了したことを示す Promise として扱う。
+- `app.locals.close` はこのファイルでは未使用だが、`createApp` が公開するアプリケーション終了 API として保持される。
+- したがって、起動責務は `ready` の待機まで、終了責務は上位の運用コードやテストから `close` を呼ぶ設計とする。
+
+## `DevelopmentSession` に関する起動責務
+- `hasDevelopmentSession(env)` を用いて、開発用固定セッション設定が有効かを起動時ログ判定に利用する。
+- セッションストアへの事前登録は `createDependencies`、リクエスト適用は `setupMiddleware` が担うため、`server.js` は環境変数解釈と起動ログ出力に責務を限定する。
+- 固定セッションの優先順位は `x-session-token` → `session_token` Cookie → 開発用固定セッションであり、その実行仕様自体は [setupMiddleware 設計書](/doc/5_api/controller/middleware/setupMiddleware/readme.md) を参照する。
+- 詳細は [DevelopmentSession 設計書](/doc/5_api/controller/middleware/DevelopmentSession/readme.md) を参照する。
+
+## 関連ドキュメント
+- [createApp 設計書](/doc/4_application/app/createApp/readme.md)
+- [createDependencies 設計書](/doc/4_application/app/createDependencies/readme.md)
+- [setupMiddleware 設計書](/doc/5_api/controller/middleware/setupMiddleware/readme.md)
+- [DevelopmentSession 設計書](/doc/5_api/controller/middleware/DevelopmentSession/readme.md)

--- a/doc/5_api/controller/middleware/DevelopmentSession/readme.md
+++ b/doc/5_api/controller/middleware/DevelopmentSession/readme.md
@@ -2,86 +2,46 @@
 
 ## 概要
 - 開発環境でのみ利用する、固定セッショントークン注入機能。
-- `src/app/developmentSession.js` が有効条件判定（`hasDevelopmentSession` / `shouldApplyDevelopmentSession`）を担い、`src/app/setupMiddleware.js` が対象リクエストへ `req.session.session_token` を補完する。
-- `src/app/createDependencies.js` は有効化時に固定セッションを `sessionStateStore` へ事前登録し、`src/server.js` は環境変数の解釈と起動ログ出力を担当する。
-- 通常ログインを置き換える本番機能ではなく、画面確認・手動疎通・ローカル開発を支援する補助手段として位置づける。
+- `src/app/developmentSession.js` は有効条件判定（`hasDevelopmentSession` / `shouldApplyDevelopmentSession`）だけを担う。
+- 固定セッションの起動配線・環境変数解釈・優先順位・ルート適用は、アプリ全体設計として別文書へ分離して管理する。
 
 ## 開発支援機能としての位置づけ
-- 認証付き画面やAPIの開発・動作確認時に、毎回ログイン操作を行わずに既知のユーザーとしてアクセスできるようにする。
-- `x-session-token` ヘッダや `session_token` Cookie が未設定のときだけ固定セッションを補完し、通常の認証導線を優先する。
+- 認証付き画面や API の開発・動作確認時に、毎回ログイン操作を行わずに既知のユーザーとしてアクセスできるようにする。
+- 通常ログインを置き換える本番機能ではなく、画面確認・手動疎通・ローカル開発を支援する補助手段として位置づける。
 - 想定利用者は開発者・ローカル検証者に限定し、公開環境・本番環境・不特定多数が接続する環境では利用しない。
 
-## 環境変数
+## 対象実装
+- 実装: `src/app/developmentSession.js`
 
-| 名前 | 必須条件 | 役割 |
-| --- | --- | --- |
-| `DEV_SESSION_TOKEN` | `string` かつ空文字不可 | 開発用に固定注入する `session_token` 値 |
-| `DEV_SESSION_USER_ID` | `string` かつ空文字不可 | 固定セッションに紐づく利用者ID |
-| `DEV_SESSION_TTL_MS` | 正の整数 | 固定セッションをストアへ保持する有効期限（ミリ秒） |
-| `DEV_SESSION_PATHS` | カンマ区切り文字列 | 固定セッションを自動補完する対象パス一覧 |
+## 判定責務
 
-- `server.js` の `createEnv` では `DEV_SESSION_PATHS` をカンマ区切りで分割し、前後空白を除去した `devSessionPaths: string[]` に変換する。
-- `DEV_SESSION_TTL_MS` は `Number.parseInt(..., 10)` で整数化し、未設定や不正値は `0` 扱いとなる。
-
-## 有効条件
-
-### `hasDevelopmentSession`
+### `hasDevelopmentSession(env)`
 以下をすべて満たす場合のみ `true` と判定する。
 - `devSessionToken` が空文字ではない `string`
 - `devSessionUserId` が空文字ではない `string`
 - `devSessionTtlMs` が正の整数
 
-### `shouldApplyDevelopmentSession`
+### `shouldApplyDevelopmentSession({ env, requestPath })`
 以下をすべて満たす場合のみ `true` と判定する。
 - `hasDevelopmentSession(env)` が `true`
 - `env.devSessionPaths` が配列である
 - `requestPath` が `env.devSessionPaths` に完全一致で含まれる
 
-## 対象パス
-- `DEV_SESSION_PATHS` に列挙したパスに対してのみ固定セッションを補完する。
-- 判定は `req.path` の完全一致で行うため、前方一致・ワイルドカード・正規表現は扱わない。
-- 対象例
-  - `/screen/entry`
-  - `/api/media`
-- 非対象例
-  - `DEV_SESSION_PATHS` に未登録の `/unknown`
-  - `/screen/entry/subpath` のような部分一致のみのパス
+## 対象パス仕様
+- `DEV_SESSION_PATHS` に列挙したパスに対してのみ固定セッションを補完する前提で判定する。
+- 判定は `requestPath` の完全一致で行い、前方一致・ワイルドカード・正規表現は扱わない。
+- 例
+  - 対象: `/screen/entry`, `/api/media`
+  - 非対象: `/unknown`, `/screen/entry/subpath`
 
 ## セキュリティ上の前提
 - 固定トークンは認証回避のための開発補助機能であるため、秘密情報として扱い、リポジトリへハードコードしない。
 - 本機能は本番利用を想定しない。公開環境で有効化すると、対象パスに対して固定ユーザーへ成り代わり可能になるため禁止する。
 - 対象パスは最小限に限定し、開発に不要な管理系・更新系エンドポイントへ無制限に適用しない。
-- `x-session-token` ヘッダおよび `session_token` Cookie が優先されるため、明示的なログイン結果や検証用トークンを上書きしない。
-- `DEV_SESSION_TTL_MS` を有限値にすることで、開発用セッションも無期限に残置しない。
 
-## 配線
-
-### `server.js`
-- `process.env` から `DEV_SESSION_TOKEN` / `DEV_SESSION_USER_ID` / `DEV_SESSION_TTL_MS` / `DEV_SESSION_PATHS` を読み取り、`createEnv` でアプリケーション向けの `env` へ変換する。
-- `startServer` では `hasDevelopmentSession(env)` が `true` の場合に、起動ログへ固定セッション有効化状態（`userId` と `paths`）を出力する。
-
-### `createDependencies`
-- `InMemorySessionStateStore` 初期化後、`hasDevelopmentSession(env)` が `true` の場合は `sessionStateStore.save(...)` を実行する。
-- 登録内容は以下の3項目。
-  - `sessionToken: env.devSessionToken`
-  - `userId: env.devSessionUserId`
-  - `ttlMs: env.devSessionTtlMs`
-- これにより、後続の `SessionAuthMiddleware` が固定トークンから `userId` を解決できるようにする。
-
-### `setupMiddleware`
-- リクエストごとに `req.session` ヘルパーを初期化する。
-- `x-session-token` ヘッダが存在する場合は、その値を `req.session.session_token` へ設定する。
-- ヘッダがなく `session_token` Cookie が存在する場合は、その値を `req.session.session_token` へ設定する。
-- ヘッダ・Cookie のどちらも無い場合のみ、`shouldApplyDevelopmentSession({ env, requestPath: req.path })` を評価する。
-- `true` のとき `req.session.session_token = env.devSessionToken` を設定し、以降の認証ミドルウェアで通常セッションと同様に扱う。
-
-## 認証フロー上の扱い
-1. `server.js` が環境変数から開発用固定セッション設定を組み立てる。
-2. `createDependencies` が固定セッションをセッションストアへ保存する。
-3. `setupMiddleware` が対象パスへのリクエストに限り固定トークンを `req.session.session_token` へ補完する。
-4. `SessionAuthMiddleware` が通常セッションと同じ経路で `session_token` を検証し、`userId` を解決する。
-
-## 運用上の注意
-- CI やステージングで利用する場合も「開発者のみが閉域で利用する」ことを明文化した上で限定運用する。
-- ログに `userId` と対象パスが出力されるため、共有ログ基盤へ送る場合は閲覧権限を制御する。
-- 対象パス追加時は、認証要否と副作用の有無を確認してから `DEV_SESSION_PATHS` に追記する。
+## アプリ全体設計への参照
+- 起動時の `env` 解釈: [server 設計書](/doc/4_application/app/server/readme.md)
+- 固定セッションの事前登録: [createDependencies 設計書](/doc/4_application/app/createDependencies/readme.md)
+- `x-session-token` / `session_token` Cookie / 開発用固定セッションの優先順位: [setupMiddleware 設計書](/doc/5_api/controller/middleware/setupMiddleware/readme.md)
+- 未定義ルート時の共通 404 JSON: [setupRoutes 設計書](/doc/5_api/controller/router/setupRoutes/readme.md)
+- アプリ全体の配線: [createApp 設計書](/doc/4_application/app/createApp/readme.md)

--- a/doc/5_api/controller/middleware/setupMiddleware/readme.md
+++ b/doc/5_api/controller/middleware/setupMiddleware/readme.md
@@ -1,0 +1,70 @@
+# setupMiddleware 設計書
+
+## 概要
+- `src/app/setupMiddleware.js` は、Express アプリケーション全体へ共通適用するミドルウェアを登録する。
+- ビュー設定、JSON / form-urlencoded パーサー、簡易 `req.session` ヘルパー生成、セッショントークンの入力正規化を担当する。
+- `SessionAuthMiddleware` が参照する `req.session.session_token` を、ヘッダ・Cookie・開発用固定セッションの優先順位に従って補完する。
+
+## 対象実装
+- 実装: `src/app/setupMiddleware.js`
+
+## 入力
+
+### `env`
+| 項目 | 用途 |
+| --- | --- |
+| `devSessionToken` | 開発用固定セッションとして `req.session.session_token` に補完する値 |
+| `devSessionPaths` | 固定セッション自動補完の対象パス一覧 |
+| `devSessionUserId` | `shouldApplyDevelopmentSession` の前提条件となる固定セッション設定の一部 |
+| `devSessionTtlMs` | `shouldApplyDevelopmentSession` の前提条件となる固定セッション設定の一部 |
+
+### `dependencies`
+- 現行実装では利用しないが、`createApp` からシグネチャを統一して受け取る。
+- 将来、共通ミドルウェアへ依存オブジェクトを注入する拡張余地として保持する。
+
+## ビュー・パーサー設定
+- `views` ディレクトリを `src/views` に設定する。
+- `view engine` を `ejs` に設定する。
+- `express.json()` を登録し、JSON リクエストボディを解釈可能にする。
+- `express.urlencoded({ extended: true })` を登録し、フォーム投稿を解釈可能にする。
+
+## `req.session` ヘルパーの扱い
+- 各リクエストで `req.context` を未設定なら空オブジェクトで初期化する。
+- `attachSessionHelpers(req)` により `req.session` を準備する。
+- `req.session.regenerate(callback)` は、`req.session` を空オブジェクトへ差し替えた後に再帰的にヘルパーを付与し、`callback(null)` を返す。
+- `req.session.destroy(callback)` も同様に、`req.session` を空オブジェクトへ差し替えてから `callback(null)` を返す。
+- この簡易実装により、`SessionStateRegistrar` / `SessionTerminator` が期待する `regenerate` / `destroy` API を最小限満たす。
+
+## セッショントークン解決優先順位
+`req.session.session_token` は次の優先順位で 1 つだけ採用する。
+
+1. `x-session-token` リクエストヘッダ
+2. `Cookie` ヘッダ内の `session_token` Cookie
+3. 開発用固定セッション (`DevelopmentSession`)
+
+### 優先順位詳細
+- `x-session-token` が非空文字列なら、その値を最優先で採用する。
+- ヘッダが無く、`session_token` Cookie が非空文字列なら、その値を採用する。
+- ヘッダ・Cookie のいずれも無い場合に限り、`shouldApplyDevelopmentSession({ env, requestPath: req.path })` を評価する。
+- `shouldApplyDevelopmentSession(...)` が `true` のときのみ `env.devSessionToken` を補完する。
+- したがって、開発用固定セッションは明示指定された通常セッションを上書きしない。
+
+## Cookie 解析
+- `parseCookieHeader(cookieHeader)` は `Cookie` ヘッダを `;` 区切りで分解し、`key=value` 形式だけを採用する。
+- `=` を含まない要素や空キーは無視する。
+- 複数 Cookie が存在する場合はオブジェクトへ格納し、`session_token` のみを参照する。
+
+## `DevelopmentSession` との関係
+- 開発用固定セッションの有効条件判定は `src/app/developmentSession.js` の `shouldApplyDevelopmentSession` に委譲する。
+- `setupMiddleware` は「どのリクエストに固定トークンを補完するか」の実行責務のみを担う。
+- 起動時のセッションストア事前登録は `createDependencies` の責務であり、本モジュールでは行わない。
+- 詳細は [DevelopmentSession 設計書](/doc/5_api/controller/middleware/DevelopmentSession/readme.md) を参照する。
+
+## 後続ミドルウェアへの契約
+- 認証が必要なルートでは、後続の `SessionAuthMiddleware` が `req.session.session_token` を検証する。
+- そのため、本モジュールは認証判定そのものを行わず、入力経路の統一だけを担う。
+
+## 関連ドキュメント
+- [SessionAuthMiddleware 設計書](/doc/5_api/controller/middleware/SessionAuthMiddleware/readme.md)
+- [createDependencies 設計書](/doc/4_application/app/createDependencies/readme.md)
+- [DevelopmentSession 設計書](/doc/5_api/controller/middleware/DevelopmentSession/readme.md)

--- a/doc/5_api/controller/router/setupRoutes/readme.md
+++ b/doc/5_api/controller/router/setupRoutes/readme.md
@@ -1,0 +1,71 @@
+# setupRoutes 設計書
+
+## 概要
+- `src/app/setupRoutes.js` は、画面系・API 系の既存ルートを 1 つの Express Router へ登録し、最後に共通 404 JSON フォールバックを設定する。
+- 個々の URL 仕様は各 `setRouter...` モジュールへ委譲し、本モジュールは登録順序と依存注入の統括を担う。
+- ルート未一致時は画面ルート・API ルートを問わず同一の JSON 404 応答を返す。
+
+## 対象実装
+- 実装: `src/app/setupRoutes.js`
+
+## 入力
+
+### `env`
+- 現行実装では参照しない。
+- `createApp` からシグネチャ統一のため受け取り、将来的に環境別ルーティング分岐が必要になった場合の拡張余地とする。
+
+### `dependencies`
+`createDependencies` が構築したオブジェクト群を受け取り、各ルートへ必要な依存を注入する。
+
+主な利用項目:
+- `authResolver`
+- `getMediaDetailService`
+- `getMediaContentWithNavigationService`
+- `getFavoriteSummariesService`
+- `getQueueService`
+- `searchMediaService`
+- `loginService`
+- `logoutService`
+- `saveAdapter`
+- `mediaIdValueGenerator`
+- `mediaRepository`
+- `unitOfWork`
+- `updateMediaService`
+- `deleteMediaService`
+- `addFavoriteService`
+- `removeFavoriteService`
+- `addQueueService`
+- `removeQueueService`
+- `routeSetters`
+
+## ルート登録責務
+- `express.Router()` を生成する。
+- 画面ルートを登録する。
+  - entry / detail / edit / error / favorite / login / queue / search / summary / viewer
+- API ルートを登録する。
+  - login / logout / media post / media patch / media delete / favorite and queue
+- 各登録時に必要な依存だけを明示的に渡すことで、各 `setRouter...` の入力契約を固定する。
+
+## 登録順序
+1. 画面ルート群を登録する。
+2. 認証・更新を含む API ルート群を登録する。
+3. `app.use(router)` でまとめた Router をアプリへマウントする。
+4. 既存ルート登録後に、最後段の共通 404 ハンドラーを `app.use((_req, res) => { ... })` で追加する。
+
+## 共通 404 JSON フォールバック仕様
+- 既存の画面ルート・API ルートのいずれにも一致しなかった場合に発火する。
+- HTTP ステータスコードは `404` を返す。
+- レスポンスボディは JSON `{ "message": "Not Found" }` を返す。
+- 画面 URL でも HTML 画面を返さず、API と同一の JSON 応答へ統一する。
+- このフォールバックは `app.use(router)` の後に登録することで、正常ルートの応答を妨げない。
+
+## `DevelopmentSession` との関係
+- `setupRoutes` 自体は `DevelopmentSession` を直接判定しない。
+- ただし、認証必須ルートに注入される `authResolver` は、`setupMiddleware` が補完した `req.session.session_token` を前提に動作する。
+- そのため、開発用固定セッションが有効な場合でも、各ルートは通常の認証フローと同じ経路で利用される。
+- 詳細は [DevelopmentSession 設計書](/doc/5_api/controller/middleware/DevelopmentSession/readme.md) を参照する。
+
+## 関連ドキュメント
+- [未定義ルート共通 404 ハンドラー](/doc/5_api/controller/router/notFound/setupRoutesNotFoundHandler/readme.md)
+- [setupMiddleware 設計書](/doc/5_api/controller/middleware/setupMiddleware/readme.md)
+- [createDependencies 設計書](/doc/4_application/app/createDependencies/readme.md)


### PR DESCRIPTION
### Motivation
- `src/app.js` / `src/app/createDependencies.js` / `src/app/setupMiddleware.js` / `src/app/setupRoutes.js` / `src/server.js` に対応する起動・配線責務が既存ドキュメントに分散していたため、起動設定や依存生成の責務を整理するために設計書を追加しました。
- DevelopmentSession に関する説明が起動配線や優先順位まで含んでいたため、固定セッション固有の判定ロジックは `DevelopmentSession` 設計書に残し、起動配線や優先順位などは新設文書へ再編しました。

### Description
- 以下の設計書を新規追加しました: `doc/4_application/app/createApp/readme.md`, `doc/4_application/app/createDependencies/readme.md`, `doc/5_api/controller/middleware/setupMiddleware/readme.md`, `doc/5_api/controller/router/setupRoutes/readme.md`, `doc/4_application/app/server/readme.md`。
- 各設計書に共通して、環境変数（`DEV_*` / DB / コンテンツディレクトリ / LOGIN_* 等）の入力項目を明記しました。
- 依存オブジェクト生成責務、`app.locals.ready` / `app.locals.close` の扱い、`x-session-token` → `session_token` Cookie → 開発用固定セッションの優先順位、既存ルート登録後の共通 404 JSON フォールバック仕様を文書化しました。
- `doc/5_api/controller/middleware/DevelopmentSession/readme.md` を判定責務と参照リンク中心に縮約し、起動配線は新設文書へ参照するように整理しました。

### Testing
- 自動チェックとして `git diff --cached --check` を実行して差分の整合を確認し成功しました。 
- 変更ファイルを `git status --short` で確認し、期待通りのファイル追加を確認しました。 
- 追加ファイル群をコミットしコミット操作は成功しました（HEAD: `17945d4`）。
- 単体テストの変更は無く、既存の自動テストスイートは今回のドキュメント追加による実行は行っていません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c181117898832ba3030ce6eadac673)