### PR TITLE
test: 未定義 screen/api パスの 404 応答を small テストで追加

### DIFF
--- a/__tests__/small/app/setupRoutes.notFound.test.js
+++ b/__tests__/small/app/setupRoutes.notFound.test.js
@@ -1,0 +1,64 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const request = require('supertest');
+
+const createApp = require('../../../src/app');
+
+const createTempPath = (prefix, leaf) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  return {
+    root,
+    target: path.join(root, leaf),
+  };
+};
+
+describe('setupRoutes not found handler (small)', () => {
+  let app;
+  let databasePath;
+  let contentRootDirectory;
+  let databaseRoot;
+  let contentRoot;
+
+  beforeEach(() => {
+    const database = createTempPath('app-small-not-found-db-', 'data.sqlite');
+    const contents = createTempPath('app-small-not-found-content-', 'contents');
+
+    databaseRoot = database.root;
+    contentRoot = contents.root;
+    databasePath = database.target;
+    contentRootDirectory = contents.target;
+
+    app = createApp({
+      databaseStoragePath: databasePath,
+      contentRootDirectory,
+    });
+  });
+
+  afterEach(async () => {
+    if (app?.locals?.close) await app.locals.close();
+
+    fs.rmSync(databaseRoot, { recursive: true, force: true });
+    fs.rmSync(contentRoot, { recursive: true, force: true });
+    app = undefined;
+  });
+
+  test('GET /screen/* の未定義パスは 404 JSON を返す', async () => {
+    await app.locals.ready;
+
+    const response = await request(app).get('/screen/not-found-handler-target');
+
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({ message: 'Not Found' });
+  });
+
+  test('GET /api/* の未定義パスは 404 JSON を返す', async () => {
+    await app.locals.ready;
+
+    const response = await request(app).get('/api/not-found-handler-target');
+
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({ message: 'Not Found' });
+  });
+});


### PR DESCRIPTION
### Motivation
- 未定義ルートの共通 404 ハンドラについて、medium テストが広範な責務を持っているため、small レベルで「単純な未定義パス応答確認」を切り出して最小要件を保証するため。 `createApp` を使った最小構成で `/screen/*` と `/api/*` の未定義パスが 404 を返すことを明確化する。

### Description
- `__tests__/small/app/setupRoutes.notFound.test.js` を新規追加し、`createApp` を使って一時 DB/コンテンツディレクトリを作成して最小構成のアプリを起動するテストを実装した。 
- テストは `GET /screen/not-found-handler-target` と `GET /api/not-found-handler-target` がそれぞれ `404` とレスポンスボディ `{ message: 'Not Found' }` を返すことを検証する。 
- 各テストで `app.locals.ready` を待ち、終了時に `app.locals.close` と一時ディレクトリの削除で後始末を行うようにしている。

### Testing
- 実行コマンド: `npm run test:small -- __tests__/small/app/setupRoutes.notFound.test.js` が成功し、該当 small テストを含む small スイートは通過した（実行ログ: PASS）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1de9dda64832b8879094e1b906206)