### PR TITLE
docs: SearchCondition と SearchResult の port 設計書を追加する

### DIFF
--- a/doc/4_application/media/port/SearchCondition/readme.md
+++ b/doc/4_application/media/port/SearchCondition/readme.md
@@ -1,0 +1,67 @@
+# SearchCondition 設計書
+
+## 概要
+`SearchCondition` はメディア検索でアプリケーション層からリポジトリ層へ渡す検索条件のポートです。  
+`SearchMediaService` が入力を受けて生成し、`SequelizeMediaQueryRepository` がこの条件をもとに絞り込み・並び順・ページングを行います。
+
+## 配置
+- 実装: `src/application/media/port/SearchCondition.js`
+- 利用箇所
+  - `SearchMediaService`: 画面・API由来の検索入力を正規化して `SearchCondition` に変換する
+  - `SequelizeMediaQueryRepository`: `search(condition)` の受け口として利用する
+  - `/screen/summary`: クエリ文字列を正規化した後、`SearchMediaService.Input` 経由で間接的に利用する
+
+## 構造
+
+### SearchCondition
+| 項目 | 型 | 制約 | 備考 |
+| --- | --- | --- | --- |
+| `title` | `string` | 文字列のみを許可する | 空文字列は「タイトル条件なし」として扱う |
+| `tags` | `SearchConditionTag[]` | 配列であり、全要素が `SearchConditionTag` インスタンスであること | 複数指定時は全タグ一致で絞り込む |
+| `sortType` | `SortType` | `SortType` 列挙値のいずれかであること | 並び順の戦略を示す |
+| `start` | `number` | 1以上の整数であること | 1始まりの取得開始位置 |
+| `size` | `number` | 1以上の整数であること | 取得件数 |
+
+### SearchConditionTag
+| 項目 | 型 | 制約 | 備考 |
+| --- | --- | --- | --- |
+| `category` | `string` | コンストラクタで型検証はしない | `SearchMediaService` / `/screen/summary` 側で文字列に正規化される前提 |
+| `label` | `string` | コンストラクタで型検証はしない | `category` と同様 |
+
+## sortType の列挙値
+| 列挙値 | 意味 | `SequelizeMediaQueryRepository` での並び |
+| --- | --- | --- |
+| `SortType.DATE_ASC` | 登録の新しい順 | `createdAtProxy DESC`, `media_id ASC` |
+| `SortType.DATE_DESC` | 登録の古い順 | `createdAtProxy ASC`, `media_id ASC` |
+| `SortType.TITLE_ASC` | タイトル名の昇順 | `title ASC`, `media_id ASC` |
+| `SortType.TITLE_DESC` | タイトル名の降順 | `title DESC`, `media_id ASC` |
+| `SortType.RANDOM` | ランダム順 | DB の random 関数を利用する |
+
+## 関連
+
+### SearchMediaService との関係
+- `SearchMediaService.Input` は `SearchCondition` と同じ形を持つ入力 DTO である。
+- `execute` は `Input.tags` を `SearchConditionTag` に詰め替え、`SearchCondition` を生成してリポジトリへ渡す。
+- そのため `SearchCondition` は「アプリケーション層内の入力」ではなく、「検索リポジトリに渡す契約」として扱う。
+
+### SequelizeMediaQueryRepository との関係
+- `search(condition)` は `SearchCondition` インスタンス以外を受け付けない。
+- `title`、`tags`、`sortType`、`start`、`size` を解釈して、条件一致件数とページング結果を計算する。
+- `tags` はカテゴリー・ラベルを順に解決し、各タグ条件を満たすメディア ID の積集合へ絞り込む。
+
+### `/screen/summary` との関係
+- `/screen/summary` は `summaryPage` / `start` / `size` / `title` / `tags` / `sort` を正規化する。
+- 正規化後に `SearchMediaService.Input` を生成し、その内部で `SearchCondition` に変換される。
+- したがって画面のクエリ仕様変更は、最終的にこのポートへ流れ込む値の制約と整合している必要がある。
+
+## テスト観点
+
+### small で保証すること
+- `title` が文字列、`tags` が `SearchConditionTag[]`、`sortType` が列挙値、`start` / `size` が 1 以上の整数である時に生成できる。
+- `title` の非文字列、`tags` の非配列または異種要素、`sortType` の未知値、`start` / `size` の 0 以下・小数・非数で `Error` になる。
+- `SearchCondition` がリポジトリ契約として最低限の型制約を守ることを確認する。
+
+### medium で保証すること
+- `SearchMediaService` と `SequelizeMediaQueryRepository` を接続したとき、`SearchCondition` の各項目が検索結果へ反映される。
+- `/screen/summary` のクエリ正規化結果が `SearchCondition` 制約に合う値へ落ちる。
+- 具体的にはタイトル部分一致、タグ全件一致、並び順、`start` / `size` によるページングが期待通り動くことを確認する。

--- a/doc/4_application/media/port/SearchCondition/testcase.md
+++ b/doc/4_application/media/port/SearchCondition/testcase.md
@@ -1,0 +1,47 @@
+# SearchCondition テストケース
+
+## テストケース一覧
+- [small: 妥当な検索条件を生成できる](#small-妥当な検索条件を生成できる)
+- [small: 不正な型や範囲の検索条件は例外を送出する](#small-不正な型や範囲の検索条件は例外を送出する)
+- [medium: SearchMediaService から渡した検索条件が SequelizeMediaQueryRepository の検索結果へ反映される](#medium-searchmediaservice-から渡した検索条件が-sequelizemediaqueryrepository-の検索結果へ反映される)
+- [medium: /screen/summary の正規化結果が SearchCondition の制約を満たす](#medium-screensummary-の正規化結果が-searchcondition-の制約を満たす)
+
+---
+
+### small: 妥当な検索条件を生成できる
+- 前提
+  - `SearchConditionTag` を使ってカテゴリー・ラベルを持つタグを用意する。
+- 操作
+  - `title`、`tags`、`sortType`、`start`、`size` に妥当な値を渡して `SearchCondition` を生成する。
+- 期待結果
+  - 例外を送出せずインスタンス生成できる。
+  - 各プロパティに指定した値が保持される。
+
+### small: 不正な型や範囲の検索条件は例外を送出する
+- 前提
+  - 生成対象クラスが読み込まれている。
+- 操作
+  - `title` に非文字列、`tags` に非配列や `SearchConditionTag` 以外、`sortType` に未知値、`start` / `size` に 0・負数・小数を渡して生成する。
+- 期待結果
+  - いずれも `Error` を送出する。
+
+### medium: SearchMediaService から渡した検索条件が SequelizeMediaQueryRepository の検索結果へ反映される
+- 前提
+  - `SearchMediaService` と `SequelizeMediaQueryRepository` を接続したテスト環境がある。
+  - タイトル・タグ・登録順が異なるメディアが複数登録済みである。
+- 操作
+  - タイトル、タグ、`sortType`、`start`、`size` を変えながら検索を実行する。
+- 期待結果
+  - タイトル部分一致が反映される。
+  - タグは全件一致で絞り込まれる。
+  - `sortType` ごとの並び順と `start` / `size` によるページングが反映される。
+
+### medium: /screen/summary の正規化結果が SearchCondition の制約を満たす
+- 前提
+  - `/screen/summary` ルーターを呼び出せる。
+- 操作
+  - `summaryPage`、`start`、`size`、`tags`、`sort` に境界値や不正値を含むクエリを渡す。
+- 期待結果
+  - `start` と `size` は 1 以上の整数へ正規化される。
+  - `tags` は `{ category, label }` の配列へ整形され、不正フォーマットは除外される。
+  - `sort` は既知の列挙値へ解決され、未知値はデフォルトへフォールバックする。

--- a/doc/4_application/media/port/SearchResult/readme.md
+++ b/doc/4_application/media/port/SearchResult/readme.md
@@ -1,0 +1,70 @@
+# SearchResult 設計書
+
+## 概要
+`SearchResult` はメディア検索リポジトリからアプリケーション層へ返す検索結果ポートです。  
+`SequelizeMediaQueryRepository` が生成し、`SearchMediaService` が画面描画用の `Output` へ引き継ぎ、最終的に `/screen/summary` の view model に利用されます。
+
+## 配置
+- 実装: `src/application/media/port/SearchResult.js`
+- 利用箇所
+  - `SequelizeMediaQueryRepository`: 検索結果の生成元
+  - `SearchMediaService`: `SearchResult` を受けて `Output` へ正規化する
+  - `/screen/summary`: `SearchMediaService.Output` を描画して一覧画面を構成する
+
+## 構造
+
+### SearchResult
+| 項目 | 型 | 制約 | 備考 |
+| --- | --- | --- | --- |
+| `mediaOverviews` | `MediaOverview[]` | 配列であり、全要素が `MediaOverview` 相当の構造を持つこと | コンストラクタ内で `MediaOverview` に再構築する |
+| `totalCount` | `number` | 0 以上の整数であること | ページング前の総件数 |
+
+### MediaOverview
+| 項目 | 型 | 制約 | 備考 |
+| --- | --- | --- | --- |
+| `mediaId` | `string` | 必須 | メディア識別子 |
+| `title` | `string` | 必須 | 一覧表示タイトル |
+| `thumbnail` | `string` | 必須 | サムネイル用コンテンツ ID / パス文字列 |
+| `tags` | `MediaOverviewTag[]` | 配列であり、各要素が `category` と `label` を持つこと | 表示順はリポジトリが整える |
+| `priorityCategories` | `string[]` | 配列であり、各要素が文字列であること | 配列順がカテゴリー優先度 |
+
+### MediaOverviewTag
+| 項目 | 型 | 制約 | 備考 |
+| --- | --- | --- | --- |
+| `category` | `string` | 必須 | タグのカテゴリー名 |
+| `label` | `string` | 必須 | タグの表示名 |
+
+## `mediaOverviews` と `totalCount` の意味
+- `mediaOverviews` は、現在ページに表示するメディア概要の配列である。
+- `totalCount` は、`start` / `size` で切り出す前に検索条件へ一致した総件数である。
+- そのため、`mediaOverviews.length` は `size` 以下になり得る一方、`totalCount` はページ送りの判断に使われる。
+- 条件一致が0件なら `mediaOverviews` は空配列、`totalCount` は `0` で返す。
+
+## 関連
+
+### SearchMediaService との関係
+- `SearchMediaService` は `SearchResult` を直接返さず、`Output` へコピーしてアプリケーション層の返却 DTO とする。
+- このとき `mediaOverviews` はプレーンオブジェクトとしても受けられるよう再正規化されるが、元契約は `SearchResult` である。
+- `SearchResult` の破損はそのまま `Output` 生成失敗につながるため、リポジトリ側での保証が重要である。
+
+### SequelizeMediaQueryRepository との関係
+- `search(condition)` は検索条件一致の総件数を `totalCount` に設定する。
+- 表示対象の `mediaOverviews` には、先頭コンテンツを `thumbnail` として採用した `MediaOverview` を詰める。
+- `tags` は `priorityCategories` を優先した順に並べ替えた上で返す。
+
+### `/screen/summary` との関係
+- `/screen/summary` は `SearchMediaService.Output.mediaOverviews` と `totalCount` をそのまま描画・ページネーションに利用する。
+- 画面ではメディアカード表示に `mediaId` / `title` / `thumbnail` / `tags` を使い、ページネーション計算に `totalCount` を使う。
+- そのため `SearchResult` は「検索処理の返却値」であると同時に「一覧画面の描画材料」の元データでもある。
+
+## テスト観点
+
+### small で保証すること
+- `mediaOverviews` に正しい構造の配列、`totalCount` に 0 以上の整数を渡したとき生成できる。
+- `mediaOverviews` の要素不足、`tags` / `priorityCategories` の型違反、`totalCount` の負数・小数で `Error` を送出する。
+- コンストラクタが `MediaOverview` / `MediaOverviewTag` を再生成し、最低限の構造保証を行うことを確認する。
+
+### medium で保証すること
+- `SequelizeMediaQueryRepository` から返る `SearchResult` が `SearchMediaService.Output` と `/screen/summary` の描画へそのまま接続できる。
+- `mediaOverviews` の並び、タグ順、サムネイル採用、`totalCount` によるページネーションが期待通りである。
+- 0件時にも `totalCount = 0` と空配列の組み合わせで一覧画面が成立することを確認する。

--- a/doc/4_application/media/port/SearchResult/testcase.md
+++ b/doc/4_application/media/port/SearchResult/testcase.md
@@ -1,0 +1,47 @@
+# SearchResult テストケース
+
+## テストケース一覧
+- [small: 妥当な検索結果を生成できる](#small-妥当な検索結果を生成できる)
+- [small: 不正な mediaOverviews や totalCount は例外を送出する](#small-不正な-mediaoverviews-や-totalcount-は例外を送出する)
+- [medium: SequelizeMediaQueryRepository の検索結果を SearchMediaService が画面用 DTO へ引き継げる](#medium-sequelizemediaqueryrepository-の検索結果を-searchmediaservice-が画面用-dto-へ引き継げる)
+- [medium: /screen/summary が totalCount と mediaOverviews を使って一覧描画とページネーションを行える](#medium-screensummary-が-totalcount-と-mediaoverviews-を使って一覧描画とページネーションを行える)
+
+---
+
+### small: 妥当な検索結果を生成できる
+- 前提
+  - `mediaId`、`title`、`thumbnail`、`tags`、`priorityCategories` を持つメディア概要を用意する。
+- 操作
+  - `mediaOverviews` と `totalCount` を渡して `SearchResult` を生成する。
+- 期待結果
+  - 例外を送出せずインスタンス生成できる。
+  - `mediaOverviews` 内の要素が `MediaOverview` / `MediaOverviewTag` として保持される。
+  - `totalCount` が保持される。
+
+### small: 不正な mediaOverviews や totalCount は例外を送出する
+- 前提
+  - 生成対象クラスが読み込まれている。
+- 操作
+  - `mediaOverviews` に配列以外や必須項目欠落データ、`tags` の型違反、`priorityCategories` の型違反を渡す。
+  - `totalCount` に負数・小数・非数を渡す。
+- 期待結果
+  - いずれも `Error` を送出する。
+
+### medium: SequelizeMediaQueryRepository の検索結果を SearchMediaService が画面用 DTO へ引き継げる
+- 前提
+  - `SequelizeMediaQueryRepository` と `SearchMediaService` を接続した環境がある。
+  - 対象メディアにコンテンツ、タグ、カテゴリー優先度が設定されている。
+- 操作
+  - 検索を実行し、`SearchResult` を経由した `SearchMediaService.Output` を取得する。
+- 期待結果
+  - `mediaOverviews` の各項目が欠落せず `Output` へ引き継がれる。
+  - `thumbnail`、`tags` の並び、`priorityCategories`、`totalCount` が維持される。
+
+### medium: /screen/summary が totalCount と mediaOverviews を使って一覧描画とページネーションを行える
+- 前提
+  - `/screen/summary` の描画処理を実行できる。
+- 操作
+  - 複数件検索結果と0件検索結果の両方を返すようにして画面を描画する。
+- 期待結果
+  - 複数件時はメディアカード描画とページネーション計算が行われる。
+  - 0件時は空一覧でもエラーとならず、`totalCount = 0` 前提の表示が成立する。

--- a/doc/4_application/media/query/SearchMediaService/readme.md
+++ b/doc/4_application/media/query/SearchMediaService/readme.md
@@ -14,75 +14,14 @@
 - ユーザーとして認証済みであること。
 
 ## 入力
-
-```plantuml
-left to right direction
-
-struct Input #pink {
-    + タイトル : string
-    + タグ一覧 : array<InputTag>
-    + ソート方法 : InputSortType
-    + 取得開始位置 : number
-    + 取得数 : number
-}
-
-Note right of Input
-    デフォルト値
-        タイトル: なし
-        タグ一覧 : なし
-        ソート方法 : 登録日新しい順
-        取得開始位置 : 必須
-        取得数 : 必須
-End Note
-
-object InputTag {
-    + カテゴリー名 : string
-    + ラベル名 : string
-}
-
-enum InputSortType {
-    + 登録日新しい順
-    + 登録日古い順
-    + タイトル順
-    + タイトル逆順
-    + ランダム
-}
-
-Input o- InputTag
-Input o- InputSortType
-```
+- `Input` は `title` / `tags` / `sortType` / `start` / `size` を受け取る。
+- 詳細な型・制約・`sortType` の列挙値は [SearchCondition 設計書](/doc/4_application/media/port/SearchCondition/readme.md) を参照する。
+- `SearchMediaService` では画面入力 DTO を `SearchCondition` に変換してリポジトリへ渡す。
 
 ## 出力
-
-```plantuml
-left to right direction
-
-struct Output #pink {
-    + メディア一覧 : array<MediaOverview>
-    + 検索結果合計数 : number
-}
-
-struct MediaOverview {
-    + メディアID : string
-    + タイトル : string
-    + サムネイル : string
-    + タグ一覧 : array<MediaOverviewTag>
-    + カテゴリー優先度 : array<string>
-}
-
-struct MediaOverviewTag {
-    + カテゴリー名 : string
-    + ラベル名 : string
-}
-
-Note right of MediaOverview
-    サムネイル：パス文字列
-    カテゴリー優先度：カテゴリー名の配列、配列順=優先度
-End Note
-
-Output o- MediaOverview
-MediaOverview o- MediaOverviewTag
-```
+- `Output` は `mediaOverviews` と `totalCount` を返す。
+- `mediaOverviews` / `totalCount` の詳細構造は [SearchResult 設計書](/doc/4_application/media/port/SearchResult/readme.md) を参照する。
+- `SearchMediaService` は `SearchResult` を受け取り、画面利用しやすい DTO として再正規化して返却する。
 
 ## エラー処理
 - 検索失敗時はエラーとする。


### PR DESCRIPTION
### Motivation
- 検索処理の契約（検索条件・検索結果）をサービス設計書から分離し、リポジトリ／画面間の責務と型制約を明確にするため。 
- `/screen/summary` や `SequelizeMediaQueryRepository` と整合するテスト観点を port 単位で共有しやすくするため。

### Description
- `doc/4_application/media/port/SearchCondition/readme.md` と `doc/4_application/media/port/SearchCondition/testcase.md` を追加し、`title`/`tags`/`sortType`/`start`/`size` の型・制約、`SortType` 列挙値、関連コンポーネント、small/medium テスト観点を定義した。 
- `doc/4_application/media/port/SearchResult/readme.md` と `doc/4_application/media/port/SearchResult/testcase.md` を追加し、`mediaOverviews`/`totalCount` の構造、`MediaOverview`/`MediaOverviewTag` の制約、関連とテスト観点を定義した。 
- `doc/4_application/media/query/SearchMediaService/readme.md` を整理し、入力／出力の詳細説明を上記の port 設計書への参照に置き換えて責務の重複を削減した。 
- 変更はドキュメント追加・既存設計書の参照整理に限定され、実装コードには影響を与えていない。 

### Testing
- 自動化チェックとして `git diff -- doc/...` を実行して差分を確認し成功した。 
- `git status --short` によりワーキングツリーを確認し、意図したファイルが追加されたことを確認した。 
- 変更をコミット（コミット ID: `8d2338f`）し、PR 作成処理を実行して PR が作成されたことを確認した。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c18113caa8832bb0f5a51c66e1226f)