### PR TITLE
Fix date sort direction, normalize uppercase content IDs, and update related tests

### DIFF
--- a/__tests__/small/controller/router/screen/setRouterScreenSearchGet.test.js
+++ b/__tests__/small/controller/router/screen/setRouterScreenSearchGet.test.js
@@ -81,8 +81,8 @@ describe('setRouterScreenSearchGet', () => {
       currentPath: '/screen/search',
       currentUserId: 'user-001',
       sortOptions: [
-        { value: 'date_asc', label: '登録の新しい順' },
-        { value: 'date_desc', label: '登録の古い順' },
+        { value: 'date_desc', label: '登録の新しい順' },
+        { value: 'date_asc', label: '登録の古い順' },
         { value: 'title_asc', label: 'タイトル名の昇順' },
         { value: 'title_desc', label: 'タイトル名の降順' },
         { value: 'random', label: 'ランダム' },

--- a/__tests__/small/controller/screen/publicContentPath.test.js
+++ b/__tests__/small/controller/screen/publicContentPath.test.js
@@ -6,6 +6,11 @@ describe('toPublicContentPath', () => {
       .toBe('/contents/aa/aa/aa/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
   });
 
+  test('32文字16進数IDが大文字でも小文字に正規化して公開パスへ変換する', () => {
+    expect(toPublicContentPath('AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'))
+      .toBe('/contents/aa/aa/aa/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+  });
+
   test('既に /contents 配下のパスはそのまま返す', () => {
     expect(toPublicContentPath('/contents/a/b/c.jpg')).toBe('/contents/a/b/c.jpg');
   });

--- a/__tests__/small/infrastructure/SequelizeMediaQueryRepository.test.js
+++ b/__tests__/small/infrastructure/SequelizeMediaQueryRepository.test.js
@@ -113,6 +113,48 @@ describe('SequelizeMediaQueryRepository', () => {
     }
   });
 
+  test('search は DATE_ASC で古い登録順、DATE_DESC で新しい登録順を返す', async () => {
+    const sequelize = new Sequelize('sqlite::memory:', { logging: false });
+    const unitOfWork = new SequelizeUnitOfWork({ sequelize });
+    const mediaRepository = new SequelizeMediaRepository({ sequelize, unitOfWorkContext: unitOfWork });
+    const queryRepository = new SequelizeMediaQueryRepository({ sequelize });
+
+    try {
+      await mediaRepository.sync();
+      await mediaRepository.save(createMedia({ mediaId: 'media-001', title: '作品1', contents: ['/contents/works-1.jpg'] }));
+      await mediaRepository.save(createMedia({ mediaId: 'media-002', title: '作品2', contents: ['/contents/works-2.jpg'] }));
+      await mediaRepository.save(createMedia({ mediaId: 'media-003', title: '作品3', contents: ['/contents/works-3.jpg'] }));
+
+      const ascResult = await queryRepository.search(new SearchCondition({
+        title: '',
+        tags: [],
+        sortType: SortType.DATE_ASC,
+        start: 1,
+        size: 10,
+      }));
+      expect(ascResult.mediaOverviews.map(overview => overview.mediaId)).toEqual([
+        'media-001',
+        'media-002',
+        'media-003',
+      ]);
+
+      const descResult = await queryRepository.search(new SearchCondition({
+        title: '',
+        tags: [],
+        sortType: SortType.DATE_DESC,
+        start: 1,
+        size: 10,
+      }));
+      expect(descResult.mediaOverviews.map(overview => overview.mediaId)).toEqual([
+        'media-003',
+        'media-002',
+        'media-001',
+      ]);
+    } finally {
+      await sequelize.close();
+    }
+  });
+
   test.each([
     ['search', repository => repository.search({})],
     ['findOverviewsByMediaIds に配列以外', repository => repository.findOverviewsByMediaIds('media-001')],

--- a/src/controller/router/screen/setRouterScreenSearchGet.js
+++ b/src/controller/router/screen/setRouterScreenSearchGet.js
@@ -27,8 +27,8 @@ const setRouterScreenSearchGet = ({
         currentPath: '/screen/search',
         currentUserId: req.context?.userId || null,
         sortOptions: [
-          { value: 'date_asc', label: '登録の新しい順' },
-          { value: 'date_desc', label: '登録の古い順' },
+          { value: 'date_desc', label: '登録の新しい順' },
+          { value: 'date_asc', label: '登録の古い順' },
           { value: 'title_asc', label: 'タイトル名の昇順' },
           { value: 'title_desc', label: 'タイトル名の降順' },
           { value: 'random', label: 'ランダム' },

--- a/src/controller/router/screen/setRouterScreenSummaryGet.js
+++ b/src/controller/router/screen/setRouterScreenSummaryGet.js
@@ -142,8 +142,8 @@ const setRouterScreenSummaryGet = ({ router, authResolver, searchMediaService })
           currentPath: '/screen/summary',
           currentUserId: req.context?.userId || null,
           sortOptions: [
-            { value: 'date_asc', label: '登録の新しい順' },
-            { value: 'date_desc', label: '登録の古い順' },
+            { value: 'date_desc', label: '登録の新しい順' },
+            { value: 'date_asc', label: '登録の古い順' },
             { value: 'title_asc', label: 'タイトル名の昇順' },
             { value: 'title_desc', label: 'タイトル名の降順' },
             { value: 'random', label: 'ランダム' },

--- a/src/controller/screen/publicContentPath.js
+++ b/src/controller/screen/publicContentPath.js
@@ -30,8 +30,9 @@ const toPublicContentPath = contentId => {
     return normalized;
   }
 
-  if ((/^[0-9a-f]{32}$/).test(normalized)) {
-    return `/contents/${buildShardedPath(normalized)}`;
+  if ((/^[0-9a-f]{32}$/i).test(normalized)) {
+    const canonicalContentId = normalized.toLowerCase();
+    return `/contents/${buildShardedPath(canonicalContentId)}`;
   }
 
   return `/contents/${normalized.replace(/^\/+/, '')}`;

--- a/src/infrastructure/SequelizeMediaQueryRepository.js
+++ b/src/infrastructure/SequelizeMediaQueryRepository.js
@@ -29,9 +29,9 @@ const extractMediaIdValue = mediaId => {
 const buildSortOrder = (sortType) => {
   switch (sortType) {
     case SortType.DATE_ASC:
-      return [['createdAtProxy', 'DESC'], ['media_id', 'ASC']];
-    case SortType.DATE_DESC:
       return [['createdAtProxy', 'ASC'], ['media_id', 'ASC']];
+    case SortType.DATE_DESC:
+      return [['createdAtProxy', 'DESC'], ['media_id', 'ASC']];
     case SortType.TITLE_ASC:
       return [['title', 'ASC'], ['media_id', 'ASC']];
     case SortType.TITLE_DESC:


### PR DESCRIPTION
### Motivation
- Align sort semantics so `DATE_ASC` means older-first and `DATE_DESC` means newer-first across query layer and UI rendering. 
- Support 32-char hex content IDs in uppercase by normalizing them to lowercase for sharded public paths.
- Update tests to reflect the corrected behaviors.

### Description
- Corrected sort order mapping in `SequelizeMediaQueryRepository.buildSortOrder` so `DATE_ASC` returns ascending `createdAtProxy` and `DATE_DESC` returns descending `createdAtProxy`.
- Updated UI route renderers in `setRouterScreenSearchGet` and `setRouterScreenSummaryGet` to present `sortOptions` with `date_desc` labelled as "登録の新しい順" and `date_asc` labelled as "登録の古い順" to match backend semantics.
- Made `toPublicContentPath` accept uppercase 32-char hex IDs by using a case-insensitive regex and converting the ID to lowercase before building the sharded `/contents/...` path.
- Updated and added unit tests to assert the corrected sort behavior and content ID normalization, and adjusted expectations in the router screen test.

### Testing
- Ran the updated Jest unit tests covering `setRouterScreenSearchGet`, `toPublicContentPath`, and `SequelizeMediaQueryRepository.search` (`__tests__/small/controller/router/screen/setRouterScreenSearchGet.test.js`, `__tests__/small/controller/screen/publicContentPath.test.js`, and `__tests__/small/infrastructure/SequelizeMediaQueryRepository.test.js`), and all assertions passed.
- Executed the small test suite that includes the modified files and confirmed no failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3041e2980832b9184ecdb9e350f6b)