### PR TITLE
fix: エラーログにスタックトレースを含めて発生箇所を特定できるようにする

### DIFF
--- a/src/app/setupRoutes.js
+++ b/src/app/setupRoutes.js
@@ -102,6 +102,7 @@ const setupRoutes = (app, { env: _env, dependencies } = {}) => {
       path: req.originalUrl,
       user_id: req.context?.userId || 'anonymous',
       message: error?.message,
+      error,
     });
     res.status(500).json({
       message: 'Internal Server Error',

--- a/src/controller/api/LoginPostController.js
+++ b/src/controller/api/LoginPostController.js
@@ -58,6 +58,7 @@ class LoginPostController {
       logger?.error('auth.login.error', {
         request_id: requestId,
         message: error?.message,
+        error,
       });
       return this.#fail(res);
     }

--- a/src/controller/api/LogoutPostController.js
+++ b/src/controller/api/LogoutPostController.js
@@ -35,6 +35,7 @@ class LogoutPostController {
       logger?.error('auth.logout.error', {
         request_id: requestId,
         message: error?.message,
+        error,
       });
       return this.#fail(res);
     }

--- a/src/controller/api/MediaPatchController.js
+++ b/src/controller/api/MediaPatchController.js
@@ -14,6 +14,7 @@ class MediaPatchController {
   }
 
   async execute(req, res) {
+    const logger = req.app?.locals?.dependencies?.logger;
     try {
       const mediaId = req?.params?.mediaId;
       const title = req?.body?.title;
@@ -41,6 +42,12 @@ class MediaPatchController {
         code: 0,
       });
     } catch (error) {
+      logger?.error('media.update.error', {
+        request_id: req.context?.requestId,
+        target_id: req?.params?.mediaId,
+        message: error?.message,
+        error,
+      });
       return this.#fail(res);
     }
   }

--- a/src/controller/api/MediaPostController.js
+++ b/src/controller/api/MediaPostController.js
@@ -14,6 +14,7 @@ class MediaPostController {
   }
 
   async execute(req, res) {
+    const logger = req.app?.locals?.dependencies?.logger;
     try {
       const title = req?.body?.title;
       const tags = req?.body?.tags;
@@ -39,6 +40,11 @@ class MediaPostController {
         mediaId: output.mediaId,
       });
     } catch (error) {
+      logger?.error('media.register.error', {
+        request_id: req.context?.requestId,
+        message: error?.message,
+        error,
+      });
       return this.#fail(res);
     }
   }

--- a/src/controller/middleware/ContentSaveMiddleware.js
+++ b/src/controller/middleware/ContentSaveMiddleware.js
@@ -10,6 +10,7 @@ class ContentSaveMiddleware {
   }
 
   async execute(req, res, next) {
+    const logger = req.app?.locals?.dependencies?.logger;
     try {
       await this.#executeUpload(req, res);
 
@@ -24,6 +25,11 @@ class ContentSaveMiddleware {
 
       return undefined;
     } catch (error) {
+      logger?.error('content.upload.error', {
+        request_id: req?.context?.requestId,
+        message: error?.message,
+        error,
+      });
       return this.#fail(res);
     }
   }

--- a/src/controller/router/screen/setRouterScreenEditGet.js
+++ b/src/controller/router/screen/setRouterScreenEditGet.js
@@ -7,6 +7,7 @@ const setRouterScreenEditGet = ({ router, authResolver, getMediaDetailService })
   router.get('/screen/edit/:mediaId', ...[
     auth.execute.bind(auth),
     async (req, res, next) => {
+      const logger = req.app?.locals?.dependencies?.logger;
       try {
         const result = await getMediaDetailService.execute(new Input({
           mediaId: req.params.mediaId,
@@ -23,6 +24,13 @@ const setRouterScreenEditGet = ({ router, authResolver, getMediaDetailService })
           },
         });
       } catch (error) {
+        logger?.error('screen.edit.error', {
+          request_id: req.context?.requestId,
+          user_id: req.context?.userId || 'anonymous',
+          target_id: req.params?.mediaId,
+          message: error?.message,
+          error,
+        });
         next(error);
       }
     },

--- a/src/controller/router/screen/setRouterScreenFavoriteGet.js
+++ b/src/controller/router/screen/setRouterScreenFavoriteGet.js
@@ -29,6 +29,7 @@ const setRouterScreenFavoriteGet = ({ router, authResolver, getFavoriteSummaries
   router.get('/screen/favorite', ...[
     auth.execute.bind(auth),
     async (req, res, next) => {
+      const logger = req.app?.locals?.dependencies?.logger;
       try {
         const sort = typeof req.query.sort === 'string' && Object.values(SORT_TYPES).includes(req.query.sort)
           ? req.query.sort
@@ -57,6 +58,12 @@ const setRouterScreenFavoriteGet = ({ router, authResolver, getFavoriteSummaries
           sortOptions: SORT_OPTIONS,
         });
       } catch (error) {
+        logger?.error('screen.favorite.error', {
+          request_id: req.context?.requestId,
+          user_id: req.context?.userId || 'anonymous',
+          message: error?.message,
+          error,
+        });
         next(error);
       }
     },

--- a/src/controller/router/screen/setRouterScreenQueueGet.js
+++ b/src/controller/router/screen/setRouterScreenQueueGet.js
@@ -30,6 +30,7 @@ const setRouterScreenQueueGet = ({ router, authResolver, getQueueService }) => {
   router.get('/screen/queue', ...[
     auth.execute.bind(auth),
     async (req, res, next) => {
+      const logger = req.app?.locals?.dependencies?.logger;
       try {
         const queuePage = Math.max(Number.parseInt(req.query.queuePage ?? '1', 10) || 1, 1);
         const sort = typeof req.query.sort === 'string' && SORT_TYPES_BY_QUERY[req.query.sort]
@@ -65,6 +66,12 @@ const setRouterScreenQueueGet = ({ router, authResolver, getQueueService }) => {
           ],
         });
       } catch (error) {
+        logger?.error('screen.queue.error', {
+          request_id: req.context?.requestId,
+          user_id: req.context?.userId || 'anonymous',
+          message: error?.message,
+          error,
+        });
         next(error);
       }
     },

--- a/src/controller/router/screen/setRouterScreenSummaryGet.js
+++ b/src/controller/router/screen/setRouterScreenSummaryGet.js
@@ -97,6 +97,7 @@ const setRouterScreenSummaryGet = ({ router, authResolver, searchMediaService })
   router.get('/screen/summary', ...[
     auth.execute.bind(auth),
     async (req, res, next) => {
+      const logger = req.app?.locals?.dependencies?.logger;
       try {
         const range = normalizeSearchRange({
           summaryPage: req.query.summaryPage,
@@ -145,6 +146,12 @@ const setRouterScreenSummaryGet = ({ router, authResolver, searchMediaService })
           ],
         });
       } catch (error) {
+        logger?.error('screen.summary.error', {
+          request_id: req.context?.requestId,
+          user_id: req.context?.userId || 'anonymous',
+          message: error?.message,
+          error,
+        });
         next(error);
       }
     },

--- a/src/controller/router/user/setRouterApiFavoriteAndQueue.js
+++ b/src/controller/router/user/setRouterApiFavoriteAndQueue.js
@@ -31,6 +31,7 @@ const setRouterApiFavoriteAndQueue = ({
         user_id: getUserId(req),
         target_id: req.params.mediaId,
         message: error?.message,
+        error,
       });
       next(error);
     }
@@ -52,6 +53,7 @@ const setRouterApiFavoriteAndQueue = ({
         user_id: getUserId(req),
         target_id: req.params.mediaId,
         message: error?.message,
+        error,
       });
       next(error);
     }
@@ -73,6 +75,7 @@ const setRouterApiFavoriteAndQueue = ({
         user_id: getUserId(req),
         target_id: req.params.mediaId,
         message: error?.message,
+        error,
       });
       next(error);
     }
@@ -94,6 +97,7 @@ const setRouterApiFavoriteAndQueue = ({
         user_id: getUserId(req),
         target_id: req.params.mediaId,
         message: error?.message,
+        error,
       });
       next(error);
     }

--- a/src/shared/AppLogger.js
+++ b/src/shared/AppLogger.js
@@ -31,6 +31,15 @@ const sanitize = (value, key = '') => {
     return value.map(entry => sanitize(entry));
   }
 
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: value.message,
+      stack: value.stack,
+      ...(value.cause ? { cause: sanitize(value.cause, 'cause') } : {}),
+    };
+  }
+
   if (!value || typeof value !== 'object') {
     return SENSITIVE_KEY_PATTERNS.some(pattern => pattern.test(key))
       ? '[REDACTED]'


### PR DESCRIPTION
## 概要
- `src/shared/AppLogger.js` の `sanitize` に `Error` インスタンス専用の処理を追加
- `name` / `message` / `stack` をログに残し、`cause` がある場合は再帰的に記録

## 背景（Why）
既存実装では `Error` を通常オブジェクトとして扱っていたため、列挙可能プロパティの都合でスタックトレースが失われ、エラー発生箇所の特定が困難でした。

## 変更点
- `sanitize(value, key)` の先頭付近に `value instanceof Error` 分岐を追加
- ログ出力時に `stack` を含めることで障害調査性を向上
- ネストした原因例外 (`cause`) も同様にサニタイズして保持

## 影響範囲
- ログ出力内容のみ（機能仕様変更なし）
- エラー発生時のログ情報量が増加

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cea3d7121c832baa4d717c8aa90ce5)