### PR TITLE
test: 編集画面の削除後導線を検証する large e2e テストを追加

### DIFF
--- a/__tests__/large/e2e/edit/edit-delete-media.large.test.js
+++ b/__tests__/large/e2e/edit/edit-delete-media.large.test.js
@@ -1,0 +1,112 @@
+const { bootstrapE2eApp } = require('../helpers/bootstrapE2eApp');
+const { createSeedMedia } = require('../helpers/seedMedia');
+
+const login = async baseUrl => {
+  await page.goto(`${baseUrl}/screen/login`, { waitUntil: 'networkidle0' });
+
+  await page.type('#username', 'admin');
+  await page.type('#password', 'admin');
+
+  const loginResponsePromise = page.waitForResponse(response => {
+    return response.url() === `${baseUrl}/api/login` && response.request().method() === 'POST';
+  });
+
+  await page.click('button[type="submit"]');
+
+  const loginResponse = await loginResponsePromise;
+  expect(loginResponse.status()).toBe(200);
+  await expect(loginResponse.json()).resolves.toMatchObject({ code: 0 });
+
+  await page.waitForNavigation({ waitUntil: 'networkidle0' });
+  expect(page.url()).toBe(`${baseUrl}/screen/summary`);
+};
+
+const expectErrorScreen = async ({ baseUrl, path }) => {
+  const response = await page.goto(`${baseUrl}${path}`, { waitUntil: 'networkidle0' });
+
+  expect(response.status()).toBe(200);
+  expect(page.url()).toBe(`${baseUrl}/screen/error`);
+
+  const bodyText = await page.evaluate(() => document.body.innerText);
+  expect(bodyText).toContain('ページを表示できませんでした');
+  expect(bodyText).toContain('ログイン画面へ戻る');
+  expect(bodyText).toContain('一覧・サマリー画面へ戻る');
+};
+
+describe('large e2e: 編集画面でメディア削除後に各画面から到達不能になることを確認する', () => {
+  const seedMediaId = 'dddddddddddddddddddddddddddddddd';
+  const seedTitle = '削除対象の seed メディア';
+
+  let appContext;
+
+  beforeEach(async () => {
+    appContext = await bootstrapE2eApp({
+      prefix: 'mangaviewer-e2e-edit-delete-',
+      seed: async ({ app, tempContentDirectory, fs, path }) => {
+        await app.locals.dependencies.unitOfWork.run(async () => {
+          await app.locals.dependencies.mediaRepository.save(createSeedMedia({
+            mediaId: seedMediaId,
+            title: seedTitle,
+            contentId: 'seed/edit-delete-content-1.jpg',
+          }));
+        });
+
+        await fs.mkdir(path.join(tempContentDirectory, 'seed'), { recursive: true });
+        await fs.writeFile(path.join(tempContentDirectory, 'seed', 'edit-delete-content-1.jpg'), 'dummy', { encoding: 'utf8' });
+      },
+    });
+  });
+
+  afterEach(async () => {
+    if (appContext?.teardown) {
+      await appContext.teardown();
+    }
+
+    appContext = null;
+  });
+
+  test('編集画面の削除成功後に summary からカードが消え、detail/viewer 直接アクセスでエラー画面へ遷移する', async () => {
+    const { baseUrl } = appContext;
+
+    await login(baseUrl);
+
+    await page.goto(`${baseUrl}/screen/edit/${seedMediaId}`, { waitUntil: 'networkidle0' });
+
+    const deleteResponsePromise = page.waitForResponse(response => {
+      return response.url() === `${baseUrl}/api/media/${seedMediaId}` && response.request().method() === 'DELETE';
+    });
+
+    const dialogPromise = new Promise(resolve => {
+      page.once('dialog', async dialog => {
+        await dialog.accept();
+        resolve();
+      });
+    });
+
+    const navigationPromise = page.waitForNavigation({ waitUntil: 'networkidle0' });
+
+    await page.click('#delete-button');
+
+    await dialogPromise;
+
+    const deleteResponse = await deleteResponsePromise;
+    expect(deleteResponse.status()).toBe(200);
+    await expect(deleteResponse.json()).resolves.toMatchObject({ code: 0 });
+
+    await navigationPromise;
+    expect(page.url()).toBe(`${baseUrl}/screen/summary`);
+
+    const deletedCard = await page.$(`[data-media-id="${seedMediaId}"]`);
+    expect(deletedCard).toBeNull();
+
+    await expectErrorScreen({
+      baseUrl,
+      path: `/screen/detail/${seedMediaId}`,
+    });
+
+    await expectErrorScreen({
+      baseUrl,
+      path: `/screen/viewer/${seedMediaId}/1`,
+    });
+  });
+});


### PR DESCRIPTION
### Motivation
- 編集画面からの削除操作について API 応答だけでなく画面遷移・一覧反映・削除後アクセス時の保護動作まで E2E で担保し、削除まわりの回帰を防ぐため。 

### Description
- `__tests__/large/e2e/edit/edit-delete-media.large.test.js` を新規追加し、`bootstrapE2eApp` を用いて一時環境と seed メディアをセットアップするテストを実装しました。 
- テストはログイン→`/screen/edit/:mediaId` へ遷移→削除ボタン押下→確認ダイアログ accept→`DELETE /api/media/:mediaId` を `waitForResponse` で捕捉して `status=200` と `body.code=0` を検証します。 
- 削除後に `/screen/summary` へ戻ることと該当カード（`data-media-id`）が消えていることを検証し、さらに削除済み `mediaId` での `/screen/detail/:mediaId` と `/screen/viewer/:mediaId/1` への直接アクセスがエラー画面へ遷移することを `invalid-route-params.large.test.js` と同等の期待値で検証します。 

### Testing
- `npm test -- __tests__/large/e2e/edit/edit-delete-media.large.test.js` を実行しようとしましたが、実行環境で `jest: not found` エラーのためテストは実行できませんでした。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2b40660ec832b8b325794d9df8d9f)