### PR TITLE
Normalize hex content IDs for public paths and correct DATE sort order in media queries

### DIFF
--- a/__tests__/small/controller/screen/publicContentPath.test.js
+++ b/__tests__/small/controller/screen/publicContentPath.test.js
@@ -6,6 +6,11 @@ describe('toPublicContentPath', () => {
       .toBe('/contents/aa/aa/aa/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
   });
 
+  test('32文字16進数IDが大文字でも小文字に正規化して公開パスへ変換する', () => {
+    expect(toPublicContentPath('AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'))
+      .toBe('/contents/aa/aa/aa/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+  });
+
   test('既に /contents 配下のパスはそのまま返す', () => {
     expect(toPublicContentPath('/contents/a/b/c.jpg')).toBe('/contents/a/b/c.jpg');
   });

--- a/__tests__/small/infrastructure/SequelizeMediaQueryRepository.test.js
+++ b/__tests__/small/infrastructure/SequelizeMediaQueryRepository.test.js
@@ -121,9 +121,9 @@ describe('SequelizeMediaQueryRepository', () => {
 
     try {
       await mediaRepository.sync();
-      await mediaRepository.save(createMedia({ mediaId: 'media-001', title: '作品1' }));
-      await mediaRepository.save(createMedia({ mediaId: 'media-002', title: '作品2' }));
-      await mediaRepository.save(createMedia({ mediaId: 'media-003', title: '作品3' }));
+      await mediaRepository.save(createMedia({ mediaId: 'media-001', title: '作品1', contents: ['/contents/works-1.jpg'] }));
+      await mediaRepository.save(createMedia({ mediaId: 'media-002', title: '作品2', contents: ['/contents/works-2.jpg'] }));
+      await mediaRepository.save(createMedia({ mediaId: 'media-003', title: '作品3', contents: ['/contents/works-3.jpg'] }));
 
       const ascResult = await queryRepository.search(new SearchCondition({
         title: '',

--- a/__tests__/small/infrastructure/SequelizeMediaQueryRepository.test.js
+++ b/__tests__/small/infrastructure/SequelizeMediaQueryRepository.test.js
@@ -113,6 +113,48 @@ describe('SequelizeMediaQueryRepository', () => {
     }
   });
 
+  test('search は DATE_ASC で古い登録順、DATE_DESC で新しい登録順を返す', async () => {
+    const sequelize = new Sequelize('sqlite::memory:', { logging: false });
+    const unitOfWork = new SequelizeUnitOfWork({ sequelize });
+    const mediaRepository = new SequelizeMediaRepository({ sequelize, unitOfWorkContext: unitOfWork });
+    const queryRepository = new SequelizeMediaQueryRepository({ sequelize });
+
+    try {
+      await mediaRepository.sync();
+      await mediaRepository.save(createMedia({ mediaId: 'media-001', title: '作品1' }));
+      await mediaRepository.save(createMedia({ mediaId: 'media-002', title: '作品2' }));
+      await mediaRepository.save(createMedia({ mediaId: 'media-003', title: '作品3' }));
+
+      const ascResult = await queryRepository.search(new SearchCondition({
+        title: '',
+        tags: [],
+        sortType: SortType.DATE_ASC,
+        start: 1,
+        size: 10,
+      }));
+      expect(ascResult.mediaOverviews.map(overview => overview.mediaId)).toEqual([
+        'media-001',
+        'media-002',
+        'media-003',
+      ]);
+
+      const descResult = await queryRepository.search(new SearchCondition({
+        title: '',
+        tags: [],
+        sortType: SortType.DATE_DESC,
+        start: 1,
+        size: 10,
+      }));
+      expect(descResult.mediaOverviews.map(overview => overview.mediaId)).toEqual([
+        'media-003',
+        'media-002',
+        'media-001',
+      ]);
+    } finally {
+      await sequelize.close();
+    }
+  });
+
   test.each([
     ['search', repository => repository.search({})],
     ['findOverviewsByMediaIds に配列以外', repository => repository.findOverviewsByMediaIds('media-001')],

--- a/src/controller/screen/publicContentPath.js
+++ b/src/controller/screen/publicContentPath.js
@@ -30,8 +30,9 @@ const toPublicContentPath = contentId => {
     return normalized;
   }
 
-  if ((/^[0-9a-f]{32}$/).test(normalized)) {
-    return `/contents/${buildShardedPath(normalized)}`;
+  if ((/^[0-9a-f]{32}$/i).test(normalized)) {
+    const canonicalContentId = normalized.toLowerCase();
+    return `/contents/${buildShardedPath(canonicalContentId)}`;
   }
 
   return `/contents/${normalized.replace(/^\/+/, '')}`;

--- a/src/infrastructure/SequelizeMediaQueryRepository.js
+++ b/src/infrastructure/SequelizeMediaQueryRepository.js
@@ -29,9 +29,9 @@ const extractMediaIdValue = mediaId => {
 const buildSortOrder = (sortType) => {
   switch (sortType) {
     case SortType.DATE_ASC:
-      return [['createdAtProxy', 'DESC'], ['media_id', 'ASC']];
-    case SortType.DATE_DESC:
       return [['createdAtProxy', 'ASC'], ['media_id', 'ASC']];
+    case SortType.DATE_DESC:
+      return [['createdAtProxy', 'DESC'], ['media_id', 'ASC']];
     case SortType.TITLE_ASC:
       return [['title', 'ASC'], ['media_id', 'ASC']];
     case SortType.TITLE_DESC:


### PR DESCRIPTION
### Motivation
- Ensure 32-character hex content IDs are treated case-insensitively and canonicalized to lowercase so public shard paths are consistent.
- Fix the date sorting behavior in media search so `DATE_ASC` returns older-first and `DATE_DESC` returns newer-first results.

### Description
- Make `toPublicContentPath` accept uppercase hex IDs by using a case-insensitive regex and lowercasing the ID before building the sharded `/contents/...` path.
- Adjust `buildSortOrder` in `SequelizeMediaQueryRepository` to return `[['createdAtProxy','ASC'], ['media_id','ASC']]` for `SortType.DATE_ASC` and `[['createdAtProxy','DESC'], ['media_id','ASC']]` for `SortType.DATE_DESC`.
- Add unit tests: one test verifying uppercase 32-char hex IDs are normalized to lowercase public paths, and one test asserting `search` returns the correct ordering for `DATE_ASC` and `DATE_DESC`.

### Testing
- Ran the unit test suite (`npm test`) including the modified small tests; all tests completed successfully.
- The `toPublicContentPath` uppercase-normalization test passed.
- The `SequelizeMediaQueryRepository` date-sort ordering test passed.
- No other automated test failures were observed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3041e2980832b9184ecdb9e350f6b)