### PR TITLE
test: setupRoutes の共通404ハンドラーに medium テストを追加

### DIFF
--- a/__tests__/medium/app/setupRoutes.notFound.test.js
+++ b/__tests__/medium/app/setupRoutes.notFound.test.js
@@ -1,0 +1,113 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const request = require('supertest');
+
+const createApp = require('../../../src/app');
+
+const createTempPath = (prefix, leaf) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  return {
+    root,
+    target: path.join(root, leaf),
+  };
+};
+
+describe('setupRoutes not found handler (middle)', () => {
+  let app;
+  let databasePath;
+  let contentRootDirectory;
+  let databaseRoot;
+  let contentRoot;
+
+  beforeEach(() => {
+    const database = createTempPath('app-not-found-db-', 'data.sqlite');
+    const contents = createTempPath('app-not-found-content-', 'contents');
+
+    databaseRoot = database.root;
+    contentRoot = contents.root;
+    databasePath = database.target;
+    contentRootDirectory = contents.target;
+  });
+
+  afterEach(async () => {
+    if (app?.locals?.close) await app.locals.close();
+
+    fs.rmSync(databaseRoot, { recursive: true, force: true });
+    fs.rmSync(contentRoot, { recursive: true, force: true });
+    app = undefined;
+  });
+
+  const createReadyApp = async (env = {}) => {
+    app = createApp({
+      databaseStoragePath: databasePath,
+      contentRootDirectory,
+      ...env,
+    });
+
+    await app.locals.ready;
+  };
+
+  test('既存の screen ルートは個別レスポンスを返し、未定義の screen ルートだけが共通 404 JSON を返す', async () => {
+    await createReadyApp();
+
+    const existingResponse = await request(app).get('/screen/error');
+    expect(existingResponse.status).toBe(200);
+    expect(existingResponse.type).toBe('text/html');
+    expect(existingResponse.text).toContain('<title>エラーが発生しました</title>');
+
+    const notFoundResponse = await request(app).get('/screen/not-found-handler-target');
+    expect(notFoundResponse.status).toBe(404);
+    expect(notFoundResponse.type).toMatch(/json/);
+    expect(notFoundResponse.body).toEqual({
+      message: 'Not Found',
+    });
+  });
+
+  test('既存の api ルートは個別レスポンスを返し、未定義の api ルートだけが共通 404 JSON を返す', async () => {
+    await createReadyApp();
+
+    const existingResponse = await request(app)
+      .post('/api/login')
+      .type('form')
+      .send({ username: 'invalid', password: 'invalid' });
+    expect(existingResponse.status).toBe(200);
+    expect(existingResponse.body).toEqual({ code: 1 });
+
+    const notFoundResponse = await request(app).get('/api/not-found-handler-target');
+    expect(notFoundResponse.status).toBe(404);
+    expect(notFoundResponse.type).toMatch(/json/);
+    expect(notFoundResponse.body).toEqual({
+      message: 'Not Found',
+    });
+  });
+
+  test('認証要否にかかわらず未定義パスは共通 404 JSON を返す', async () => {
+    await createReadyApp();
+
+    const unauthenticatedScreenRoute = await request(app).get('/screen/login/not-found');
+    expect(unauthenticatedScreenRoute.status).toBe(404);
+    expect(unauthenticatedScreenRoute.body).toEqual({
+      message: 'Not Found',
+    });
+
+    const authenticatedScreenRoute = await request(app).get('/screen/entry/not-found');
+    expect(authenticatedScreenRoute.status).toBe(404);
+    expect(authenticatedScreenRoute.body).toEqual({
+      message: 'Not Found',
+    });
+
+    const unauthenticatedApiRoute = await request(app).get('/api/login/not-found');
+    expect(unauthenticatedApiRoute.status).toBe(404);
+    expect(unauthenticatedApiRoute.body).toEqual({
+      message: 'Not Found',
+    });
+
+    const authenticatedApiRoute = await request(app).get('/api/media/not-found');
+    expect(authenticatedApiRoute.status).toBe(404);
+    expect(authenticatedApiRoute.body).toEqual({
+      message: 'Not Found',
+    });
+  });
+});

--- a/__tests__/small/app/createApp.test.js
+++ b/__tests__/small/app/createApp.test.js
@@ -66,29 +66,6 @@ describe('createApp', () => {
     });
   });
 
-  test('既存 screen / api ルートに一致しない場合は共通の404 JSONを返す', async () => {
-    app = createApp({
-      databaseStoragePath: databasePath,
-      contentRootDirectory,
-    });
-
-    await app.locals.ready;
-
-    const unknownScreenResponse = await request(app).get('/screen/unknown');
-    expect(unknownScreenResponse.status).toBe(404);
-    expect(unknownScreenResponse.type).toMatch(/json/);
-    expect(unknownScreenResponse.body).toEqual({
-      message: 'Not Found',
-    });
-
-    const unknownApiResponse = await request(app).get('/api/unknown');
-    expect(unknownApiResponse.status).toBe(404);
-    expect(unknownApiResponse.type).toMatch(/json/);
-    expect(unknownApiResponse.body).toEqual({
-      message: 'Not Found',
-    });
-  });
-
   test('固定セッション設定が無効な場合は対象パスでも自動補完されず認証エラーになる', async () => {
     app = createApp({
       databaseStoragePath: databasePath,


### PR DESCRIPTION
### Motivation
- setupRoutes の末尾で登録している共通 404 ハンドラーの振る舞いを medium レベルで専用に検証して責務を分離するため。 

### Description
- `__tests__/medium/app/setupRoutes.notFound.test.js` を新規作成し、既存の screen/api ルートと未定義ルートの対比を検証するテストを追加しました。 
- 未定義パスに対しては全て共通の 404 JSON `{ message: 'Not Found' }` が返ることを、認証要否を問わず確認するケースを追加しました。 
- `__tests__/small/app/createApp.test.js` から共通 404 検証を削除して small / medium の役割を分離しました。 
- 変更はコミット済みです（コミットメッセージ: `test: 共通404ハンドラーのmediumテストを追加する`）。

### Testing
- `jest` 実行を試みましたが環境に `jest` が見つからなかったため `npm test` による実行は失敗しました（`jest: not found`）。
- 追加したテストファイルと修正ファイルについて `node --check` による構文チェックを実行し問題ないことを確認しました。 
- 実行環境での dev-deps インストール（`jest`/`supertest` 等）の不足やネットワーク制約により、統合的なランタイム実行は行えませんでした。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1811848a8832b9a6e4f2dbdb0ca94)