### PR TITLE
fix: 大文字の16進contentIdでも公開パスを正しく解決するようにする

### DIFF
--- a/__tests__/small/controller/screen/publicContentPath.test.js
+++ b/__tests__/small/controller/screen/publicContentPath.test.js
@@ -6,6 +6,11 @@ describe('toPublicContentPath', () => {
       .toBe('/contents/aa/aa/aa/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
   });
 
+  test('32文字16進数IDが大文字でも小文字に正規化して公開パスへ変換する', () => {
+    expect(toPublicContentPath('AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'))
+      .toBe('/contents/aa/aa/aa/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+  });
+
   test('既に /contents 配下のパスはそのまま返す', () => {
     expect(toPublicContentPath('/contents/a/b/c.jpg')).toBe('/contents/a/b/c.jpg');
   });

--- a/src/controller/screen/publicContentPath.js
+++ b/src/controller/screen/publicContentPath.js
@@ -30,8 +30,9 @@ const toPublicContentPath = contentId => {
     return normalized;
   }
 
-  if ((/^[0-9a-f]{32}$/).test(normalized)) {
-    return `/contents/${buildShardedPath(normalized)}`;
+  if ((/^[0-9a-f]{32}$/i).test(normalized)) {
+    const canonicalContentId = normalized.toLowerCase();
+    return `/contents/${buildShardedPath(canonicalContentId)}`;
   }
 
   return `/contents/${normalized.replace(/^\/+/, '')}`;


### PR DESCRIPTION
### Motivation
- `toPublicContentPath` が小文字のみを32文字16進IDとして判定していたため、大文字IDが来るとシャーディング済みパスへ変換されず静的コンテンツ参照が壊れる可能性がありました。

### Description
- `src/controller/screen/publicContentPath.js` の正規表現を `/^[0-9a-f]{32}$/i` に変更し、判定時に `toLowerCase()` で canonical な ID に正規化してから `buildShardedPath` に渡すようにしました。
- 大文字16進ID入力時に小文字へ正規化してシャーディング付きパスへ変換されることを検証する単体テストを `__tests__/small/controller/screen/publicContentPath.test.js` に追加しました。

### Testing
- 追加した単体テストファイルはコミット済みですが、ローカルでのフルテスト実行は `cross-env: not found` や npm registry へのアクセス制限（403）により `jest` を実行できなかったため未実行です。 
- 手動で `node -e "const {toPublicContentPath}=require('./src/controller/screen/publicContentPath'); console.log(toPublicContentPath('AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'));"` を実行し期待どおり `/contents/aa/aa/aa/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa` が出力されることを確認しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3041e2980832b9184ecdb9e350f6b)