### PR TITLE
feat: 共通ナビに「メディア検索」リンクを追加

### DIFF
--- a/__tests__/medium/app/commonNavigator.integration.test.js
+++ b/__tests__/medium/app/commonNavigator.integration.test.js
@@ -49,6 +49,7 @@ describe('medium: common navigator integration', () => {
       expect(response.status).toBe(200);
       expect(response.bodyText).toContain('共通ナビゲーター');
       expect(response.bodyText).toContain('メディア一覧');
+      expect(response.bodyText).toContain('メディア検索');
       expect(response.bodyText).toContain('お気に入り');
       expect(response.bodyText).toContain('あとで見る');
       expect(response.bodyText).toContain('メディア登録');
@@ -71,6 +72,7 @@ describe('medium: common navigator integration', () => {
 
       expect(response.status).toBe(200);
       expect(response.bodyText).toContain('共通ナビゲーター');
+      expect(response.bodyText).toContain('メディア検索');
       expect(response.bodyText).not.toContain('>メディア登録<');
     } finally {
       await app.locals.close();

--- a/__tests__/small/views/partials/topNavigator.test.js
+++ b/__tests__/small/views/partials/topNavigator.test.js
@@ -12,6 +12,7 @@ describe('views/partials/topNavigator', () => {
 
     expect(html).toContain('aria-label="共通ナビゲーター"');
     expect(html).toContain('メディア一覧');
+    expect(html).toContain('メディア検索');
     expect(html).toContain('お気に入り');
     expect(html).toContain('あとで見る');
     expect(html).toContain('メディア登録');
@@ -26,8 +27,19 @@ describe('views/partials/topNavigator', () => {
     });
 
     expect(html).toContain('メディア一覧');
+    expect(html).toContain('メディア検索');
     expect(html).toContain('お気に入り');
     expect(html).toContain('href="/screen/favorite" aria-current=&#39;page&#39;');
     expect(html).not.toContain('メディア登録');
+  });
+
+  test('currentPath が /screen/search のときメディア検索リンクに aria-current が付く', async () => {
+    const html = await ejs.renderFile(templatePath, {
+      currentPath: '/screen/search',
+      currentUserId: 'user-001',
+    });
+
+    expect(html).toContain('href="/screen/search" aria-current=&#39;page&#39;');
+    expect(html).not.toContain('href="/screen/summary" aria-current=&#39;page&#39;');
   });
 });

--- a/src/views/partials/topNavigator.ejs
+++ b/src/views/partials/topNavigator.ejs
@@ -61,6 +61,7 @@
   <div class="common-nav__inner">
     <div class="common-nav__links">
       <a class="common-nav__link" href="/screen/summary" <%= isCurrent('/screen/summary') ? "aria-current='page'" : '' %>>メディア一覧</a>
+      <a class="common-nav__link" href="/screen/search" <%= isCurrent('/screen/search') ? "aria-current='page'" : '' %>>メディア検索</a>
       <a class="common-nav__link" href="/screen/favorite" <%= isCurrent('/screen/favorite') ? "aria-current='page'" : '' %>>お気に入り</a>
       <a class="common-nav__link" href="/screen/queue" <%= isCurrent('/screen/queue') ? "aria-current='page'" : '' %>>あとで見る</a>
       <% if (isAdminUser) { %>


### PR DESCRIPTION
### Motivation
- 「メディア一覧」付近に検索導線を追加し、頻繁に使う操作の動線を統一するため。 
- 共通ナビの表示回帰をテストで検知できるようにし、将来の変更による欠落や表示崩れを防止するため。 

### Description
- `src/views/partials/topNavigator.ejs` の `.common-nav__links` 内に `class=

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1087be408832b8b6c3a754a1f59dd)