### PR TITLE
test: 詳細画面からお気に入り・あとで見る追加解除のE2Eを追加

### DIFF
--- a/__tests__/large/e2e/detail/detail-favorite-queue-actions.large.test.js
+++ b/__tests__/large/e2e/detail/detail-favorite-queue-actions.large.test.js
@@ -1,0 +1,206 @@
+const fs = require('fs/promises');
+const os = require('os');
+const path = require('path');
+
+const createApp = require('../../../../src/app');
+const Media = require('../../../../src/domain/media/media');
+const MediaId = require('../../../../src/domain/media/mediaId');
+const MediaTitle = require('../../../../src/domain/media/mediaTitle');
+const ContentId = require('../../../../src/domain/media/contentId');
+const Tag = require('../../../../src/domain/media/tag');
+const Category = require('../../../../src/domain/media/category');
+const Label = require('../../../../src/domain/media/label');
+
+const createTempDirectory = prefix => fs.mkdtemp(path.join(os.tmpdir(), prefix));
+
+const removePathIfExists = async targetPath => {
+  if (!targetPath) {
+    return;
+  }
+
+  await fs.rm(targetPath, {
+    recursive: true,
+    force: true,
+  });
+};
+
+const createSeedMedia = ({ mediaId, title, contentId }) => new Media(
+  new MediaId(mediaId),
+  new MediaTitle(title),
+  [new ContentId(contentId)],
+  [
+    new Tag(new Category('カテゴリ'), new Label('ラベル')),
+  ],
+  [new Category('カテゴリ')],
+);
+
+const waitForApiResponse = ({ pageInstance, baseUrl, pathSuffix, method }) => {
+  const expectedUrl = `${baseUrl}${pathSuffix}`;
+  return pageInstance.waitForResponse(response => response.url() === expectedUrl
+    && response.request().method() === method);
+};
+
+describe('large e2e: 詳細画面から favorite/queue の追加と解除を行う', () => {
+  const seedMediaId = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+  const seedTitle = 'お気に入りとあとで見る対象タイトル';
+
+  let app;
+  let server;
+  let baseUrl;
+  let tempRootDirectory;
+  let tempDatabasePath;
+  let tempContentDirectory;
+
+  beforeEach(async () => {
+    tempRootDirectory = await createTempDirectory('mangaviewer-e2e-detail-');
+    tempDatabasePath = path.join(tempRootDirectory, 'db', 'test.sqlite');
+    tempContentDirectory = path.join(tempRootDirectory, 'contents');
+
+    app = createApp({
+      databaseStoragePath: tempDatabasePath,
+      contentRootDirectory: tempContentDirectory,
+      loginUsername: 'admin',
+      loginPassword: 'admin',
+      loginUserId: 'admin',
+      loginSessionTtlMs: 60_000,
+    });
+
+    await app.locals.ready;
+
+    await app.locals.dependencies.unitOfWork.run(async () => {
+      await app.locals.dependencies.mediaRepository.save(createSeedMedia({
+        mediaId: seedMediaId,
+        title: seedTitle,
+        contentId: 'seed/detail-content-1.jpg',
+      }));
+    });
+
+    await fs.mkdir(path.join(tempContentDirectory, 'seed'), { recursive: true });
+    await fs.writeFile(path.join(tempContentDirectory, 'seed', 'detail-content-1.jpg'), 'dummy', { encoding: 'utf8' });
+
+    server = await new Promise((resolve, reject) => {
+      const listeningServer = app.listen(0, () => resolve(listeningServer));
+      listeningServer.on('error', reject);
+    });
+
+    const address = server.address();
+    if (!address || typeof address === 'string') {
+      throw new Error('テストサーバーの待受ポート解決に失敗しました');
+    }
+
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterEach(async () => {
+    if (server) {
+      await new Promise((resolve, reject) => {
+        server.close(error => (error ? reject(error) : resolve()));
+      });
+      server = null;
+    }
+
+    if (app?.locals?.close) {
+      await app.locals.close();
+    }
+
+    await removePathIfExists(tempRootDirectory);
+
+    app = null;
+    baseUrl = null;
+    tempRootDirectory = null;
+    tempDatabasePath = null;
+    tempContentDirectory = null;
+  });
+
+  test('詳細画面の favorite/queue 追加と解除が一覧画面に反映される', async () => {
+    await page.goto(`${baseUrl}/screen/login`, { waitUntil: 'networkidle0' });
+
+    await page.type('#username', 'admin');
+    await page.type('#password', 'admin');
+
+    const loginResponsePromise = waitForApiResponse({
+      pageInstance: page,
+      baseUrl,
+      pathSuffix: '/api/login',
+      method: 'POST',
+    });
+
+    await page.click('button[type="submit"]');
+
+    const loginResponse = await loginResponsePromise;
+    expect(loginResponse.status()).toBe(200);
+
+    await page.waitForNavigation({ waitUntil: 'networkidle0' });
+    expect(page.url()).toBe(`${baseUrl}/screen/summary`);
+
+    await page.goto(`${baseUrl}/screen/detail/${seedMediaId}`, { waitUntil: 'networkidle0' });
+
+    const favoriteAddResponsePromise = waitForApiResponse({
+      pageInstance: page,
+      baseUrl,
+      pathSuffix: `/api/favorite/${seedMediaId}`,
+      method: 'PUT',
+    });
+    await page.click('#favorite-add');
+    const favoriteAddResponse = await favoriteAddResponsePromise;
+    expect(favoriteAddResponse.status()).toBe(200);
+
+    await page.goto(`${baseUrl}/screen/favorite`, { waitUntil: 'networkidle0' });
+    await page.waitForSelector(`[data-media-id="${seedMediaId}"]`);
+
+    const favoriteText = await page.evaluate(() => document.body.innerText);
+    expect(favoriteText).toContain(seedTitle);
+
+    await page.goto(`${baseUrl}/screen/detail/${seedMediaId}`, { waitUntil: 'networkidle0' });
+
+    const queueAddResponsePromise = waitForApiResponse({
+      pageInstance: page,
+      baseUrl,
+      pathSuffix: `/api/queue/${seedMediaId}`,
+      method: 'PUT',
+    });
+    await page.click('#queue-add');
+    const queueAddResponse = await queueAddResponsePromise;
+    expect(queueAddResponse.status()).toBe(200);
+
+    await page.goto(`${baseUrl}/screen/queue`, { waitUntil: 'networkidle0' });
+    await page.waitForSelector(`[data-media-id="${seedMediaId}"]`);
+
+    const queueText = await page.evaluate(() => document.body.innerText);
+    expect(queueText).toContain(seedTitle);
+
+    await page.goto(`${baseUrl}/screen/favorite`, { waitUntil: 'networkidle0' });
+
+    const favoriteDeleteResponsePromise = waitForApiResponse({
+      pageInstance: page,
+      baseUrl,
+      pathSuffix: `/api/favorite/${seedMediaId}`,
+      method: 'DELETE',
+    });
+    await page.click(`[data-media-id="${seedMediaId}"] .js-favorite-remove`);
+    const favoriteDeleteResponse = await favoriteDeleteResponsePromise;
+    expect(favoriteDeleteResponse.status()).toBe(200);
+
+    await page.waitForFunction(
+      mediaId => !document.querySelector(`[data-media-id="${mediaId}"]`),
+      {},
+      seedMediaId,
+    );
+
+    await page.goto(`${baseUrl}/screen/queue`, { waitUntil: 'networkidle0' });
+
+    const queueDeleteResponsePromise = waitForApiResponse({
+      pageInstance: page,
+      baseUrl,
+      pathSuffix: `/api/queue/${seedMediaId}`,
+      method: 'DELETE',
+    });
+    await page.click(`[data-media-id="${seedMediaId}"] .js-queue-toggle`);
+    const queueDeleteResponse = await queueDeleteResponsePromise;
+    expect(queueDeleteResponse.status()).toBe(200);
+
+    await page.goto(`${baseUrl}/screen/queue`, { waitUntil: 'networkidle0' });
+    const remainingQueueCard = await page.$(`[data-media-id="${seedMediaId}"]`);
+    expect(remainingQueueCard).toBeNull();
+  });
+});


### PR DESCRIPTION
### Motivation
- 詳細画面での「お気に入り」「あとで見る」操作が一覧画面へ正しく反映されることを E2E で保証するため。 
- API の呼び出しパスや HTTP メソッドの取り違えを `page.waitForResponse()` で早期検知できるようにするため。

### Description
- `__tests__/large/e2e/detail/detail-favorite-queue-actions.large.test.js` を新規追加して、詳細画面から favorite/queue の追加・解除と一覧への反映を一連で検証する E2E を実装しました。 
- テストは一時 DB とコンテンツディレクトリを作成して seed メディアを投入し、サーバ起動/停止と後片付けまでファイル内で完結する構成にしています。 
- `waitForApiResponse` ヘルパーを用いて `page.waitForResponse()` でレスポンスの URL とリクエストの HTTP メソッドを厳密に検証するようにしました。 
- テスト内のシナリオはログイン → `/screen/detail/:mediaId` で `PUT /api/favorite/:mediaId` → `/screen/favorite` に表示確認 → `/screen/detail/:mediaId` で `PUT /api/queue/:mediaId` → `/screen/queue` に表示確認 → `DELETE` による解除と一覧からの消失確認、という流れです。

### Testing
- `node --check __tests__/large/e2e/detail/detail-favorite-queue-actions.large.test.js` は構文チェックとして成功しました。 
- `npm test -- --selectProjects e2e __tests__/large/e2e/detail/detail-favorite-queue-actions.large.test.js` は環境に `jest` が見つからないため実行できませんでした（`jest: not found`）。 
- `npm ci` を試行しましたが依存解決／インストールが環境で長時間停止したため E2E 実行まで完了できませんでした。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c28c8a7ad4832b89c5b7e80cbc760f)