### PR TITLE
test: 編集画面のメディア更新E2Eシナリオを追加

### DIFF
--- a/__tests__/large/e2e/edit/edit-update-media.large.test.js
+++ b/__tests__/large/e2e/edit/edit-update-media.large.test.js
@@ -1,0 +1,214 @@
+const fs = require('fs/promises');
+
+const Media = require('../../../../src/domain/media/media');
+const MediaId = require('../../../../src/domain/media/mediaId');
+const MediaTitle = require('../../../../src/domain/media/mediaTitle');
+const ContentId = require('../../../../src/domain/media/contentId');
+const Tag = require('../../../../src/domain/media/tag');
+const Category = require('../../../../src/domain/media/category');
+const Label = require('../../../../src/domain/media/label');
+const { bootstrapE2eApp } = require('../helpers/bootstrapE2eApp');
+
+const createSeedMedia = ({ mediaId, title, contentIds, tags }) => new Media(
+  new MediaId(mediaId),
+  new MediaTitle(title),
+  contentIds.map(contentId => new ContentId(contentId)),
+  tags.map(tag => new Tag(new Category(tag.category), new Label(tag.label))),
+  [new Category(tags[0].category)],
+);
+
+const login = async ({ page, baseUrl }) => {
+  await page.goto(`${baseUrl}/screen/login`, { waitUntil: 'networkidle0' });
+
+  await page.type('#username', 'admin');
+  await page.type('#password', 'admin');
+
+  const loginResponsePromise = page.waitForResponse(response => {
+    return response.url() === `${baseUrl}/api/login` && response.request().method() === 'POST';
+  });
+
+  await page.click('button[type="submit"]');
+
+  const loginResponse = await loginResponsePromise;
+  expect(loginResponse.status()).toBe(200);
+  await expect(loginResponse.json()).resolves.toEqual({ code: 0 });
+
+  await page.waitForNavigation({ waitUntil: 'networkidle0' });
+  expect(page.url()).toBe(`${baseUrl}/screen/summary`);
+};
+
+const assertViewerState = async ({ page, baseUrl, mediaId, mediaPage, expectedContentId }) => {
+  expect(page.url()).toBe(`${baseUrl}/screen/viewer/${mediaId}/${mediaPage}`);
+
+  const metaText = await page.$eval('.meta-chip', element => element.textContent.trim());
+  expect(metaText).toContain(`mediaId: ${mediaId}`);
+  expect(metaText).toContain(`page: ${mediaPage}`);
+
+  const imageState = await page.$eval('.stage img', element => ({
+    src: element.getAttribute('src'),
+    alt: element.getAttribute('alt'),
+  }));
+
+  expect(imageState.src).toBe(expectedContentId);
+  expect(imageState.alt).toBe(`${mediaId} の ${mediaPage} ページ`);
+};
+
+describe('large e2e: edit 画面での既存メディア更新', () => {
+  const seedMediaId = 'media-seed-edit-update-1';
+  const initialTitle = '編集前タイトル';
+  const updatedTitle = '編集後タイトル';
+  const initialTags = [
+    { category: 'ジャンル', label: '初期タグ' },
+    { category: '作者', label: '初期作者' },
+  ];
+  const updatedTags = [
+    { category: 'ジャンル', label: '更新タグ' },
+    { category: '連載', label: '連載中' },
+  ];
+  const seedContentIds = [
+    'seed/edit-update-content-1.jpg',
+    'seed/edit-update-content-2.jpg',
+    'seed/edit-update-content-3.jpg',
+  ];
+
+  let context;
+
+  beforeEach(async () => {
+    context = await bootstrapE2eApp({
+      prefix: 'mangaviewer-e2e-edit-update-',
+      seed: async ({ app, tempContentDirectory, path }) => {
+        await app.locals.dependencies.unitOfWork.run(async () => {
+          await app.locals.dependencies.mediaRepository.save(createSeedMedia({
+            mediaId: seedMediaId,
+            title: initialTitle,
+            contentIds: seedContentIds,
+            tags: initialTags,
+          }));
+        });
+
+        await fs.mkdir(path.join(tempContentDirectory, 'seed'), { recursive: true });
+        await Promise.all(seedContentIds.map(contentId => {
+          return fs.writeFile(path.join(tempContentDirectory, contentId), 'dummy', { encoding: 'utf8' });
+        }));
+      },
+    });
+  });
+
+  afterEach(async () => {
+    if (context?.teardown) {
+      await context.teardown();
+    }
+    context = null;
+  });
+
+  test('初期値表示・編集送信・一覧反映・ビューアー順序変更を確認できる', async () => {
+    const { baseUrl } = context;
+
+    await login({ page, baseUrl });
+
+    await page.goto(`${baseUrl}/screen/edit/${seedMediaId}`, { waitUntil: 'networkidle0' });
+
+    await page.waitForSelector('#title');
+    await expect(page.$eval('#title', element => element.value)).resolves.toBe(initialTitle);
+
+    const initialTagTexts = await page.$$eval('#tag-list .tag-item', elements => {
+      return elements.map(element => element.textContent.replace(/\s+/g, ' ').trim());
+    });
+    expect(initialTagTexts).toEqual(expect.arrayContaining([
+      expect.stringContaining('ジャンル'),
+      expect.stringContaining('初期タグ'),
+      expect.stringContaining('作者'),
+      expect.stringContaining('初期作者'),
+    ]));
+
+    const initialMediaTexts = await page.$$eval('#media-list .media-item .media-item-body', elements => {
+      return elements.map(element => element.textContent.replace(/\s+/g, ' ').trim());
+    });
+    expect(initialMediaTexts).toEqual([
+      `既存 contentId: ${seedContentIds[0]}`,
+      `既存 contentId: ${seedContentIds[1]}`,
+      `既存 contentId: ${seedContentIds[2]}`,
+    ]);
+
+    await page.click('#title', { clickCount: 3 });
+    await page.type('#title', updatedTitle);
+
+    await page.click('button[data-remove-tag="1"]');
+    await page.click('button[data-remove-tag="0"]');
+
+    await page.type('#category-input', updatedTags[0].category);
+    await page.type('#tag-input', updatedTags[0].label);
+    await page.click('#add-tag-button');
+
+    await page.type('#category-input', updatedTags[1].category);
+    await page.type('#tag-input', updatedTags[1].label);
+    await page.click('#add-tag-button');
+
+    await page.click('button[data-move-down="0"]');
+    await page.click('button[data-move-up="2"]');
+
+    const patchResponsePromise = page.waitForResponse(response => {
+      return response.url() === `${baseUrl}/api/media/${seedMediaId}` && response.request().method() === 'PATCH';
+    });
+
+    await page.click('button[type="submit"]');
+
+    const patchResponse = await patchResponsePromise;
+    expect(patchResponse.status()).toBe(200);
+    await expect(patchResponse.json()).resolves.toEqual({ code: 0 });
+
+    const successMessage = await page.$eval('#form-message', element => element.textContent.trim());
+    expect(successMessage).toBe('メディアを更新しました。');
+
+    await page.goto(`${baseUrl}/screen/detail/${seedMediaId}`, { waitUntil: 'networkidle0' });
+    const detailText = await page.evaluate(() => document.body.innerText);
+    expect(detailText).toContain(updatedTitle);
+    expect(detailText).toContain('ジャンル:更新タグ');
+    expect(detailText).toContain('連載:連載中');
+
+    await page.goto(`${baseUrl}/screen/summary`, { waitUntil: 'networkidle0' });
+    const summaryText = await page.evaluate(() => document.body.innerText);
+    expect(summaryText).toContain(updatedTitle);
+    expect(summaryText).toContain('ジャンル:更新タグ');
+    expect(summaryText).toContain('連載:連載中');
+
+    const expectedContentIdsAfterReorder = [
+      seedContentIds[1],
+      seedContentIds[2],
+      seedContentIds[0],
+    ];
+
+    await page.goto(`${baseUrl}/screen/viewer/${seedMediaId}/1`, { waitUntil: 'networkidle0' });
+    await assertViewerState({
+      page,
+      baseUrl,
+      mediaId: seedMediaId,
+      mediaPage: 1,
+      expectedContentId: expectedContentIdsAfterReorder[0],
+    });
+
+    await Promise.all([
+      page.waitForNavigation({ waitUntil: 'networkidle0' }),
+      page.click(`nav.footer-nav a[href="/screen/viewer/${seedMediaId}/2"]`),
+    ]);
+    await assertViewerState({
+      page,
+      baseUrl,
+      mediaId: seedMediaId,
+      mediaPage: 2,
+      expectedContentId: expectedContentIdsAfterReorder[1],
+    });
+
+    await Promise.all([
+      page.waitForNavigation({ waitUntil: 'networkidle0' }),
+      page.click(`nav.footer-nav a[href="/screen/viewer/${seedMediaId}/3"]`),
+    ]);
+    await assertViewerState({
+      page,
+      baseUrl,
+      mediaId: seedMediaId,
+      mediaPage: 3,
+      expectedContentId: expectedContentIdsAfterReorder[2],
+    });
+  });
+});


### PR DESCRIPTION
### Motivation
- 編集画面はタイトル・タグ・ページ順が UI と API を跨いで連動するため、ユーザー操作での回帰を検出する E2E テストが必要である。
- タイトル・タグ・並び替えの更新が一覧・詳細・ビューアーへ正しく反映されることを自動で担保するためのシナリオを追加する。 

### Description
- `__tests__/large/e2e/edit/edit-update-media.large.test.js` を新規作成し、seed データ（3 ページ分コンテンツ＋複数タグ）を投入して編集画面の初期表示を検証するテストを追加した。 
- 編集操作としてタイトル編集、既存タグの削除、新しいタグの追加、コンテンツの並び替え（`data-move-up` / `data-move-down` ボタン）を自動操作するよう実装した。 
- 更新送信時に `PATCH /api/media/:mediaId` を待ち受けて `status === 200` と `body.code === 0` を検証し、フォーム上の成功メッセージ確認も行う。 
- 更新後に `/screen/detail/:mediaId` と `/screen/summary` でタイトル・タグの反映を確認し、`/screen/viewer/:mediaId/:mediaPage` でページ順が編集結果どおりに反映されていることを `assertViewerState` で検証する（既存の viewer テスト検証ロジックを再利用）。

### Testing
- `npm test -- __tests__/large/e2e/edit/edit-update-media.large.test.js` を実行しようとしたが、実行環境で `jest` が見つからず失敗した（`sh: 1: jest: not found`）。
- 依存関係の取得を試みたが、`npm install --include=dev` が環境依存の状態不整合（`ENOTEMPTY`）や長時間のインストールで完了せず検証を継続できなかった。 
- 個別に `jest` をインストールしようとしたが、レジストリアクセス制限により `403 Forbidden` で失敗したためテストは実行できなかった。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2b405a9c0832bb41bc8368554d4bf)