### PR TITLE
docs: GetFavoriteSummariesService の入出力とページング仕様を明確化

### DIFF
--- a/doc/4_application/user/query/GetFavoriteSummariesService/readme.md
+++ b/doc/4_application/user/query/GetFavoriteSummariesService/readme.md
@@ -20,8 +20,19 @@ left to right direction
 
 struct Input #pink {
     + userId : string
+    + sort : string = "date_asc"
+    + page : number = 1
 }
 ```
+
+- `userId`
+  - 必須。空文字以外の文字列であること。
+- `sort`
+  - 省略時の既定値は `date_asc`。
+  - 許可値は `date_asc` / `date_desc` / `title_asc` / `title_desc` のみ。
+- `page`
+  - 省略時の既定値は `1`。
+  - 1 以上の整数であること。
 
 ## 出力
 
@@ -30,6 +41,7 @@ left to right direction
 
 struct Output #pink {
     + mediaOverviews : array<MediaOverview>
+    + totalCount : number
 }
 
 struct MediaOverview {
@@ -41,15 +53,30 @@ struct MediaOverview {
 }
 ```
 
+- `mediaOverviews`
+  - 1 ページあたり 20 件（`PAGE_SIZE=20`）を上限として返す。
+  - `page` が総ページ数を超える場合は空配列を返す。
+- `totalCount`
+  - ページング適用前（全 favorite 件数）の件数を返す。
+  - `mediaOverviews` が空配列でも、該当ユーザーに favorite が存在する場合は全件数を保持する。
+
 ## 振る舞い
 - `userRepository.findByUserId` で `userId` に対応するユーザーを取得する。
-- ユーザーが存在しない場合は `Output({ mediaOverviews: [] })` を返す。
+- ユーザーが存在しない場合は `Output({ mediaOverviews: [], totalCount: 0 })` を返す。
 - ユーザーの `favorite` から `mediaId` 一覧を取得する。
-- `favorite` が 0 件の場合は `Output({ mediaOverviews: [] })` を返す。
-- `mediaQueryRepository.findOverviewsByMediaIds` で `mediaOverviews` を取得して返す。
+- `favorite` が 0 件の場合は `Output({ mediaOverviews: [], totalCount: 0 })` を返す。
+- `mediaQueryRepository.findOverviewsByMediaIds` で `mediaOverviews` を取得する。
+- 取得した `mediaOverviews` を `sort` 指定で並び替える。
+  - `date_desc`: favorite 追加順（新しい順）
+  - `date_asc`: favorite 追加順の逆順（古い順）
+  - `title_asc`: `title` 昇順（同一タイトル時は `mediaId` 昇順）
+  - `title_desc`: `title` 降順（同一タイトル時は `mediaId` 昇順）
+- `page` と `PAGE_SIZE=20` を用いて、`(page-1)*20` から 20 件を返す。
+- `Output.totalCount` にはページング前件数、`Output.mediaOverviews` にはページング後配列を設定して返す。
 
 ## エラー処理
 - 入力が `Input` でない場合はエラーとする。
+- `Input` のバリデーションに違反（`userId` が空、`sort` が許可値外、`page` が 1 以上の整数でない）の場合はエラーとする。
 - ユーザー取得または `mediaOverviews` 取得に失敗した場合はエラーとする。
 
 ## シーケンス図
@@ -64,15 +91,17 @@ Controller -> Application: execute(Input)
 Application -> UserRepository: findByUserId(userId)
 Application <-- UserRepository: user | null
 alt user が存在しない
-  Controller <-- Application: Output(mediaOverviews = [])
+  Controller <-- Application: Output(mediaOverviews = [], totalCount = 0)
 else user が存在する
   Application -> Application: favorite から mediaId 一覧を生成
   alt favorite が 0 件
-    Controller <-- Application: Output(mediaOverviews = [])
+    Controller <-- Application: Output(mediaOverviews = [], totalCount = 0)
   else favorite が 1 件以上
     Application -> MediaQueryRepository: findOverviewsByMediaIds(mediaIds)
     Application <-- MediaQueryRepository: mediaOverviews
-    Controller <-- Application: Output(mediaOverviews)
+    Application -> Application: sort 指定で並び替え
+    Application -> Application: page と PAGE_SIZE=20 で slice
+    Controller <-- Application: Output(mediaOverviews(page分), totalCount(全件))
   end
 end
 ```


### PR DESCRIPTION
### Motivation
- `GetFavoriteSummariesService` の実装と `testcase.md` に記載された期待（`sort`/`page`/`totalCount` の扱い）に差異があり、参照時に誤解が生じやすかったため。 
- 読み手が実装挙動（並び順・ページング・空結果時の戻り値）を確実に理解できるようにするため。 
- ドキュメントを実装仕様に合わせることで、仕様・実装・テストの整合性を高めるため。 

### Description
- `doc/4_application/user/query/GetFavoriteSummariesService/readme.md` に `Input` の `userId` / `sort` / `page` を明記し、`sort` の既定値 `date_asc` と許可値、`page` の既定値 `1` と 1 以上の整数バリデーション条件を追記した。 
- `Output` に `totalCount` を追加し、`mediaOverviews` のページング方針として `PAGE_SIZE=20`、ページ超過時は空配列を返すこと、および `totalCount` はページング適用前の総件数であることを明記した。 
- ユーザー未存在時および `favorite` が 0 件の場合の戻り値を `mediaOverviews: []` と `totalCount: 0` に合わせて明文化し、実装と一致させた。 
- シーケンス図を更新して `totalCount` と並び替え・ページング（`sort` 指定での並び替え、`page` と `PAGE_SIZE=20` による slice）を含むフローに修正した。 

### Testing
- 自動化されたテストは実行していません（今回の変更はドキュメントのみの修正のため）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1e3994cc4832bb018cf37e1f8144f)