### PR TITLE
test: SearchCondition の small テストを追加する

### DIFF
--- a/__tests__/small/application/media/port/SearchCondition.test.js
+++ b/__tests__/small/application/media/port/SearchCondition.test.js
@@ -1,0 +1,102 @@
+const {
+  SearchCondition,
+  SearchConditionTag,
+  SortType,
+} = require('../../../../../src/application/media/port/SearchCondition');
+
+describe('SearchCondition', () => {
+  test('妥当な title / tags / sortType / start / size で生成できる', () => {
+    const tags = [
+      new SearchConditionTag({ category: 'ジャンル', label: 'アクション' }),
+      new SearchConditionTag({ category: '状態', label: '連載中' }),
+    ];
+
+    const condition = new SearchCondition({
+      title: '検索タイトル',
+      tags,
+      sortType: SortType.TITLE_ASC,
+      start: 1,
+      size: 20,
+    });
+
+    expect(condition).toBeInstanceOf(SearchCondition);
+    expect(condition.title).toBe('検索タイトル');
+    expect(condition.tags).toEqual(tags);
+    expect(condition.sortType).toBe(SortType.TITLE_ASC);
+    expect(condition.start).toBe(1);
+    expect(condition.size).toBe(20);
+  });
+
+  test('title が非文字列のとき Error になる', () => {
+    const invalidTitles = [undefined, null, 123, {}, [], true];
+
+    invalidTitles.forEach((title) => {
+      expect(() => new SearchCondition({
+        title,
+        tags: [],
+        sortType: SortType.DATE_ASC,
+        start: 1,
+        size: 10,
+      })).toThrow(Error);
+    });
+  });
+
+  test('tags が配列でない、または SearchConditionTag 以外を含むと Error になる', () => {
+    const invalidTagsList = [
+      undefined,
+      null,
+      'tag',
+      {},
+      new SearchConditionTag({ category: 'ジャンル', label: 'アクション' }),
+      [{}],
+      [{ category: 'ジャンル', label: 'アクション' }],
+      [new SearchConditionTag({ category: 'ジャンル', label: 'アクション' }), 'invalid'],
+    ];
+
+    invalidTagsList.forEach((tags) => {
+      expect(() => new SearchCondition({
+        title: '検索タイトル',
+        tags,
+        sortType: SortType.DATE_ASC,
+        start: 1,
+        size: 10,
+      })).toThrow(Error);
+    });
+  });
+
+  test('sortType が列挙値以外だと Error になる', () => {
+    const invalidSortTypes = [undefined, null, 'DATE_ASC', Symbol('DATE_ASC'), {}, 1];
+
+    invalidSortTypes.forEach((sortType) => {
+      expect(() => new SearchCondition({
+        title: '検索タイトル',
+        tags: [],
+        sortType,
+        start: 1,
+        size: 10,
+      })).toThrow(Error);
+    });
+  });
+
+  test.each([
+    ['start', 0],
+    ['start', -1],
+    ['start', 1.5],
+    ['start', NaN],
+    ['size', 0],
+    ['size', -1],
+    ['size', 1.5],
+    ['size', NaN],
+  ])('%s が %p のとき Error になる', (target, invalidValue) => {
+    const params = {
+      title: '検索タイトル',
+      tags: [],
+      sortType: SortType.DATE_ASC,
+      start: 1,
+      size: 10,
+      [target]: invalidValue,
+    };
+
+    expect(() => new SearchCondition(params)).toThrow(Error);
+  });
+});


### PR DESCRIPTION
### Motivation
- `SearchCondition` の値オブジェクト単体の妥当性（型・列挙・範囲）を small テストで明確に検証して早期に不具合を検出するため。

### Description
- `__tests__/small/application/media/port/SearchCondition.test.js` を新規追加し、`SearchCondition` / `SearchConditionTag` / `SortType` を直接検証するテストを実装しました。
- 正常系として妥当な `title` / `tags` / `sortType` / `start` / `size` でインスタンス生成できることを検証しています。
- 異常系として `title` の非文字列、`tags` が配列でないまたは `SearchConditionTag` 以外を含む場合、`sortType` が列挙値以外の場合、`start` / `size` が 0・負数・小数・`NaN` の場合に `Error` を送出することを検証しています。

### Testing
- `npm test -- __tests__/small/application/media/port/SearchCondition.test.js` を実行しようとしましたが、実行環境に `jest` が存在せず `jest: not found` で失敗しました。
- 依存導入のために `npm install` を試行しましたが、環境でパッケージ導入が途中で問題となり（ディレクトリ競合等）、テスト実行まで完了できませんでした。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c184ac00bc832ba9e98312fa93c890)