### PR TITLE
fix: サマリー画面の並び順変更で先頭ページに戻らない不具合を修正

### DIFF
--- a/__tests__/small/controller/router/screen/setRouterScreenSummaryGet.test.js
+++ b/__tests__/small/controller/router/screen/setRouterScreenSummaryGet.test.js
@@ -71,6 +71,7 @@ describe('setRouterScreenSummaryGet', () => {
     expect(bodyText).toContain('<title>メディア一覧</title>');
     expect(bodyText).toContain('タイトル1');
     expect(bodyText).toContain('/screen/detail/media-001');
+    expect(bodyText).toContain('name="start" value="1"');
     expect(searchMediaService.execute).toHaveBeenCalledWith(expect.objectContaining({
       title: '太郎',
       tags: [{ category: '作者', label: '山田' }],

--- a/src/views/screen/summary.ejs
+++ b/src/views/screen/summary.ejs
@@ -78,7 +78,7 @@
             <p><strong><%= totalCount %></strong> 件</p>
             <form class="sort-form" method="get" action="/screen/summary">
               <input type="hidden" name="summaryPage" value="1" />
-              <input type="hidden" name="start" value="<%= currentConditions.start %>" />
+              <input type="hidden" name="start" value="1" />
               <input type="hidden" name="size" value="<%= currentConditions.size %>" />
               <% if (currentConditions.title) { %><input type="hidden" name="title" value="<%= currentConditions.title %>" /><% } %>
               <% currentConditions.tags.forEach((tag) => { %>


### PR DESCRIPTION
### Motivation
- サマリー画面の並び替えフォームが `summaryPage=1` を送信している一方で `start` に現在ページの値を保持しており、サーバー側で `start` が優先されるため並び順変更時に先頭ページへ戻らない不整合を解消するため。 

### Description
- `src/views/screen/summary.ejs` の並び替えフォームで hidden パラメータ `start` を ` <%= currentConditions.start %>` から固定値 `1` に変更し、回帰防止のため `__tests__/small/controller/router/screen/setRouterScreenSummaryGet.test.js` にフォーム内に `name="start" value="1"` が描画されることを検証するアサーションを追加した。 

### Testing
- `node --check __tests__/small/controller/router/screen/setRouterScreenSummaryGet.test.js` を実行して該当テストファイルの構文チェックは成功した。 
- `npm run test:small` および `npx jest` は環境依存（`cross-env` が見つからない、または npm レジストリアクセス制限）により実行できなかったため、Jest による完全なテスト実行は未確認である。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd61ec96b4832ba61d750b5d90ae07)