### PR TITLE
test: setupMiddlewareのsmall/mediumテストを分離して追加

### DIFF
--- a/__tests__/medium/app/setupMiddleware.integration.test.js
+++ b/__tests__/medium/app/setupMiddleware.integration.test.js
@@ -1,0 +1,94 @@
+const express = require('express');
+const request = require('supertest');
+
+const setupMiddleware = require('../../../src/app/setupMiddleware');
+const SessionAuthMiddleware = require('../../../src/controller/middleware/SessionAuthMiddleware');
+
+const createApp = () => {
+  const app = express();
+  const authAdapter = {
+    execute: jest.fn(async token => {
+      if (token === 'header-token' || token === 'cookie-token' || token === 'dev-token') {
+        return `user:${token}`;
+      }
+      return null;
+    }),
+  };
+  const sessionAuthMiddleware = new SessionAuthMiddleware(authAdapter);
+
+  setupMiddleware(app, {
+    env: {
+      devSessionToken: 'dev-token',
+      devSessionUserId: 'admin-dev',
+      devSessionTtlMs: 60_000,
+      devSessionPaths: ['/protected'],
+    },
+    dependencies: {},
+  });
+
+  app.get('/protected',
+    (req, res, next) => sessionAuthMiddleware.execute(req, res, next),
+    (req, res) => {
+      res.status(200).json({
+        sessionToken: req.session.session_token,
+        userId: req.context.userId,
+      });
+    });
+
+  return { app, authAdapter };
+};
+
+describe('setupMiddleware と SessionAuthMiddleware の接続 (medium)', () => {
+  test.each([
+    {
+      title: 'x-session-token を最優先で採用する',
+      headers: {
+        'x-session-token': 'header-token',
+        cookie: 'session_token=cookie-token',
+      },
+      expected: 'header-token',
+    },
+    {
+      title: 'x-session-token が無い場合は session_token Cookie を採用する',
+      headers: {
+        cookie: 'theme=dark; session_token=cookie-token',
+      },
+      expected: 'cookie-token',
+    },
+    {
+      title: 'ヘッダ/Cookie が無い場合は DevelopmentSession を採用する',
+      headers: {},
+      expected: 'dev-token',
+    },
+  ])('セッショントークン解決優先順位: $title', async ({ headers, expected }) => {
+    const { app, authAdapter } = createApp();
+    let req = request(app).get('/protected');
+
+    Object.entries(headers).forEach(([key, value]) => {
+      req = req.set(key, value);
+    });
+
+    const response = await req;
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      sessionToken: expected,
+      userId: `user:${expected}`,
+    });
+    expect(authAdapter.execute).toHaveBeenCalledWith(expected);
+  });
+
+  test('後続ミドルウェアへの契約: setupMiddleware が解決した req.session.session_token を SessionAuthMiddleware が利用できる', async () => {
+    const { app } = createApp();
+
+    const response = await request(app)
+      .get('/protected')
+      .set('cookie', 'invalid; session_token=cookie-token');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      sessionToken: 'cookie-token',
+      userId: 'user:cookie-token',
+    });
+  });
+});

--- a/__tests__/small/app/setupMiddleware.test.js
+++ b/__tests__/small/app/setupMiddleware.test.js
@@ -1,0 +1,117 @@
+const setupMiddleware = require('../../../src/app/setupMiddleware');
+
+const createReq = ({
+  headers = {},
+  path = '/screen/entry',
+} = {}) => ({
+  path,
+  header: name => headers[name.toLowerCase()],
+});
+
+const createHarness = ({ env = {} } = {}) => {
+  const middlewares = [];
+  const app = {
+    set: jest.fn(),
+    use: jest.fn(handler => {
+      middlewares.push(handler);
+    }),
+  };
+
+  setupMiddleware(app, { env, dependencies: {} });
+
+  return {
+    app,
+    middleware: middlewares[middlewares.length - 1],
+  };
+};
+
+describe('setupMiddleware (small)', () => {
+  test.each([
+    {
+      title: 'x-session-token が存在する場合は最優先で採用する',
+      headers: {
+        'x-session-token': 'header-token',
+        cookie: 'session_token=cookie-token',
+      },
+      expected: 'header-token',
+    },
+    {
+      title: 'x-session-token が無い場合は session_token Cookie を採用する',
+      headers: {
+        cookie: 'theme=dark; session_token=cookie-token',
+      },
+      expected: 'cookie-token',
+    },
+    {
+      title: 'x-session-token と session_token Cookie が無い場合は開発用固定セッションを採用する',
+      headers: {},
+      expected: 'dev-token',
+    },
+  ])('セッショントークン解決優先順位: $title', ({ headers, expected }) => {
+    const { middleware } = createHarness({
+      env: {
+        devSessionToken: 'dev-token',
+        devSessionUserId: 'admin-dev',
+        devSessionTtlMs: 60_000,
+        devSessionPaths: ['/screen/entry'],
+      },
+    });
+
+    const req = createReq({ headers, path: '/screen/entry' });
+    const next = jest.fn();
+
+    middleware(req, {}, next);
+
+    expect(req.session.session_token).toBe(expected);
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  test('Cookie 解析: Cookieヘッダの不正要素は無視し、session_token が無い場合は開発用固定セッションへフォールバックする', () => {
+    const { middleware } = createHarness({
+      env: {
+        devSessionToken: 'dev-token',
+        devSessionUserId: 'admin-dev',
+        devSessionTtlMs: 60_000,
+        devSessionPaths: ['/screen/entry'],
+      },
+    });
+
+    const req = createReq({
+      headers: {
+        cookie: 'broken; =ignored; session_token; foo=bar',
+      },
+      path: '/screen/entry',
+    });
+
+    middleware(req, {}, jest.fn());
+
+    expect(req.session.session_token).toBe('dev-token');
+  });
+
+  test('req.session ヘルパーの扱い: req.session.regenerate/destroy の最小契約を満たす', () => {
+    const { middleware } = createHarness();
+    const req = createReq();
+
+    middleware(req, {}, jest.fn());
+    req.session.custom = 'kept';
+
+    const regenerateCallback = jest.fn();
+    req.session.regenerate(regenerateCallback);
+
+    expect(regenerateCallback).toHaveBeenCalledWith(null);
+    expect(req.session.custom).toBeUndefined();
+    expect(req.session.req).toBe(req);
+    expect(typeof req.session.regenerate).toBe('function');
+    expect(typeof req.session.destroy).toBe('function');
+
+    req.session.custom = 'again';
+    const destroyCallback = jest.fn();
+    req.session.destroy(destroyCallback);
+
+    expect(destroyCallback).toHaveBeenCalledWith(null);
+    expect(req.session.custom).toBeUndefined();
+    expect(req.session.req).toBe(req);
+    expect(typeof req.session.regenerate).toBe('function');
+    expect(typeof req.session.destroy).toBe('function');
+  });
+});


### PR DESCRIPTION
### Motivation

- `setupMiddleware` の振る舞いを単体と統合で明確に分離して検証し、回帰時に原因を切り分けやすくするため。 
- 設計書の節名と対応するテスト名で仕様との紐付けを容易にし、将来のトレーサビリティを高めるため。

### Description

- `__tests__/small/app/setupMiddleware.test.js` を追加し、`setupMiddleware` の単体検証として `x-session-token` > `session_token` cookie > 開発用固定トークン の優先順位、Cookie ヘッダの不正要素無視、`req.session.regenerate/destroy` の最小契約を検証する。 
- `__tests__/medium/app/setupMiddleware.integration.test.js` を追加し、Express 経由で `setupMiddleware` と `SessionAuthMiddleware` を組み合わせたときに `req.session.session_token` が期待どおり解決され、`SessionAuthMiddleware` がそのトークンを利用して `req.context.userId` を解決できることを検証する。 
- テストケース名は `doc/5_api/controller/middleware/setupMiddleware/readme.md` の節名に対応づけて命名し、仕様との対応を明確化した。 

### Testing

- 追加したテストファイルは `__tests__/small/app/setupMiddleware.test.js` と `__tests__/medium/app/setupMiddleware.integration.test.js` である。 
- `npm test -- __tests__/small/app/setupMiddleware.test.js __tests__/medium/app/setupMiddleware.integration.test.js` を試行したが、この実行環境では `jest: not found` のため実行できなかった。 
- `npx jest __tests__/small/app/setupMiddleware.test.js __tests__/medium/app/setupMiddleware.integration.test.js` を試行したが、npm レジストリへのアクセス制約により `403 Forbidden` となり実行不可だった。 
- テストファイルはローカルのテストランナー（ネットワークアクセス可能な環境）で実行すれば正常に動作する想定で作成してある。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1dea186c0832bb3e83b4837eae057)