### PR TITLE
E2E: favorite/queue 一覧のソート・ページング・解除再計算を検証するテストを追加

### DIFF
--- a/__tests__/large/e2e/detail/detail-favorite-queue-actions.large.test.js
+++ b/__tests__/large/e2e/detail/detail-favorite-queue-actions.large.test.js
@@ -10,6 +10,7 @@ const ContentId = require('../../../../src/domain/media/contentId');
 const Tag = require('../../../../src/domain/media/tag');
 const Category = require('../../../../src/domain/media/category');
 const Label = require('../../../../src/domain/media/label');
+const { waitForApiResponse } = require('../support/api-response');
 
 const createTempDirectory = prefix => fs.mkdtemp(path.join(os.tmpdir(), prefix));
 
@@ -34,11 +35,6 @@ const createSeedMedia = ({ mediaId, title, contentId }) => new Media(
   [new Category('カテゴリ')],
 );
 
-const waitForApiResponse = ({ pageInstance, baseUrl, pathSuffix, method }) => {
-  const expectedUrl = `${baseUrl}${pathSuffix}`;
-  return pageInstance.waitForResponse(response => response.url() === expectedUrl
-    && response.request().method() === method);
-};
 
 describe('large e2e: 詳細画面から favorite/queue の追加と解除を行う', () => {
   const seedMediaId = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';

--- a/__tests__/large/e2e/favorite-queue/favorite-queue-sort-pagination.large.test.js
+++ b/__tests__/large/e2e/favorite-queue/favorite-queue-sort-pagination.large.test.js
@@ -1,0 +1,271 @@
+const fs = require('fs/promises');
+const os = require('os');
+const path = require('path');
+
+const createApp = require('../../../../src/app');
+const Media = require('../../../../src/domain/media/media');
+const MediaId = require('../../../../src/domain/media/mediaId');
+const MediaTitle = require('../../../../src/domain/media/mediaTitle');
+const ContentId = require('../../../../src/domain/media/contentId');
+const Tag = require('../../../../src/domain/media/tag');
+const Category = require('../../../../src/domain/media/category');
+const Label = require('../../../../src/domain/media/label');
+const { waitForApiResponse } = require('../support/api-response');
+
+const createTempDirectory = prefix => fs.mkdtemp(path.join(os.tmpdir(), prefix));
+
+const removePathIfExists = async targetPath => {
+  if (!targetPath) {
+    return;
+  }
+
+  await fs.rm(targetPath, {
+    recursive: true,
+    force: true,
+  });
+};
+
+const createSeedMedia = ({ mediaId, title, contentId }) => new Media(
+  new MediaId(mediaId),
+  new MediaTitle(title),
+  [new ContentId(contentId)],
+  [
+    new Tag(new Category('シリーズ'), new Label('E2E')),
+  ],
+  [new Category('シリーズ')],
+);
+
+const createSeedMedias = (count) => {
+  return Array.from({ length: count }, (_value, index) => {
+    const number = String(index + 1).padStart(2, '0');
+    return {
+      mediaId: `fq-media-${number}`,
+      title: `作品 ${number}`,
+      contentId: `seed/content-${number}.jpg`,
+    };
+  });
+};
+
+const login = async ({ page, baseUrl }) => {
+  await page.goto(`${baseUrl}/screen/login`, { waitUntil: 'networkidle0' });
+
+  await page.type('#username', 'admin');
+  await page.type('#password', 'admin');
+
+  const loginResponsePromise = waitForApiResponse({
+    pageInstance: page,
+    baseUrl,
+    pathSuffix: '/api/login',
+    method: 'POST',
+  });
+
+  await page.click('button[type="submit"]');
+
+  const loginResponse = await loginResponsePromise;
+  expect(loginResponse.status()).toBe(200);
+
+  await page.waitForNavigation({ waitUntil: 'networkidle0' });
+  expect(page.url()).toBe(`${baseUrl}/screen/summary`);
+};
+
+const prepareFavoriteAndQueue = async ({ page, mediaIds }) => {
+  const responseStatuses = await page.evaluate(async ids => {
+    const statuses = [];
+    for (const mediaId of ids) {
+      const favoriteResponse = await fetch(`/api/favorite/${mediaId}`, {
+        method: 'PUT',
+        headers: { Accept: 'application/json' },
+      });
+      statuses.push(favoriteResponse.status);
+
+      const queueResponse = await fetch(`/api/queue/${mediaId}`, {
+        method: 'PUT',
+        headers: { Accept: 'application/json' },
+      });
+      statuses.push(queueResponse.status);
+    }
+    return statuses;
+  }, mediaIds);
+
+  expect(responseStatuses.every(status => status === 200)).toBe(true);
+};
+
+const readTitles = async currentPage => currentPage.evaluate(() => {
+  return Array.from(document.querySelectorAll('.media-card h2'))
+    .map(node => (node.textContent || '').trim())
+    .filter(Boolean);
+});
+
+const readCurrentPage = async currentPage => currentPage.evaluate(() => {
+  const node = document.querySelector('.page-current');
+  return node ? Number.parseInt((node.textContent || '').trim(), 10) : null;
+});
+
+const clickPageLink = async ({ page, pageNumber }) => {
+  await page.evaluate(number => {
+    const link = Array.from(document.querySelectorAll('a.page-link')).find(candidate => {
+      return (candidate.textContent || '').trim() === String(number);
+    });
+    if (!link) {
+      throw new Error(`ページ ${number} のリンクが見つかりません`);
+    }
+    link.click();
+  }, pageNumber);
+
+  await page.waitForNavigation({ waitUntil: 'networkidle0' });
+};
+
+describe('large e2e: favorite/queue の並び替えとページング', () => {
+  const seedMedias = createSeedMedias(22);
+
+  let app;
+  let server;
+  let baseUrl;
+  let tempRootDirectory;
+  let tempDatabasePath;
+  let tempContentDirectory;
+
+  beforeEach(async () => {
+    tempRootDirectory = await createTempDirectory('mangaviewer-e2e-favorite-queue-');
+    tempDatabasePath = path.join(tempRootDirectory, 'db', 'test.sqlite');
+    tempContentDirectory = path.join(tempRootDirectory, 'contents');
+
+    app = createApp({
+      databaseStoragePath: tempDatabasePath,
+      contentRootDirectory: tempContentDirectory,
+      loginUsername: 'admin',
+      loginPassword: 'admin',
+      loginUserId: 'admin',
+      loginSessionTtlMs: 60_000,
+    });
+
+    await app.locals.ready;
+
+    await app.locals.dependencies.unitOfWork.run(async () => {
+      await Promise.all(seedMedias.map(media => app.locals.dependencies.mediaRepository.save(createSeedMedia(media))));
+    });
+
+    await fs.mkdir(path.join(tempContentDirectory, 'seed'), { recursive: true });
+    await Promise.all(seedMedias.map(media => fs.writeFile(path.join(tempContentDirectory, media.contentId), 'dummy', { encoding: 'utf8' })));
+
+    server = await new Promise((resolve, reject) => {
+      const listeningServer = app.listen(0, () => resolve(listeningServer));
+      listeningServer.on('error', reject);
+    });
+
+    const address = server.address();
+    if (!address || typeof address === 'string') {
+      throw new Error('テストサーバーの待受ポート解決に失敗しました');
+    }
+
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterEach(async () => {
+    if (server) {
+      await new Promise((resolve, reject) => {
+        server.close(error => (error ? reject(error) : resolve()));
+      });
+      server = null;
+    }
+
+    if (app?.locals?.close) {
+      await app.locals.close();
+    }
+
+    await removePathIfExists(tempRootDirectory);
+
+    app = null;
+    baseUrl = null;
+    tempRootDirectory = null;
+    tempDatabasePath = null;
+    tempContentDirectory = null;
+  });
+
+  test('favorite/queue のページングと並び替え、解除後の再計算が行える', async () => {
+    const mediaIds = seedMedias.map(media => media.mediaId);
+
+    await login({ page, baseUrl });
+    await prepareFavoriteAndQueue({ page, mediaIds });
+
+    await page.goto(`${baseUrl}/screen/favorite?page=1&sort=date_asc`, { waitUntil: 'networkidle0' });
+
+    const favoritePageText = await page.evaluate(() => document.body.innerText);
+    expect(favoritePageText).toContain('22');
+    expect(favoritePageText).toContain('ページ 1 / 2');
+
+    const favoriteDateAscTitles = await readTitles(page);
+    expect(favoriteDateAscTitles[0]).toBe('作品 01');
+
+    await clickPageLink({ page, pageNumber: 2 });
+
+    expect(await readCurrentPage(page)).toBe(2);
+    expect(await page.$$eval('.media-card', cards => cards.length)).toBe(2);
+
+    await page.goto(`${baseUrl}/screen/favorite?page=1&sort=title_desc`, { waitUntil: 'networkidle0' });
+    const favoriteTitleDescTitles = await readTitles(page);
+    expect(favoriteTitleDescTitles[0]).toBe('作品 22');
+
+    await page.goto(`${baseUrl}/screen/favorite?page=1&sort=title_asc`, { waitUntil: 'networkidle0' });
+    const favoriteTitleAscTitles = await readTitles(page);
+    expect(favoriteTitleAscTitles[0]).toBe('作品 01');
+
+    await page.goto(`${baseUrl}/screen/favorite?page=2&sort=date_asc`, { waitUntil: 'networkidle0' });
+
+    const favoriteDeleteResponsePromise = waitForApiResponse({
+      pageInstance: page,
+      baseUrl,
+      pathSuffix: '/api/favorite/fq-media-22',
+      method: 'DELETE',
+    });
+    await page.click('[data-media-id="fq-media-22"] .js-favorite-remove');
+    const favoriteDeleteResponse = await favoriteDeleteResponsePromise;
+    expect(favoriteDeleteResponse.status()).toBe(200);
+
+    await page.goto(`${baseUrl}/screen/favorite?page=2&sort=date_asc`, { waitUntil: 'networkidle0' });
+    const favoriteAfterDeleteText = await page.evaluate(() => document.body.innerText);
+    expect(favoriteAfterDeleteText).toContain('21');
+    expect(favoriteAfterDeleteText).toContain('ページ 2 / 2');
+    expect(await page.$$eval('.media-card', cards => cards.length)).toBe(1);
+
+    await page.goto(`${baseUrl}/screen/queue?queuePage=1&sort=date_asc`, { waitUntil: 'networkidle0' });
+
+    const queuePageText = await page.evaluate(() => document.body.innerText);
+    expect(queuePageText).toContain('22 件');
+    expect(await readCurrentPage(page)).toBe(1);
+
+    const queueDateAscTitles = await readTitles(page);
+    expect(queueDateAscTitles[0]).toBe('作品 01');
+
+    await clickPageLink({ page, pageNumber: 2 });
+
+    expect(await readCurrentPage(page)).toBe(2);
+    expect(await page.$$eval('.media-card', cards => cards.length)).toBe(2);
+
+    await page.goto(`${baseUrl}/screen/queue?queuePage=1&sort=title_desc`, { waitUntil: 'networkidle0' });
+    const queueTitleDescTitles = await readTitles(page);
+    expect(queueTitleDescTitles[0]).toBe('作品 22');
+
+    await page.goto(`${baseUrl}/screen/queue?queuePage=1&sort=title_asc`, { waitUntil: 'networkidle0' });
+    const queueTitleAscTitles = await readTitles(page);
+    expect(queueTitleAscTitles[0]).toBe('作品 01');
+
+    await page.goto(`${baseUrl}/screen/queue?queuePage=2&sort=date_asc`, { waitUntil: 'networkidle0' });
+
+    const queueDeleteResponsePromise = waitForApiResponse({
+      pageInstance: page,
+      baseUrl,
+      pathSuffix: '/api/queue/fq-media-22',
+      method: 'DELETE',
+    });
+    await page.click('[data-media-id="fq-media-22"] .js-queue-toggle');
+    const queueDeleteResponse = await queueDeleteResponsePromise;
+    expect(queueDeleteResponse.status()).toBe(200);
+
+    await page.goto(`${baseUrl}/screen/queue?queuePage=2&sort=date_asc`, { waitUntil: 'networkidle0' });
+    const queueAfterDeleteText = await page.evaluate(() => document.body.innerText);
+    expect(queueAfterDeleteText).toContain('21 件');
+    expect(await readCurrentPage(page)).toBe(2);
+    expect(await page.$$eval('.media-card', cards => cards.length)).toBe(1);
+  });
+});

--- a/__tests__/large/e2e/support/api-response.js
+++ b/__tests__/large/e2e/support/api-response.js
@@ -1,0 +1,9 @@
+const waitForApiResponse = ({ pageInstance, baseUrl, pathSuffix, method }) => {
+  const expectedUrl = `${baseUrl}${pathSuffix}`;
+  return pageInstance.waitForResponse(response => response.url() === expectedUrl
+    && response.request().method() === method);
+};
+
+module.exports = {
+  waitForApiResponse,
+};


### PR DESCRIPTION
### Motivation
- 大量件数時の `favorite` / `queue` 一覧でのページング・並び順・解除後の再計算での回帰を検出・防止するために E2E テストを追加し、API 待受ロジックの重複を削減する。

### Description
- `__tests__/large/e2e/favorite-queue/favorite-queue-sort-pagination.large.test.js` を追加し、22 件のメディアを seed して `PUT /api/favorite/:mediaId` / `PUT /api/queue/:mediaId` で事前登録し、`/screen/favorite` と `/screen/queue` のページリンク操作・`sort` クエリ（date/title の asc/desc）切替・一覧からの削除操作とそれに伴う `DELETE` エンドポイント待受と再計算検証を行う。 
- `__tests__/large/e2e/support/api-response.js` を追加し、`waitForApiResponse` ヘルパーを共通化した。 
- 既存の `__tests__/large/e2e/detail/detail-favorite-queue-actions.large.test.js` を修正してローカル実装の API 待受ロジックを共通ヘルパーに置換し、重複コードを削減した。

### Testing
- 追加・更新したテストファイルとヘルパーに対して `node --check` を実行し構文チェックは成功した。 
- `npm test -- __tests__/large/e2e/favorite-queue/favorite-queue-sort-pagination.large.test.js __tests__/large/e2e/detail/detail-favorite-queue-actions.large.test.js` を試行したが、実行環境で `jest: not found` のためフルテスト実行は行えなかった。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2b407f7f4832b91f2624177dc43a8)