### PR TITLE
test: e2e共通処理をhelpersへ分離し機能別ディレクトリを追加

### DIFF
--- a/__tests__/large/e2e/auth/.gitkeep
+++ b/__tests__/large/e2e/auth/.gitkeep
@@ -1,0 +1,1 @@
+# e2e auth tests

--- a/__tests__/large/e2e/detail/.gitkeep
+++ b/__tests__/large/e2e/detail/.gitkeep
@@ -1,0 +1,1 @@
+# e2e detail tests

--- a/__tests__/large/e2e/favorite_queue/.gitkeep
+++ b/__tests__/large/e2e/favorite_queue/.gitkeep
@@ -1,0 +1,1 @@
+# e2e favorite_queue tests

--- a/__tests__/large/e2e/helpers/bootstrapE2eApp.js
+++ b/__tests__/large/e2e/helpers/bootstrapE2eApp.js
@@ -1,0 +1,86 @@
+const fs = require('fs/promises');
+const os = require('os');
+const path = require('path');
+
+const createApp = require('../../../../src/app');
+const { removePathIfExists } = require('./fsCleanup');
+
+const createTempDirectory = prefix => fs.mkdtemp(path.join(os.tmpdir(), prefix));
+
+const listenServer = app => new Promise((resolve, reject) => {
+  const listeningServer = app.listen(0, () => resolve(listeningServer));
+  listeningServer.on('error', reject);
+});
+
+const resolveBaseUrl = server => {
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('テストサーバーの待受ポート解決に失敗しました');
+  }
+
+  return `http://127.0.0.1:${address.port}`;
+};
+
+const bootstrapE2eApp = async ({
+  prefix = 'mangaviewer-e2e-',
+  loginUsername = 'admin',
+  loginPassword = 'admin',
+  loginUserId = 'admin',
+  loginSessionTtlMs = 60_000,
+  seed,
+} = {}) => {
+  const tempRootDirectory = await createTempDirectory(prefix);
+  const tempDatabasePath = path.join(tempRootDirectory, 'db', 'test.sqlite');
+  const tempContentDirectory = path.join(tempRootDirectory, 'contents');
+
+  const app = createApp({
+    databaseStoragePath: tempDatabasePath,
+    contentRootDirectory: tempContentDirectory,
+    loginUsername,
+    loginPassword,
+    loginUserId,
+    loginSessionTtlMs,
+  });
+
+  await app.locals.ready;
+
+  if (seed) {
+    await seed({
+      app,
+      tempRootDirectory,
+      tempDatabasePath,
+      tempContentDirectory,
+      fs,
+      path,
+    });
+  }
+
+  const server = await listenServer(app);
+  const baseUrl = resolveBaseUrl(server);
+
+  const teardown = async () => {
+    await new Promise((resolve, reject) => {
+      server.close(error => (error ? reject(error) : resolve()));
+    });
+
+    if (app?.locals?.close) {
+      await app.locals.close();
+    }
+
+    await removePathIfExists(tempRootDirectory);
+  };
+
+  return {
+    app,
+    server,
+    baseUrl,
+    tempRootDirectory,
+    tempDatabasePath,
+    tempContentDirectory,
+    teardown,
+  };
+};
+
+module.exports = {
+  bootstrapE2eApp,
+};

--- a/__tests__/large/e2e/helpers/fsCleanup.js
+++ b/__tests__/large/e2e/helpers/fsCleanup.js
@@ -1,0 +1,16 @@
+const fs = require('fs/promises');
+
+const removePathIfExists = async targetPath => {
+  if (!targetPath) {
+    return;
+  }
+
+  await fs.rm(targetPath, {
+    recursive: true,
+    force: true,
+  });
+};
+
+module.exports = {
+  removePathIfExists,
+};

--- a/__tests__/large/e2e/helpers/seedMedia.js
+++ b/__tests__/large/e2e/helpers/seedMedia.js
@@ -1,0 +1,21 @@
+const Media = require('../../../../src/domain/media/media');
+const MediaId = require('../../../../src/domain/media/mediaId');
+const MediaTitle = require('../../../../src/domain/media/mediaTitle');
+const ContentId = require('../../../../src/domain/media/contentId');
+const Tag = require('../../../../src/domain/media/tag');
+const Category = require('../../../../src/domain/media/category');
+const Label = require('../../../../src/domain/media/label');
+
+const createSeedMedia = ({ mediaId, title, contentId }) => new Media(
+  new MediaId(mediaId),
+  new MediaTitle(title),
+  [new ContentId(contentId)],
+  [
+    new Tag(new Category('カテゴリ'), new Label('ラベル')),
+  ],
+  [new Category('カテゴリ')],
+);
+
+module.exports = {
+  createSeedMedia,
+};

--- a/__tests__/large/e2e/login-to-summary.large.test.js
+++ b/__tests__/large/e2e/login-to-summary.large.test.js
@@ -1,111 +1,39 @@
-const fs = require('fs/promises');
-const os = require('os');
-const path = require('path');
-
-const createApp = require('../../../src/app');
-const Media = require('../../../src/domain/media/media');
-const MediaId = require('../../../src/domain/media/mediaId');
-const MediaTitle = require('../../../src/domain/media/mediaTitle');
-const ContentId = require('../../../src/domain/media/contentId');
-const Tag = require('../../../src/domain/media/tag');
-const Category = require('../../../src/domain/media/category');
-const Label = require('../../../src/domain/media/label');
-
-const createTempDirectory = prefix => fs.mkdtemp(path.join(os.tmpdir(), prefix));
-
-const removePathIfExists = async targetPath => {
-  if (!targetPath) {
-    return;
-  }
-
-  await fs.rm(targetPath, {
-    recursive: true,
-    force: true,
-  });
-};
-
-const createSeedMedia = ({ mediaId, title, contentId }) => new Media(
-  new MediaId(mediaId),
-  new MediaTitle(title),
-  [new ContentId(contentId)],
-  [
-    new Tag(new Category('カテゴリ'), new Label('ラベル')),
-  ],
-  [new Category('カテゴリ')],
-);
+const { bootstrapE2eApp } = require('./helpers/bootstrapE2eApp');
+const { createSeedMedia } = require('./helpers/seedMedia');
 
 describe('large e2e: ログイン画面からサマリー画面まで遷移する', () => {
   const seedTitle = 'seed済みタイトル';
 
-  let app;
-  let server;
-  let baseUrl;
-  let tempRootDirectory;
-  let tempDatabasePath;
-  let tempContentDirectory;
+  let appContext;
 
   beforeEach(async () => {
-    tempRootDirectory = await createTempDirectory('mangaviewer-e2e-');
-    tempDatabasePath = path.join(tempRootDirectory, 'db', 'test.sqlite');
-    tempContentDirectory = path.join(tempRootDirectory, 'contents');
+    appContext = await bootstrapE2eApp({
+      seed: async ({ app, tempContentDirectory, fs, path }) => {
+        await app.locals.dependencies.unitOfWork.run(async () => {
+          await app.locals.dependencies.mediaRepository.save(createSeedMedia({
+            mediaId: 'media-seed-1',
+            title: seedTitle,
+            contentId: 'seed/content-1.jpg',
+          }));
+        });
 
-    app = createApp({
-      databaseStoragePath: tempDatabasePath,
-      contentRootDirectory: tempContentDirectory,
-      loginUsername: 'admin',
-      loginPassword: 'admin',
-      loginUserId: 'admin',
-      loginSessionTtlMs: 60_000,
+        await fs.mkdir(path.join(tempContentDirectory, 'seed'), { recursive: true });
+        await fs.writeFile(path.join(tempContentDirectory, 'seed', 'content-1.jpg'), 'dummy', { encoding: 'utf8' });
+      },
     });
-
-    await app.locals.ready;
-
-    await app.locals.dependencies.unitOfWork.run(async () => {
-      await app.locals.dependencies.mediaRepository.save(createSeedMedia({
-        mediaId: 'media-seed-1',
-        title: seedTitle,
-        contentId: 'seed/content-1.jpg',
-      }));
-    });
-
-    await fs.mkdir(path.join(tempContentDirectory, 'seed'), { recursive: true });
-    await fs.writeFile(path.join(tempContentDirectory, 'seed', 'content-1.jpg'), 'dummy', { encoding: 'utf8' });
-
-    server = await new Promise((resolve, reject) => {
-      const listeningServer = app.listen(0, () => resolve(listeningServer));
-      listeningServer.on('error', reject);
-    });
-
-    const address = server.address();
-    if (!address || typeof address === 'string') {
-      throw new Error('テストサーバーの待受ポート解決に失敗しました');
-    }
-
-    baseUrl = `http://127.0.0.1:${address.port}`;
   });
 
   afterEach(async () => {
-    if (server) {
-      await new Promise((resolve, reject) => {
-        server.close(error => (error ? reject(error) : resolve()));
-      });
-      server = null;
+    if (appContext?.teardown) {
+      await appContext.teardown();
     }
 
-    if (app?.locals?.close) {
-      await app.locals.close();
-    }
-
-    await removePathIfExists(tempRootDirectory);
-
-    app = null;
-    baseUrl = null;
-    tempRootDirectory = null;
-    tempDatabasePath = null;
-    tempContentDirectory = null;
+    appContext = null;
   });
 
   test('ログイン成功後に /screen/summary へ遷移して seed データが表示される', async () => {
+    const { baseUrl } = appContext;
+
     await page.goto(`${baseUrl}/screen/login`, { waitUntil: 'networkidle0' });
 
     await page.type('#username', 'admin');

--- a/__tests__/large/e2e/navigation/.gitkeep
+++ b/__tests__/large/e2e/navigation/.gitkeep
@@ -1,0 +1,1 @@
+# e2e navigation tests

--- a/__tests__/large/e2e/summary/.gitkeep
+++ b/__tests__/large/e2e/summary/.gitkeep
@@ -1,0 +1,1 @@
+# e2e summary tests


### PR DESCRIPTION
### Motivation
- E2Eテストの初期化／後始末やseed処理が各テストに重複して存在していたため、保守性向上のため共通化する必要があった。 
- 機能別（auth／summary／detail／favorite_queue／navigation）にテストを整理することで今後のシナリオ追加を容易にするため。 

### Description
- `__tests__/large/e2e/` 配下に機能別ディレクトリとして `auth/`, `summary/`, `detail/`, `favorite_queue/`, `navigation/` を追加し追跡用の `.gitkeep` を配置した。 
- E2E共通処理を `__tests__/large/e2e/helpers/` に切り出し、以下のファイルを新規追加した: `bootstrapE2eApp.js`（`createApp` 起動、テンポラリDB/contents準備、`listen`/`teardown` を提供）、`seedMedia.js`（Mediaエンティティのseed生成）、`fsCleanup.js`（テンポラリ削除ユーティリティ）。 
- 既存の `__tests__/large/e2e/login-to-summary.large.test.js` をリファクタリングし、直接のセットアップ/ティアダウンやseedロジックを取り除いて `bootstrapE2eApp` と `createSeedMedia` を利用するように変更した。 
- 既存のテストファイル名（`*.large.test.js`）と `jest.config.js` のマッチパターン（`__tests__/large/e2e/**/*.test.js`）はそのまま維持して整合性を保った。 

### Testing
- `npm test -- --selectProjects=e2e --runTestsByPath __tests__/large/e2e/login-to-summary.large.test.js` を実行しテストを試行したが、実行環境で `jest: not found` によりテストは実行できなかった（依存が無いため未実行）。 
- リポジトリ内の影響範囲はローカルでのファイル移動/追加とテストファイルのリファクタリングに限定され、コミット済みであることを確認した。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c28c8764b8832b9355c7ffd42f5ee2)