### PR TITLE
test: ログイン失敗時にログイン画面へ留まるE2Eテストを追加

### DIFF
--- a/__tests__/large/e2e/auth/login-failure.large.test.js
+++ b/__tests__/large/e2e/auth/login-failure.large.test.js
@@ -1,0 +1,53 @@
+const { bootstrapE2eApp } = require('../helpers/bootstrapE2eApp');
+
+describe('large e2e: ログイン失敗時の再入力導線', () => {
+  let appContext;
+
+  beforeEach(async () => {
+    appContext = await bootstrapE2eApp({
+      prefix: 'mangaviewer-e2e-auth-login-failure-',
+    });
+  });
+
+  afterEach(async () => {
+    if (appContext?.teardown) {
+      await appContext.teardown();
+    }
+    appContext = null;
+  });
+
+  test('誤った認証情報では /screen/login に留まり、失敗メッセージ表示後も再入力できる', async () => {
+    const { baseUrl } = appContext;
+
+    await page.goto(`${baseUrl}/screen/login`, { waitUntil: 'networkidle0' });
+
+    await page.type('#username', 'admin');
+    await page.type('#password', 'wrong-password');
+
+    const loginResponsePromise = page.waitForResponse(response => {
+      return response.url() === `${baseUrl}/api/login` && response.request().method() === 'POST';
+    });
+
+    await page.click('button[type="submit"]');
+
+    const loginResponse = await loginResponsePromise;
+    expect(loginResponse.status()).toBe(200);
+    await expect(loginResponse.json()).resolves.toEqual({ code: 1 });
+
+    await page.waitForFunction(() => {
+      const message = document.querySelector('#loginMessage');
+      return message && message.textContent.includes('ログインに失敗しました。入力内容をご確認ください。');
+    });
+
+    expect(page.url()).toBe(`${baseUrl}/screen/login`);
+    expect(page.url()).not.toBe(`${baseUrl}/screen/summary`);
+
+    const loginMessage = await page.$eval('#loginMessage', element => element.textContent.trim());
+    expect(loginMessage).toContain('ログインに失敗しました。入力内容をご確認ください。');
+
+    const isUsernameDisabled = await page.$eval('#username', element => element.disabled);
+    const isPasswordDisabled = await page.$eval('#password', element => element.disabled);
+    expect(isUsernameDisabled).toBe(false);
+    expect(isPasswordDisabled).toBe(false);
+  });
+});


### PR DESCRIPTION
### Motivation
- `LoginPostController` の仕様ではログイン失敗時に HTTP 200 と `{ code: 1 }` を返すため、フロントが遷移制御と再入力導線を正しく維持できることを E2E で担保する必要がある。

### Description
- 新規ファイル `__tests__/large/e2e/auth/login-failure.large.test.js` を追加し、ログイン画面で誤った認証情報を入力して submit する失敗フローを検証するテストを実装した。 
- `POST /api/login` のレスポンスを `page.waitForResponse` で捕捉し、`status` が `200` でレスポンスボディが `{ code: 1 }` であることを検証している。 
- 画面の挙動として `page.url()` が引き続き `/screen/login` のままであることと `/screen/summary` へ遷移しないこと、失敗メッセージ表示と `#username` / `#password` が再入力可能（`disabled === false`）であることを検証している。 

### Testing
- `npm test -- __tests__/large/e2e/auth/login-failure.large.test.js` を実行しようとしたが環境で `jest: not found` のためテスト実行は失敗した。 
- 依存導入のために `npm ci` を試行したが、この環境では完了確認できず `jest` 実行環境は整っていない状態であった。 
- テストファイルはリポジトリへ追加・コミット済み（`__tests__/large/e2e/auth/login-failure.large.test.js`）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2b4089a14832b8f3fb73b27596c97)