### PR TITLE
test: ログインからサマリー遷移までを検証する large e2e テストを追加

### DIFF
--- a/__tests__/large/e2e/login-to-summary.large.test.js
+++ b/__tests__/large/e2e/login-to-summary.large.test.js
@@ -1,0 +1,138 @@
+const fs = require('fs/promises');
+const os = require('os');
+const path = require('path');
+
+const createApp = require('../../../src/app');
+const Media = require('../../../src/domain/media/media');
+const MediaId = require('../../../src/domain/media/mediaId');
+const MediaTitle = require('../../../src/domain/media/mediaTitle');
+const ContentId = require('../../../src/domain/media/contentId');
+const Tag = require('../../../src/domain/media/tag');
+const Category = require('../../../src/domain/media/category');
+const Label = require('../../../src/domain/media/label');
+
+const createTempDirectory = prefix => fs.mkdtemp(path.join(os.tmpdir(), prefix));
+
+const removePathIfExists = async targetPath => {
+  if (!targetPath) {
+    return;
+  }
+
+  await fs.rm(targetPath, {
+    recursive: true,
+    force: true,
+  });
+};
+
+const createSeedMedia = ({ mediaId, title, contentId }) => new Media(
+  new MediaId(mediaId),
+  new MediaTitle(title),
+  [new ContentId(contentId)],
+  [
+    new Tag(new Category('カテゴリ'), new Label('ラベル')),
+  ],
+  [new Category('カテゴリ')],
+);
+
+describe('large e2e: ログイン画面からサマリー画面まで遷移する', () => {
+  const seedTitle = 'seed済みタイトル';
+
+  let app;
+  let server;
+  let baseUrl;
+  let tempRootDirectory;
+  let tempDatabasePath;
+  let tempContentDirectory;
+
+  beforeEach(async () => {
+    tempRootDirectory = await createTempDirectory('mangaviewer-e2e-');
+    tempDatabasePath = path.join(tempRootDirectory, 'db', 'test.sqlite');
+    tempContentDirectory = path.join(tempRootDirectory, 'contents');
+
+    app = createApp({
+      databaseStoragePath: tempDatabasePath,
+      contentRootDirectory: tempContentDirectory,
+      loginUsername: 'admin',
+      loginPassword: 'admin',
+      loginUserId: 'admin',
+      loginSessionTtlMs: 60_000,
+    });
+
+    await app.locals.ready;
+
+    await app.locals.dependencies.unitOfWork.run(async () => {
+      await app.locals.dependencies.mediaRepository.save(createSeedMedia({
+        mediaId: 'media-seed-1',
+        title: seedTitle,
+        contentId: 'seed/content-1.jpg',
+      }));
+    });
+
+    await fs.mkdir(path.join(tempContentDirectory, 'seed'), { recursive: true });
+    await fs.writeFile(path.join(tempContentDirectory, 'seed', 'content-1.jpg'), 'dummy', { encoding: 'utf8' });
+
+    server = await new Promise((resolve, reject) => {
+      const listeningServer = app.listen(0, () => resolve(listeningServer));
+      listeningServer.on('error', reject);
+    });
+
+    const address = server.address();
+    if (!address || typeof address === 'string') {
+      throw new Error('テストサーバーの待受ポート解決に失敗しました');
+    }
+
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterEach(async () => {
+    if (server) {
+      await new Promise((resolve, reject) => {
+        server.close(error => (error ? reject(error) : resolve()));
+      });
+      server = null;
+    }
+
+    if (app?.locals?.close) {
+      await app.locals.close();
+    }
+
+    await removePathIfExists(tempRootDirectory);
+
+    app = null;
+    baseUrl = null;
+    tempRootDirectory = null;
+    tempDatabasePath = null;
+    tempContentDirectory = null;
+  });
+
+  test('ログイン成功後に /screen/summary へ遷移して seed データが表示される', async () => {
+    await page.goto(`${baseUrl}/screen/login`, { waitUntil: 'networkidle0' });
+
+    await page.type('#username', 'admin');
+    await page.type('#password', 'admin');
+
+    const loginResponsePromise = page.waitForResponse(response => {
+      return response.url() === `${baseUrl}/api/login` && response.request().method() === 'POST';
+    });
+
+    await page.click('button[type="submit"]');
+
+    const loginResponse = await loginResponsePromise;
+    expect(loginResponse.status()).toBe(200);
+    await expect(loginResponse.json()).resolves.toMatchObject({ code: 0 });
+
+    await page.waitForNavigation({
+      waitUntil: 'networkidle0',
+    });
+    expect(page.url()).toBe(`${baseUrl}/screen/summary`);
+
+    await page.waitForFunction(
+      expectedTitle => document.body && document.body.innerText.includes(expectedTitle),
+      {},
+      seedTitle,
+    );
+
+    const bodyText = await page.evaluate(() => document.body.innerText);
+    expect(bodyText).toContain(seedTitle);
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -12,7 +12,7 @@ module.exports = {
     },
     {
       displayName: 'e2e',
-      testMatch: ['<rootDir>/__tests__/e2e/**/*.test.js'],
+      testMatch: ['<rootDir>/__tests__/large/e2e/**/*.test.js'],
       preset: "jest-puppeteer",
     },
   ],


### PR DESCRIPTION
### Motivation
- ログイン画面操作から実際に `/screen/summary` へ遷移し、seed データが画面に表示されることを E2E で検証するため。 
- テスト実行毎に DB とコンテンツを分離することでテスト独立性を担保するため。
- 既存の small/medium 設定は維持したまま、e2e の探索先パターンを large な配置に変更するため。 

### Description
- `__tests__/large/e2e/login-to-summary.large.test.js` を追加し、Puppeteer（jest-puppeteer 環境）で「ログイン → `POST /api/login` 成功（code=0）捕捉 → `/screen/summary` へ遷移 → seed タイトル表示確認」を行うシナリオを実装しました。 
- 各テストで一時ディレクトリを `fs.mkdtemp` で作成し、`databaseStoragePath`（一時 SQLite）と `contentRootDirectory`（一時コンテンツディレクトリ）をアプリに注入して分離しています。 
- `beforeEach` で `app.locals.ready` を待機後、`unitOfWork.run` 経由で seed メディアを `mediaRepository.save` し、必要なダミーコンテンツファイルを書き込んでいます。 
- `afterEach` でサーバ停止、依存クローズ（`app.locals.close`）、および一時ディレクトリ削除を実行して後片付けを行います。 
- `jest.config.js` の e2e 対象パターンを `__tests__/large/e2e/**/*.test.js` に変更しました。 

### Testing
- `node --check __tests__/large/e2e/login-to-summary.large.test.js` を実行して構文チェックは成功しました。 
- `node --check jest.config.js` を実行して構文チェックは成功しました。 
- `npm test -- --selectProjects e2e --runInBand`（`jest` 実行）はこの環境で `jest: not found` のため実行不可でした。 
- `npx jest --selectProjects e2e --runInBand` はレジストリ/環境要因で `403 Forbidden` となり実行できませんでした。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c23e62fce4832bbb81650ca8bced72)