### PR TITLE
test: GetMediaContentWithNavigationService の medium テストを追加する

### DIFF
--- a/__tests__/medium/application/media/getMediaContentWithNavigationService.test.js
+++ b/__tests__/medium/application/media/getMediaContentWithNavigationService.test.js
@@ -1,0 +1,118 @@
+const { Sequelize } = require('sequelize');
+
+const SequelizeMediaRepository = require('../../../../src/infrastructure/SequelizeMediaRepository');
+const SequelizeUnitOfWork = require('../../../../src/infrastructure/SequelizeUnitOfWork');
+const { RegisterMediaService, RegisterMediaServiceInput } = require('../../../../src/application/media/command/RegisterMediaService');
+const {
+  Input,
+  FoundResult,
+  MediaNotFoundResult,
+  ContentNotFoundResult,
+  GetMediaContentWithNavigationService,
+} = require('../../../../src/application/media/query/GetMediaContentWithNavigationService');
+
+class SequenceMediaIdValueGenerator {
+  constructor(ids) {
+    this.ids = [...ids];
+  }
+
+  generate() {
+    const id = this.ids.shift();
+    if (!id) {
+      throw new Error('mediaId が不足しています');
+    }
+    return id;
+  }
+}
+
+describe('GetMediaContentWithNavigationService (medium)', () => {
+  let sequelize;
+  let unitOfWork;
+  let mediaRepository;
+  let registerMediaService;
+  let service;
+
+  beforeEach(async () => {
+    sequelize = new Sequelize('sqlite::memory:', { logging: false });
+    unitOfWork = new SequelizeUnitOfWork({ sequelize });
+    mediaRepository = new SequelizeMediaRepository({ sequelize, unitOfWorkContext: unitOfWork });
+    await mediaRepository.sync();
+
+    registerMediaService = new RegisterMediaService({
+      mediaIdValueGenerator: new SequenceMediaIdValueGenerator([
+        'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      ]),
+      mediaRepository,
+      unitOfWork,
+    });
+    service = new GetMediaContentWithNavigationService({ mediaRepository });
+
+    await registerMediaService.execute(new RegisterMediaServiceInput({
+      title: 'ナビゲーション確認用メディア',
+      contents: ['content-001', 'content-002', 'content-003'],
+      tags: [{ category: '作者', label: 'テスト太郎' }],
+      priorityCategories: ['作者'],
+    }));
+  });
+
+  afterEach(async () => {
+    await sequelize.close();
+  });
+
+  test('先頭コンテンツ指定時に previousContentId は null で nextContentId が返る', async () => {
+    const result = await service.execute(new Input({
+      mediaId: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      contentPosition: 1,
+    }));
+
+    expect(result).toEqual(new FoundResult({
+      contentId: 'content-001',
+      previousContentId: null,
+      nextContentId: 'content-002',
+    }));
+  });
+
+  test('中間コンテンツ指定時に前後双方の contentId が返る', async () => {
+    const result = await service.execute(new Input({
+      mediaId: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      contentPosition: 2,
+    }));
+
+    expect(result).toEqual(new FoundResult({
+      contentId: 'content-002',
+      previousContentId: 'content-001',
+      nextContentId: 'content-003',
+    }));
+  });
+
+  test('末尾コンテンツ指定時に nextContentId は null で previousContentId が返る', async () => {
+    const result = await service.execute(new Input({
+      mediaId: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      contentPosition: 3,
+    }));
+
+    expect(result).toEqual(new FoundResult({
+      contentId: 'content-003',
+      previousContentId: 'content-002',
+      nextContentId: null,
+    }));
+  });
+
+  test('存在しない contentPosition 指定時に ContentNotFoundResult を返す', async () => {
+    const result = await service.execute(new Input({
+      mediaId: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      contentPosition: 4,
+    }));
+
+    expect(result).toEqual(new ContentNotFoundResult());
+  });
+
+  test('存在しない mediaId 指定時に MediaNotFoundResult を返す', async () => {
+    const result = await service.execute(new Input({
+      mediaId: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      contentPosition: 1,
+    }));
+
+    expect(result).toEqual(new MediaNotFoundResult());
+  });
+});


### PR DESCRIPTION
### Motivation
- `GetMediaContentWithNavigationService` の永続化層を含む動作を medium テストで担保するために、実際の `Sequelize` 経由の配線で前後ナビゲーションの挙動を確認する必要があった。
- 既存の `mediaServices.test.js` に追記すると競合しやすいため、専用ファイルとして分離して保守性を高めることを意図している。

### Description
- 新規に `__tests__/medium/application/media/getMediaContentWithNavigationService.test.js` を追加し、`SequelizeMediaRepository` と `SequelizeUnitOfWork` を利用した medium テストを実装した。 
- テストは `RegisterMediaService` を使って in-memory SQLite 上にメディアを登録し、その上で `GetMediaContentWithNavigationService` を実行して検証する構成になっている。 
- カバーするケースは先頭・中間・末尾コンテンツのナビゲーション、存在しない `contentPosition` の場合の `ContentNotFoundResult`、存在しない `mediaId` の場合の `MediaNotFoundResult` である。 

### Testing
- `node --check __tests__/medium/application/media/getMediaContentWithNavigationService.test.js` を実行して構文チェックは問題なかった（成功）。
- `npx jest __tests__/medium/application/media/getMediaContentWithNavigationService.test.js` はこの環境で `jest` パッケージ取得が `403 Forbidden` となり実行できなかった（失敗）。
- `./node_modules/.bin/jest __tests__/medium/application/media/getMediaContentWithNavigationService.test.js` はローカルに `jest` バイナリが存在せず実行できなかった（失敗）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c181153608832ba928928d1eba230e)