### PR TITLE
test: 検索画面からサマリー画面への条件引き継ぎを検証する E2E テストを追加

### DIFF
--- a/__tests__/large/e2e/helpers/seedMedia.js
+++ b/__tests__/large/e2e/helpers/seedMedia.js
@@ -6,14 +6,20 @@ const Tag = require('../../../../src/domain/media/tag');
 const Category = require('../../../../src/domain/media/category');
 const Label = require('../../../../src/domain/media/label');
 
-const createSeedMedia = ({ mediaId, title, contentId }) => new Media(
+const createSeedMedia = ({
+  mediaId,
+  title,
+  contentId,
+  tags = [{ category: 'カテゴリ', label: 'ラベル' }],
+  priorityCategories = tags.length > 0 ? [tags[0].category] : [],
+  registeredAt,
+}) => new Media(
   new MediaId(mediaId),
   new MediaTitle(title),
   [new ContentId(contentId)],
-  [
-    new Tag(new Category('カテゴリ'), new Label('ラベル')),
-  ],
-  [new Category('カテゴリ')],
+  tags.map(tag => new Tag(new Category(tag.category), new Label(tag.label))),
+  priorityCategories.map(category => new Category(category)),
+  registeredAt,
 );
 
 module.exports = {

--- a/__tests__/large/e2e/helpers/summaryDom.js
+++ b/__tests__/large/e2e/helpers/summaryDom.js
@@ -1,0 +1,8 @@
+const readSummaryTitles = async currentPage => currentPage.evaluate(() => {
+  const headingElements = Array.from(document.querySelectorAll('.media-card h2'));
+  return headingElements.map(node => (node.textContent || '').trim()).filter(Boolean);
+});
+
+module.exports = {
+  readSummaryTitles,
+};

--- a/__tests__/large/e2e/search/search-to-summary.large.test.js
+++ b/__tests__/large/e2e/search/search-to-summary.large.test.js
@@ -1,0 +1,139 @@
+const { bootstrapE2eApp } = require('../helpers/bootstrapE2eApp');
+const { createSeedMedia } = require('../helpers/seedMedia');
+
+describe('large e2e: search から summary への条件引き継ぎ', () => {
+  let appContext;
+
+  beforeEach(async () => {
+    appContext = await bootstrapE2eApp({
+      prefix: 'mangaviewer-search-to-summary-e2e-',
+      seed: async ({ app, tempContentDirectory, fs, path }) => {
+        const medias = [
+          createSeedMedia({
+            mediaId: 'media-1',
+            title: 'target newest',
+            contentId: 'seed/content-1.jpg',
+            tags: [
+              { category: 'シリーズ', label: '対象' },
+              { category: 'ジャンル', label: '少年' },
+            ],
+            registeredAt: new Date('2024-02-01T00:00:00.000Z'),
+          }),
+          createSeedMedia({
+            mediaId: 'media-2',
+            title: 'target old',
+            contentId: 'seed/content-2.jpg',
+            tags: [
+              { category: 'シリーズ', label: '対象' },
+              { category: 'ジャンル', label: '青年' },
+            ],
+            registeredAt: new Date('2024-01-01T00:00:00.000Z'),
+          }),
+          createSeedMedia({
+            mediaId: 'media-3',
+            title: 'other newest',
+            contentId: 'seed/content-3.jpg',
+            tags: [
+              { category: 'シリーズ', label: '別作品' },
+              { category: 'ジャンル', label: '少年' },
+            ],
+            registeredAt: new Date('2024-03-01T00:00:00.000Z'),
+          }),
+          createSeedMedia({
+            mediaId: 'media-4',
+            title: 'misc',
+            contentId: 'seed/content-4.jpg',
+            tags: [{ category: 'ジャンル', label: '一般' }],
+            registeredAt: new Date('2024-01-15T00:00:00.000Z'),
+          }),
+        ];
+
+        await app.locals.dependencies.unitOfWork.run(async () => {
+          await Promise.all(medias.map(media => app.locals.dependencies.mediaRepository.save(media)));
+        });
+
+        await fs.mkdir(path.join(tempContentDirectory, 'seed'), { recursive: true });
+        await Promise.all([
+          fs.writeFile(path.join(tempContentDirectory, 'seed', 'content-1.jpg'), 'dummy-1', { encoding: 'utf8' }),
+          fs.writeFile(path.join(tempContentDirectory, 'seed', 'content-2.jpg'), 'dummy-2', { encoding: 'utf8' }),
+          fs.writeFile(path.join(tempContentDirectory, 'seed', 'content-3.jpg'), 'dummy-3', { encoding: 'utf8' }),
+          fs.writeFile(path.join(tempContentDirectory, 'seed', 'content-4.jpg'), 'dummy-4', { encoding: 'utf8' }),
+        ]);
+      },
+    });
+  });
+
+  afterEach(async () => {
+    if (appContext?.teardown) {
+      await appContext.teardown();
+    }
+
+    appContext = null;
+  });
+
+  test('/screen/search で入力した条件を /screen/summary で URL と表示に引き継ぐ', async () => {
+    const { baseUrl } = appContext;
+
+    await page.goto(`${baseUrl}/screen/login`, { waitUntil: 'networkidle0' });
+    await page.type('#username', 'admin');
+    await page.type('#password', 'admin');
+
+    const loginResponsePromise = page.waitForResponse(response => {
+      return response.url() === `${baseUrl}/api/login` && response.request().method() === 'POST';
+    });
+
+    await page.click('button[type="submit"]');
+
+    const loginResponse = await loginResponsePromise;
+    expect(loginResponse.status()).toBe(200);
+
+    await page.waitForNavigation({ waitUntil: 'networkidle0' });
+    expect(page.url()).toBe(`${baseUrl}/screen/summary`);
+
+    await page.goto(`${baseUrl}/screen/search`, { waitUntil: 'networkidle0' });
+
+    await page.type('#title', 'target');
+    await page.click('#start', { clickCount: 3 });
+    await page.type('#start', '1');
+    await page.click('#size', { clickCount: 3 });
+    await page.type('#size', '2');
+    await page.select('#sort', 'title_desc');
+
+    await page.type('#category-input', 'シリーズ');
+    await page.type('#tag-input', '対象');
+    await page.click('#add-tag-button');
+
+    await page.type('#category-input', 'ジャンル');
+    await page.type('#tag-input', '少年');
+    await page.click('#add-tag-button');
+
+    await page.click('button[type="submit"]');
+    await page.waitForNavigation({ waitUntil: 'networkidle0' });
+
+    const currentUrl = new URL(page.url());
+    expect(currentUrl.pathname).toBe('/screen/summary');
+    expect(currentUrl.searchParams.get('title')).toBe('target');
+    expect(currentUrl.searchParams.get('start')).toBe('1');
+    expect(currentUrl.searchParams.get('size')).toBe('2');
+    expect(currentUrl.searchParams.get('sort')).toBe('title_desc');
+    expect(currentUrl.searchParams.get('summaryPage')).toBe('1');
+    expect(currentUrl.searchParams.getAll('tags')).toEqual(['シリーズ:対象', 'ジャンル:少年']);
+
+    const chips = await page.evaluate(() => {
+      return Array.from(document.querySelectorAll('.condition-list .chip'))
+        .map(node => (node.textContent || '').trim())
+        .filter(Boolean);
+    });
+
+    expect(chips).toEqual(expect.arrayContaining([
+      'タイトル: target',
+      'シリーズ:対象',
+      'ジャンル:少年',
+      '取得開始位置: 1',
+      '取得数: 2',
+    ]));
+
+    const bodyText = await page.evaluate(() => document.body.innerText);
+    expect(bodyText).toContain('1 件');
+  });
+});

--- a/__tests__/large/e2e/summary/summary-search-sort-pagination.large.test.js
+++ b/__tests__/large/e2e/summary/summary-search-sort-pagination.large.test.js
@@ -10,6 +10,7 @@ const ContentId = require('../../../../src/domain/media/contentId');
 const Tag = require('../../../../src/domain/media/tag');
 const Category = require('../../../../src/domain/media/category');
 const Label = require('../../../../src/domain/media/label');
+const { readSummaryTitles } = require('../helpers/summaryDom');
 
 const createTempDirectory = prefix => fs.mkdtemp(path.join(os.tmpdir(), prefix));
 
@@ -57,12 +58,6 @@ const login = async ({ page, baseUrl }) => {
   await page.waitForNavigation({ waitUntil: 'networkidle0' });
   expect(page.url()).toBe(`${baseUrl}/screen/summary`);
 };
-
-const readSummaryTitles = async (currentPage) => currentPage.evaluate(() => {
-  const headingElements = Array.from(document.querySelectorAll('.media-card h2'));
-  return headingElements.map(node => (node.textContent || '').trim()).filter(Boolean);
-});
-
 const readDetailLinks = async (currentPage) => currentPage.evaluate(() => {
   return Array.from(document.querySelectorAll('.media-card .actions a'))
     .filter(link => (link.textContent || '').includes('詳細画面へ'))


### PR DESCRIPTION
### Motivation
- 検索画面で入力した条件がサマリー画面に正しく引き継がれていることを自動回帰で検証するために E2E テストを追加しました。
- 既存テストで重複していた DOM 取得処理と seed 作成処理を共通化して保守性を高めるためにヘルパー化しました。

### Description
- 新規に `__tests__/large/e2e/search/search-to-summary.large.test.js` を追加し、`/screen/search` で `title/start/size/sort/複数tags` を入力して遷移後に `/screen/summary` の URL クエリ（`title,tags,start,size,sort,summaryPage`）を `new URL(page.url())` で検証します。
- 検索条件の画面表示（「現在の検索条件」チップ）と結果件数表示が入力条件に一致することを検証します。
- `__tests__/large/e2e/helpers/summaryDom.js` を追加し、既存の summary テストで使用していたタイトル読み取りヘルパーを共通化しました。
- `__tests__/large/e2e/helpers/seedMedia.js` を修正し、タグ・優先カテゴリ・登録日時を指定できるようにして、タイトル差・タグ差・登録順差のある seed データを投入可能にしました。
- 既存の `__tests__/large/e2e/summary/summary-search-sort-pagination.large.test.js` を該当ヘルパーを使うように調整しました。

### Testing
- `npm test -- __tests__/large/e2e/search/search-to-summary.large.test.js __tests__/large/e2e/summary/summary-search-sort-pagination.large.test.js` を実行しましたが、環境で `jest: not found` が発生しテストは実行できませんでした（失敗）。
- 依存解決のために `npm ci` と `npm install` を試みましたが、この環境では完了確認できずテスト実行可能な状態に到達できませんでした（未完了）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2b407b440832b80dc07cc7d961399)