### PR TITLE
test: Docker Compose起動確認をGitHub Actionsで自動検証する

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.gitignore
+node_modules
+npm-debug.log*
+coverage
+__tests__
+doc
+var

--- a/.github/workflows/docker-compose-ci.yml
+++ b/.github/workflows/docker-compose-ci.yml
@@ -1,0 +1,47 @@
+name: docker-compose-ci
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - master
+
+jobs:
+  docker-compose-smoke-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build and start services
+        run: docker compose up --build -d
+
+      - name: Wait for app
+        run: |
+          for i in $(seq 1 30); do
+            if curl -fsS http://localhost:3000/screen/login > /dev/null; then
+              echo "app is ready"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "app did not become ready"
+          docker compose logs app db
+          exit 1
+
+      - name: Smoke test login page
+        run: |
+          status=$(curl -o /tmp/login.html -s -w '%{http_code}' http://localhost:3000/screen/login)
+          test "$status" = "200"
+          grep -q "login" /tmp/login.html
+
+      - name: Show logs on failure
+        if: failure()
+        run: docker compose logs app db
+
+      - name: Stop services
+        if: always()
+        run: docker compose down -v

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
+RUN npm install pg pg-hstore --omit=dev --no-save
+
+COPY src ./src
+COPY scripts ./scripts
+
+RUN mkdir -p /app/var/contents /app/var/logs
+
+ENV NODE_ENV=production
+ENV PORT=3000
+EXPOSE 3000
+
+CMD ["node", "./src/server.js"]

--- a/doc/README.md
+++ b/doc/README.md
@@ -39,6 +39,35 @@ MediaViewerは、漫画・動画などの複数種類のメディアを閲覧可
   - `seed:user` を実行してから通常起動する。
   - 初期セットアップや手動確認用。
 
+## Docker運用（PostgreSQL）
+
+### 構成
+- `docker-compose.yml`
+  - `app`: Node.js アプリケーション
+  - `db`: PostgreSQL 16
+- `Dockerfile`
+  - 本番実行向け（`NODE_ENV=production`）
+  - 依存は `npm ci --omit=dev` で導入
+
+### 起動方法
+1. プロジェクトルートで以下を実行する
+   - `docker compose up --build -d`
+2. アプリケーションにアクセスする
+   - `http://localhost:3000`
+
+### 停止方法
+- `docker compose down`
+
+### 注意事項
+- Docker構成では DB を PostgreSQL として起動するため、アプリ側は `DATABASE_DIALECT=postgres` で起動する。
+- DB接続は `DATABASE_URL` もしくは `DATABASE_HOST` / `DATABASE_PORT` / `DATABASE_NAME` / `DATABASE_USERNAME` / `DATABASE_PASSWORD` で指定可能。
+- `seed:user` は production 環境では禁止のため、Dockerの `app` コンテナ起動時には実行しない。
+
+### GitHub Actionsでの確認
+- `.github/workflows/docker-compose-ci.yml` で Docker Compose の起動確認を自動実行する。
+- CI では `docker compose up --build -d` 後に `http://localhost:3000/screen/login` へ疎通し、HTTP 200 を確認する。
+- 失敗時は `app` / `db` のログを出力する。
+
 ### 利用可能環境と禁止事項
 - `seed:user` / `start:seeded` は **production環境での実行禁止**。
 - seed実行時は、冒頭で production ガードが動作し、

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,48 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: mangaviewer-app
+    environment:
+      PORT: 3000
+      NODE_ENV: production
+      DATABASE_DIALECT: postgres
+      DATABASE_HOST: db
+      DATABASE_PORT: 5432
+      DATABASE_NAME: mangaviewer
+      DATABASE_USERNAME: mangaviewer
+      DATABASE_PASSWORD: mangaviewer
+      CONTENT_ROOT_DIRECTORY: /app/var/contents
+      LOG_FILE_PATH: /app/var/logs/mangaviewer.log
+      FIXED_LOGIN_USER_ID: admin
+      FIXED_LOGIN_USERNAME: admin
+      FIXED_LOGIN_PASSWORD: admin
+    ports:
+      - "3000:3000"
+    volumes:
+      - app_contents:/app/var/contents
+      - app_logs:/app/var/logs
+    depends_on:
+      db:
+        condition: service_healthy
+
+  db:
+    image: postgres:16-alpine
+    container_name: mangaviewer-db
+    environment:
+      POSTGRES_DB: mangaviewer
+      POSTGRES_USER: mangaviewer
+      POSTGRES_PASSWORD: mangaviewer
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U mangaviewer -d mangaviewer"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+volumes:
+  postgres_data:
+  app_contents:
+  app_logs:

--- a/src/app/createDependencies.js
+++ b/src/app/createDependencies.js
@@ -60,8 +60,37 @@ const parseLogOutputs = value => String(value || '')
   .map(entry => entry.trim())
   .filter(entry => entry.length > 0);
 
+const createSequelize = env => {
+  if (env.databaseDialect === 'postgres') {
+    if (env.databaseUrl) {
+      return new Sequelize(env.databaseUrl, {
+        dialect: 'postgres',
+        logging: false,
+      });
+    }
+
+    return new Sequelize({
+      dialect: 'postgres',
+      host: env.databaseHost || 'db',
+      port: env.databasePort || 5432,
+      database: env.databaseName || 'mangaviewer',
+      username: env.databaseUsername || 'mangaviewer',
+      password: env.databasePassword || 'mangaviewer',
+      logging: false,
+    });
+  }
+
+  return new Sequelize({
+    dialect: 'sqlite',
+    storage: env.databaseStoragePath,
+    logging: false,
+  });
+};
+
 const createDependencies = (env = {}) => {
-  ensureParentDirectory(env.databaseStoragePath);
+  if (env.databaseDialect !== 'postgres') {
+    ensureParentDirectory(env.databaseStoragePath);
+  }
   ensureDirectory(env.contentRootDirectory);
   const resolvedLogFilePath = env.logFilePath || path.join(process.cwd(), 'var', 'logs', 'mangaviewer.log');
   ensureParentDirectory(resolvedLogFilePath);
@@ -73,11 +102,7 @@ const createDependencies = (env = {}) => {
     outputs: logOutputs.length > 0 ? logOutputs : ['console', 'file'],
   });
 
-  const sequelize = new Sequelize({
-    dialect: 'sqlite',
-    storage: env.databaseStoragePath,
-    logging: false,
-  });
+  const sequelize = createSequelize(env);
 
   const unitOfWork = new SequelizeUnitOfWork({ sequelize });
   const mediaRepository = new SequelizeMediaRepository({

--- a/src/server.js
+++ b/src/server.js
@@ -10,6 +10,13 @@ const parseSessionPaths = value => (value || '')
 
 const createEnv = source => ({
   port: Number.parseInt(source.PORT, 10) || 3000,
+  databaseDialect: source.DATABASE_DIALECT || 'sqlite',
+  databaseUrl: source.DATABASE_URL || '',
+  databaseHost: source.DATABASE_HOST || '',
+  databasePort: Number.parseInt(source.DATABASE_PORT, 10) || 5432,
+  databaseName: source.DATABASE_NAME || '',
+  databaseUsername: source.DATABASE_USERNAME || '',
+  databasePassword: source.DATABASE_PASSWORD || '',
   databaseStoragePath: source.DATABASE_STORAGE_PATH
     || path.join(process.cwd(), 'var', 'data', 'mangaviewer.sqlite'),
   contentRootDirectory: source.CONTENT_ROOT_DIRECTORY


### PR DESCRIPTION
## 概要
Docker本番構成（app + PostgreSQL）がCI上で起動可能であることを、GitHub Actionsで継続的に確認できるようにしました。

## 変更内容
- `.github/workflows/docker-compose-ci.yml` を追加
  - `docker compose up --build -d` でサービス起動
  - `http://localhost:3000/screen/login` への疎通を待機
  - `/screen/login` が HTTP 200 を返すことをスモークテスト
  - 失敗時に `app` / `db` ログを出力
  - 最後に `docker compose down -v` でクリーンアップ
- `doc/README.md`
  - GitHub Actionsでの確認手順を追記

## Why
ローカルでのみDocker起動確認していると、依存更新や設定変更で本番想定構成が壊れても気づきにくいため、PR/Push時に自動で検証できる状態にする必要がありました。

## 補足
今回のCIは「Docker環境でアプリが起動し、主要画面へアクセスできるか」の確認です。必要であれば次段階で、コンテナ内でのテストスイート実行やAPIシナリオ追加にも拡張できます。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce1d78c100832ba7b3bd2a0d6588bd)