### PR TITLE
test: 不正なルートパラメータに対するE2E異常系シナリオを追加する

### DIFF
--- a/__tests__/large/e2e/error/invalid-route-params.large.test.js
+++ b/__tests__/large/e2e/error/invalid-route-params.large.test.js
@@ -1,0 +1,122 @@
+const { bootstrapE2eApp } = require('../helpers/bootstrapE2eApp');
+const { createSeedMedia } = require('../helpers/seedMedia');
+
+const login = async baseUrl => {
+  await page.goto(`${baseUrl}/screen/login`, { waitUntil: 'networkidle0' });
+
+  await page.type('#username', 'admin');
+  await page.type('#password', 'admin');
+
+  const loginResponsePromise = page.waitForResponse(response => {
+    return response.url() === `${baseUrl}/api/login` && response.request().method() === 'POST';
+  });
+
+  await page.click('button[type="submit"]');
+
+  const loginResponse = await loginResponsePromise;
+  expect(loginResponse.status()).toBe(200);
+
+  await page.waitForNavigation({ waitUntil: 'networkidle0' });
+  expect(page.url()).toBe(`${baseUrl}/screen/summary`);
+};
+
+const expectErrorScreen = async ({ baseUrl, path }) => {
+  const response = await page.goto(`${baseUrl}${path}`, { waitUntil: 'networkidle0' });
+
+  expect(response.status()).toBe(200);
+  expect(page.url()).toBe(`${baseUrl}/screen/error`);
+
+  const bodyText = await page.evaluate(() => document.body.innerText);
+  expect(bodyText).toContain('ページを表示できませんでした');
+  expect(bodyText).toContain('ログイン画面へ戻る');
+  expect(bodyText).toContain('一覧・サマリー画面へ戻る');
+};
+
+describe('large e2e: 不正な route params でエラー画面へ遷移し安全に復帰できる', () => {
+  const seedMediaId = 'media-invalid-route-seed';
+  const seedTitle = '不正ルート復帰確認タイトル';
+
+  let appContext;
+
+  beforeEach(async () => {
+    appContext = await bootstrapE2eApp({
+      prefix: 'mangaviewer-e2e-invalid-route-',
+      seed: async ({ app, tempContentDirectory, fs, path }) => {
+        await app.locals.dependencies.unitOfWork.run(async () => {
+          await app.locals.dependencies.mediaRepository.save(createSeedMedia({
+            mediaId: seedMediaId,
+            title: seedTitle,
+            contentId: 'seed/invalid-route-content-1.jpg',
+          }));
+        });
+
+        await fs.mkdir(path.join(tempContentDirectory, 'seed'), { recursive: true });
+        await fs.writeFile(path.join(tempContentDirectory, 'seed', 'invalid-route-content-1.jpg'), 'dummy', { encoding: 'utf8' });
+      },
+    });
+  });
+
+  afterEach(async () => {
+    if (appContext?.teardown) {
+      await appContext.teardown();
+    }
+
+    appContext = null;
+  });
+
+  test('存在しない mediaId と不正 page 指定時にエラー画面へ遷移し、一覧へ復帰できる', async () => {
+    const { baseUrl } = appContext;
+
+    await login(baseUrl);
+
+    await expectErrorScreen({
+      baseUrl,
+      path: '/screen/detail/media-not-exists-for-e2e',
+    });
+
+    await expectErrorScreen({
+      baseUrl,
+      path: '/screen/viewer/media-not-exists-for-e2e/1',
+    });
+
+    await expectErrorScreen({
+      baseUrl,
+      path: `/screen/viewer/${seedMediaId}/0`,
+    });
+
+    await expectErrorScreen({
+      baseUrl,
+      path: `/screen/viewer/${seedMediaId}/9999`,
+    });
+
+    const currentResponse = await page.goto(page.url(), { waitUntil: 'networkidle0' });
+    expect(currentResponse.status()).toBe(200);
+
+    await Promise.all([
+      page.waitForNavigation({ waitUntil: 'networkidle0' }),
+      page.click('a[href="/screen/summary"]'),
+    ]);
+
+    expect(page.url()).toMatch(new RegExp(`^${baseUrl}/screen/summary\\?`));
+
+    const summaryBodyText = await page.evaluate(() => document.body.innerText);
+    expect(summaryBodyText).toContain(seedTitle);
+
+    const notFoundApiResponse = await page.evaluate(async () => {
+      const response = await fetch('/screen/not-defined-path-for-e2e', {
+        method: 'GET',
+        headers: {
+          Accept: 'application/json',
+        },
+      });
+
+      return {
+        status: response.status,
+        body: await response.json(),
+      };
+    });
+
+    expect(notFoundApiResponse.status).toBe(404);
+    expect(notFoundApiResponse.body).toEqual({ message: 'Not Found' });
+  });
+});

--- a/doc/6_ui/flow/e2e/testcase.large.md
+++ b/doc/6_ui/flow/e2e/testcase.large.md
@@ -44,6 +44,15 @@
   - 保護画面へのアクセス制御
   - ログアウト後の遷移/再アクセス制御
 
+### TC-E2E-005: 不正なルートパラメータでエラー画面に遷移し復帰できる
+
+- 対応テスト: `__tests__/large/e2e/error/invalid-route-params.large.test.js`
+- 観点:
+  - 存在しない `mediaId` での `/screen/detail/:mediaId` / `/screen/viewer/:mediaId/:mediaPage` のエラー遷移
+  - `mediaPage=0` や過大ページ番号での `/screen/viewer/:mediaId/:mediaPage` のエラー遷移
+  - エラー画面からナビゲーションリンク経由で `/screen/summary` に安全に復帰できること
+  - 未定義パスで定義済みの HTTP ステータス (`404`) とレスポンスボディを返すこと
+
 ## 判定基準
 
 - 各シナリオで期待する HTTP ステータス・画面遷移・表示要素が一致すること


### PR DESCRIPTION
### Motivation

- 詳細画面およびビューアー画面で存在しない `mediaId` や不正な `mediaPage` が渡された場合の異常遷移（エラー画面表示）と復帰導線が既存の large E2E でカバーされていなかったため、回帰テストとして追加する必要がありました。 
- テスト実装と合わせて E2E テストケース定義書へ同観点を明示して仕様との対応を維持します。

### Description

- 新規に `__tests__/large/e2e/error/invalid-route-params.large.test.js` を追加し、存在しない `mediaId` での `/screen/detail/:mediaId` と `/screen/viewer/:mediaId/:mediaPage`、および `mediaPage=0` や過大ページ番号でのアクセス時にエラー画面へ遷移することを検証する E2E シナリオを実装しました。 
- 追加テストはエラー画面が表示されること（`/screen/error`、画面文言とナビゲーションリンクの存在）を確認し、エラー画面から `一覧・サマリー` へ安全に復帰できることを検証します。 
- 未定義パスに対して HTTP `404` とボディ `{ message: 'Not Found' }` が返ることも同テスト内で確認します。 
- テストケース定義書 `doc/6_ui/flow/e2e/testcase.large.md` に `TC-E2E-005` を追記し、今回の異常系観点を文書化しました。

### Testing

- `npm test -- __tests__/large/e2e/error/invalid-route-params.large.test.js` を実行して E2E を起動しようとしましたが、実行環境に `jest` が存在しないため `sh: 1: jest: not found` で自動テスト実行は失敗しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2a813d67c832b989e51c00aab9b37)