### PR TITLE
feat: DBユーザーの追加・一覧取得・削除を実行するnpm scriptsを追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,10 @@
     "watch-api": "node ./node_modules/aglio/bin/aglio.js -i ./doc/5_api/openapi/openapi.yaml -s",
     "dev:entry": "cross-env FIXED_LOGIN_USER_ID=admin FIXED_LOGIN_USERNAME=admin FIXED_LOGIN_PASSWORD=admin DEV_SESSION_TOKEN=dev-token DEV_SESSION_USER_ID=admin-dev DEV_SESSION_TTL_MS=86400000 DEV_SESSION_PATHS=/screen/entry,/api/media nodemon ./src/server.js --watch ./src",
     "seed:user": "node ./scripts/seed-fixed-user.js",
-    "start:seeded": "npm run seed:user && npm run start"
+    "start:seeded": "npm run seed:user && npm run start",
+    "db:user:add": "node ./scripts/db-user-add.js",
+    "db:user:list": "node ./scripts/db-user-list.js",
+    "db:user:delete": "node ./scripts/db-user-delete.js"
   },
   "author": "",
   "license": "MIT",

--- a/scripts/db-user-add.js
+++ b/scripts/db-user-add.js
@@ -1,0 +1,61 @@
+const path = require('path');
+
+const { Sequelize, DataTypes } = require('sequelize');
+
+const createDatabaseStoragePath = source => source.DATABASE_STORAGE_PATH
+  || path.join(process.cwd(), 'var', 'data', 'mangaviewer.sqlite');
+
+const printUsage = () => {
+  console.log('使い方: npm run db:user:add -- <userId>');
+  console.log('例: npm run db:user:add -- admin');
+};
+
+const addUser = async (argv = process.argv.slice(2), source = process.env) => {
+  const [userId] = argv;
+
+  if (typeof userId !== 'string' || userId.trim().length === 0) {
+    printUsage();
+    return false;
+  }
+
+  const sequelize = new Sequelize({
+    dialect: 'sqlite',
+    storage: createDatabaseStoragePath(source),
+    logging: false,
+  });
+
+  const UserModel = sequelize.define('user', {
+    user_id: { type: DataTypes.STRING, primaryKey: true },
+  }, { tableName: 'user', timestamps: false });
+
+  try {
+    await sequelize.sync();
+    const normalizedUserId = userId.trim();
+    const [record, created] = await UserModel.findOrCreate({
+      where: { user_id: normalizedUserId },
+      defaults: { user_id: normalizedUserId },
+    });
+
+    if (created) {
+      console.log(`[db:user:add] 作成しました userId=${record.user_id}`);
+    } else {
+      console.log(`[db:user:add] 既に存在します userId=${record.user_id}`);
+    }
+
+    return created;
+  } finally {
+    await sequelize.close();
+  }
+};
+
+if (require.main === module) {
+  addUser().catch(error => {
+    console.error('[db:user:add] 失敗', error.message);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  addUser,
+  createDatabaseStoragePath,
+};

--- a/scripts/db-user-delete.js
+++ b/scripts/db-user-delete.js
@@ -1,0 +1,61 @@
+const path = require('path');
+
+const { Sequelize, DataTypes } = require('sequelize');
+
+const createDatabaseStoragePath = source => source.DATABASE_STORAGE_PATH
+  || path.join(process.cwd(), 'var', 'data', 'mangaviewer.sqlite');
+
+const printUsage = () => {
+  console.log('使い方: npm run db:user:delete -- <userId>');
+  console.log('例: npm run db:user:delete -- admin');
+};
+
+const deleteUser = async (argv = process.argv.slice(2), source = process.env) => {
+  const [userId] = argv;
+
+  if (typeof userId !== 'string' || userId.trim().length === 0) {
+    printUsage();
+    return false;
+  }
+
+  const sequelize = new Sequelize({
+    dialect: 'sqlite',
+    storage: createDatabaseStoragePath(source),
+    logging: false,
+  });
+
+  const UserModel = sequelize.define('user', {
+    user_id: { type: DataTypes.STRING, primaryKey: true },
+  }, { tableName: 'user', timestamps: false });
+
+  try {
+    await sequelize.sync();
+
+    const normalizedUserId = userId.trim();
+    const deletedCount = await UserModel.destroy({
+      where: { user_id: normalizedUserId },
+    });
+
+    if (deletedCount > 0) {
+      console.log(`[db:user:delete] 削除しました userId=${normalizedUserId}`);
+      return true;
+    }
+
+    console.log(`[db:user:delete] 対象が存在しません userId=${normalizedUserId}`);
+    return false;
+  } finally {
+    await sequelize.close();
+  }
+};
+
+if (require.main === module) {
+  deleteUser().catch(error => {
+    console.error('[db:user:delete] 失敗', error.message);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  deleteUser,
+  createDatabaseStoragePath,
+};

--- a/scripts/db-user-list.js
+++ b/scripts/db-user-list.js
@@ -1,0 +1,50 @@
+const path = require('path');
+
+const { Sequelize, DataTypes } = require('sequelize');
+
+const createDatabaseStoragePath = source => source.DATABASE_STORAGE_PATH
+  || path.join(process.cwd(), 'var', 'data', 'mangaviewer.sqlite');
+
+const listUsers = async (source = process.env) => {
+  const sequelize = new Sequelize({
+    dialect: 'sqlite',
+    storage: createDatabaseStoragePath(source),
+    logging: false,
+  });
+
+  const UserModel = sequelize.define('user', {
+    user_id: { type: DataTypes.STRING, primaryKey: true },
+  }, { tableName: 'user', timestamps: false });
+
+  try {
+    await sequelize.sync();
+    const users = await UserModel.findAll({
+      attributes: ['user_id'],
+      order: [['user_id', 'ASC']],
+    });
+
+    if (users.length === 0) {
+      console.log('[db:user:list] ユーザーは登録されていません');
+      return [];
+    }
+
+    users.forEach((user, index) => {
+      console.log(`${index + 1}. ${user.user_id}`);
+    });
+    return users.map(user => user.user_id);
+  } finally {
+    await sequelize.close();
+  }
+};
+
+if (require.main === module) {
+  listUsers().catch(error => {
+    console.error('[db:user:list] 失敗', error.message);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  listUsers,
+  createDatabaseStoragePath,
+};


### PR DESCRIPTION
## 概要
- `package.json` に DB ユーザー管理用の scripts を追加
  - `db:user:add`
  - `db:user:list`
  - `db:user:delete`
- 各 script 実体を `scripts/` 配下に追加
  - `scripts/db-user-add.js`
  - `scripts/db-user-list.js`
  - `scripts/db-user-delete.js`

## 変更内容
- 追加・削除スクリプトは必須引数 `userId` が不足している場合に、使い方をコンソールへ表示
- 一覧スクリプトは登録済みユーザー ID を昇順で表示
- いずれも `DATABASE_STORAGE_PATH` 未指定時は既定の SQLite パス (`var/data/mangaviewer.sqlite`) を使用

## なぜこの変更が必要か
- DB 操作を npm scripts 経由で標準化し、手動 SQL の実行負荷とミスを減らすため
- 引数不足時に使い方を明示し、運用・開発時の実行ミスを即座に自己解決できるようにするめ

## 確認
- `node --check` による追加スクリプトの構文チェックを実施
- `package.json` は JSON パースで妥当性を確認

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce98311e2c832b885a89d95f964bca)