### PR TITLE
Change default content root directory to public/contents

### DIFF
--- a/doc/4_application/app/server/readme.md
+++ b/doc/4_application/app/server/readme.md
@@ -14,7 +14,7 @@
 | --- | --- | --- | --- |
 | `PORT` | `port` | `parseInt(..., 10) || 3000` | HTTP listen ポート |
 | `DATABASE_STORAGE_PATH` | `databaseStoragePath` | `var/data/mangaviewer.sqlite` | SQLite 保存先 |
-| `CONTENT_ROOT_DIRECTORY` | `contentRootDirectory` | `var/contents` | コンテンツ保存先 |
+| `CONTENT_ROOT_DIRECTORY` | `contentRootDirectory` | `public/contents` | コンテンツ保存先 |
 | `DEV_SESSION_TOKEN` | `devSessionToken` | 空文字 | 開発用固定セッショントークン |
 | `DEV_SESSION_USER_ID` | `devSessionUserId` | 空文字 | 開発用固定セッションの利用者ID |
 | `DEV_SESSION_TTL_MS` | `devSessionTtlMs` | `parseInt(..., 10) || 0` | 開発用固定セッションの TTL |

--- a/src/server.js
+++ b/src/server.js
@@ -20,7 +20,7 @@ const createEnv = source => ({
   databaseStoragePath: source.DATABASE_STORAGE_PATH
     || path.join(process.cwd(), 'var', 'data', 'mangaviewer.sqlite'),
   contentRootDirectory: source.CONTENT_ROOT_DIRECTORY
-    || path.join(process.cwd(), 'var', 'contents'),
+    || path.join(process.cwd(), 'public', 'contents'),
   devSessionToken: source.DEV_SESSION_TOKEN || '',
   devSessionUserId: source.DEV_SESSION_USER_ID || '',
   devSessionTtlMs: Number.parseInt(source.DEV_SESSION_TTL_MS, 10) || 0,


### PR DESCRIPTION
### Motivation
- Use `public/contents` as the default storage location for application content instead of `var/contents` to match the public/static asset layout and updated documentation. 

### Description
- Updated `contentRootDirectory` fallback in `src/server.js` from `path.join(process.cwd(), 'var', 'contents')` to `path.join(process.cwd(), 'public', 'contents')` and synchronized the change in `doc/4_application/app/server/readme.md`. 

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0bc25d6e0832bbb0b26f678d2383b)