### PR TITLE
feat: 共通ナビゲーターに検索リンクを追加

### DIFF
--- a/__tests__/medium/app/commonNavigator.integration.test.js
+++ b/__tests__/medium/app/commonNavigator.integration.test.js
@@ -48,6 +48,7 @@ describe('medium: common navigator integration', () => {
 
       expect(response.status).toBe(200);
       expect(response.bodyText).toContain('共通ナビゲーター');
+      expect(response.bodyText).toContain('検索');
       expect(response.bodyText).toContain('メディア一覧');
       expect(response.bodyText).toContain('お気に入り');
       expect(response.bodyText).toContain('あとで見る');
@@ -71,6 +72,7 @@ describe('medium: common navigator integration', () => {
 
       expect(response.status).toBe(200);
       expect(response.bodyText).toContain('共通ナビゲーター');
+      expect(response.bodyText).toContain('検索');
       expect(response.bodyText).not.toContain('>メディア登録<');
     } finally {
       await app.locals.close();

--- a/__tests__/small/views/partials/topNavigator.test.js
+++ b/__tests__/small/views/partials/topNavigator.test.js
@@ -11,6 +11,7 @@ describe('views/partials/topNavigator', () => {
     });
 
     expect(html).toContain('aria-label="共通ナビゲーター"');
+    expect(html).toContain('検索');
     expect(html).toContain('メディア一覧');
     expect(html).toContain('お気に入り');
     expect(html).toContain('あとで見る');
@@ -26,8 +27,18 @@ describe('views/partials/topNavigator', () => {
     });
 
     expect(html).toContain('メディア一覧');
+    expect(html).toContain('検索');
     expect(html).toContain('お気に入り');
     expect(html).toContain('href="/screen/favorite" aria-current=&#39;page&#39;');
     expect(html).not.toContain('メディア登録');
+  });
+
+  test('検索画面では検索リンクがカレント表示になる', async () => {
+    const html = await ejs.renderFile(templatePath, {
+      currentPath: '/screen/search',
+      currentUserId: 'user-001',
+    });
+
+    expect(html).toContain('href="/screen/search" aria-current=&#39;page&#39;');
   });
 });

--- a/src/views/partials/topNavigator.ejs
+++ b/src/views/partials/topNavigator.ejs
@@ -60,6 +60,7 @@
 <nav class="common-nav" aria-label="共通ナビゲーター">
   <div class="common-nav__inner">
     <div class="common-nav__links">
+      <a class="common-nav__link" href="/screen/search" <%= isCurrent('/screen/search') ? "aria-current='page'" : '' %>>検索</a>
       <a class="common-nav__link" href="/screen/summary" <%= isCurrent('/screen/summary') ? "aria-current='page'" : '' %>>メディア一覧</a>
       <a class="common-nav__link" href="/screen/favorite" <%= isCurrent('/screen/favorite') ? "aria-current='page'" : '' %>>お気に入り</a>
       <a class="common-nav__link" href="/screen/queue" <%= isCurrent('/screen/queue') ? "aria-current='page'" : '' %>>あとで見る</a>


### PR DESCRIPTION
### Motivation
- 一覧系画面から検索条件入力画面へ戻る導線がなかったため、ユーザビリティ向上のためにナビゲーターから直接検索画面へ遷移できるリンクを追加しました。 

### Description
- 共通ナビゲーター部分テンプレートに `/screen/search` への「検索」リンクを追加し、現在ページ判定で `aria-current='page'` を付与するようにしました (`src/views/partials/topNavigator.ejs`)。 
- 部分テンプレートの単体テストを更新して「検索」リンクの表示と検索画面でのカレント表示を検証するケースを追加しました (`__tests__/small/views/partials/topNavigator.test.js`)。 
- 共通ナビゲーターの統合テストに「検索」リンクの表示検証を追加しました (`__tests__/medium/app/commonNavigator.integration.test.js`)。 

### Testing
- `npx jest __tests__/small/views/partials/topNavigator.test.js __tests__/medium/app/commonNavigator.integration.test.js` を実行しようとしましたが、環境での `jest` 取得が `403 Forbidden` になり実行できませんでした（失敗）。 
- `npm run test:small -- __tests__/small/views/partials/topNavigator.test.js` を実行しようとしましたが、`cross-env: not found` により実行できませんでした（失敗）。 
- 変更はローカルでコミット済みで、テスト追加はソース上に反映されていますが、CI/環境依存のため自動テストの実行は現環境では完了していません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d10b682ba0832b847278fe8cdb2666)