### PR TITLE
fix: Cookieベース認証へ統一しセッションCookie属性と互換フラグを追加

### DIFF
--- a/__tests__/medium/app/setupMiddleware.integration.test.js
+++ b/__tests__/medium/app/setupMiddleware.integration.test.js
@@ -22,6 +22,7 @@ const createApp = () => {
       devSessionUserId: 'admin-dev',
       devSessionTtlMs: 60_000,
       devSessionPaths: ['/protected'],
+      allowLegacySessionTokenHeader: 'true',
     },
     dependencies: {},
   });
@@ -41,19 +42,18 @@ const createApp = () => {
 describe('setupMiddleware と SessionAuthMiddleware の接続 (medium)', () => {
   test.each([
     {
-      title: 'x-session-token を最優先で採用する',
+      title: 'session_token Cookie を優先して採用する',
       headers: {
-        'x-session-token': 'header-token',
         cookie: 'session_token=cookie-token',
       },
-      expected: 'header-token',
+      expected: 'cookie-token',
     },
     {
-      title: 'x-session-token が無い場合は session_token Cookie を採用する',
+      title: 'Cookie が無い場合は feature flag で x-session-token を採用できる',
       headers: {
-        cookie: 'theme=dark; session_token=cookie-token',
+        'x-session-token': 'header-token',
       },
-      expected: 'cookie-token',
+      expected: 'header-token',
     },
     {
       title: 'ヘッダ/Cookie が無い場合は DevelopmentSession を採用する',

--- a/__tests__/medium/controller/router/media/cookieAuthMediaPost.integration.test.js
+++ b/__tests__/medium/controller/router/media/cookieAuthMediaPost.integration.test.js
@@ -1,0 +1,123 @@
+const express = require('express');
+const request = require('supertest');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { Sequelize } = require('sequelize');
+
+const setupMiddleware = require('../../../../../src/app/setupMiddleware');
+const setRouterApiLogin = require('../../../../../src/controller/router/user/setRouterApiLogin');
+const setRouterApiMediaPost = require('../../../../../src/controller/router/media/setRouterApiMediaPost');
+const SessionStateRegistrar = require('../../../../../src/infrastructure/SessionStateRegistrar');
+const InMemorySessionStateStore = require('../../../../../src/infrastructure/InMemorySessionStateStore');
+const StaticLoginAuthenticator = require('../../../../../src/infrastructure/StaticLoginAuthenticator');
+const SequelizeMediaRepository = require('../../../../../src/infrastructure/SequelizeMediaRepository');
+const SequelizeUnitOfWork = require('../../../../../src/infrastructure/SequelizeUnitOfWork');
+const MulterDiskStorageContentUploadAdapter = require('../../../../../src/infrastructure/MulterDiskStorageContentUploadAdapter');
+const { LoginService } = require('../../../../../src/application/user/command/LoginService');
+
+class FixedMediaIdValueGenerator {
+  generate() {
+    return 'abcdefabcdefabcdefabcdefabcdefab';
+  }
+}
+
+describe('Cookie認証での /api/media 回帰テスト (medium)', () => {
+  let sequelize;
+  let unitOfWork;
+  let mediaRepository;
+  let rootDirectory;
+
+  beforeEach(async () => {
+    rootDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'router-media-cookie-auth-'));
+    sequelize = new Sequelize('sqlite::memory:', { logging: false });
+    unitOfWork = new SequelizeUnitOfWork({ sequelize });
+    mediaRepository = new SequelizeMediaRepository({
+      sequelize,
+      unitOfWorkContext: unitOfWork,
+    });
+    await mediaRepository.sync();
+  });
+
+  afterEach(async () => {
+    fs.rmSync(rootDirectory, { recursive: true, force: true });
+    await sequelize.close();
+  });
+
+  const createApp = () => {
+    const app = express();
+    const router = express.Router();
+    const sessionStateStore = new InMemorySessionStateStore();
+
+    setupMiddleware(app, {
+      env: {
+        allowLegacySessionTokenHeader: 'false',
+      },
+      dependencies: {},
+    });
+
+    setRouterApiLogin({
+      router,
+      loginService: new LoginService({
+        loginAuthenticator: new StaticLoginAuthenticator({
+          username: 'admin',
+          password: 'secret',
+          userId: 'user-001',
+        }),
+        sessionStateRegistrar: new SessionStateRegistrar({ sessionStateStore }),
+        sessionTtlMs: 60_000,
+      }),
+    });
+
+    const authResolver = {
+      execute: jest.fn(async sessionToken => sessionStateStore.findUserIdBySessionToken(sessionToken) ?? null),
+    };
+
+    setRouterApiMediaPost({
+      router,
+      authResolver,
+      saveAdapter: new MulterDiskStorageContentUploadAdapter({ rootDirectory }),
+      mediaIdValueGenerator: new FixedMediaIdValueGenerator(),
+      mediaRepository,
+      unitOfWork,
+    });
+
+    app.use(router);
+
+    return {
+      app,
+      authResolver,
+    };
+  };
+
+  test('ログイン後は Cookie のみで /api/media に成功し、x-session-token なしでも認証できる', async () => {
+    const { app, authResolver } = createApp();
+
+    const loginResponse = await request(app)
+      .post('/api/login')
+      .type('form')
+      .send({ username: 'admin', password: 'secret' });
+
+    expect(loginResponse.status).toBe(200);
+    expect(loginResponse.body).toEqual({ code: 0 });
+    expect(loginResponse.headers['set-cookie']).toBeDefined();
+
+    const response = await request(app)
+      .post('/api/media')
+      .set('Cookie', loginResponse.headers['set-cookie'])
+      .field('title', 'cookie-auth-title')
+      .field('tags[0][category]', '作者')
+      .field('tags[0][label]', '山田')
+      .field('contents[0][position]', '1')
+      .attach('contents[0][file]', Buffer.from('a'), 'first.jpg');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      code: 0,
+      mediaId: 'abcdefabcdefabcdefabcdefabcdefab',
+    });
+
+    expect(authResolver.execute).toHaveBeenCalledTimes(1);
+    expect(authResolver.execute.mock.calls[0][0]).toMatch(/^[0-9a-f]{32}$/);
+  });
+});

--- a/__tests__/medium/controller/router/user/setRouterApiLogin.test.js
+++ b/__tests__/medium/controller/router/user/setRouterApiLogin.test.js
@@ -19,7 +19,9 @@ describe('setRouterApiLogin (middle)', () => {
     const auth = new SessionAuthMiddleware(authResolver);
 
     setupMiddleware(app, {
-      env: {},
+      env: {
+        loginSessionTtlMs: 60_000,
+      },
       dependencies: {},
     });
 

--- a/__tests__/medium/controller/router/user/setRouterApiLogin.test.js
+++ b/__tests__/medium/controller/router/user/setRouterApiLogin.test.js
@@ -55,7 +55,7 @@ describe('setRouterApiLogin (middle)', () => {
     expect(loginResponse.status).toBe(200);
     expect(loginResponse.body).toEqual({ code: 0 });
     expect(loginResponse.headers['set-cookie']).toEqual(
-      expect.arrayContaining([expect.stringMatching(/^session_token=[^;]+; Path=\/; HttpOnly/)]),
+      expect.arrayContaining([expect.stringMatching(/^session_token=[^;]+; Max-Age=60; Path=\/; Expires=[^;]+; HttpOnly; SameSite=Lax/)]),
     );
 
     const protectedResponse = await request(app)

--- a/__tests__/small/app/setupMiddleware.test.js
+++ b/__tests__/small/app/setupMiddleware.test.js
@@ -28,32 +28,35 @@ const createHarness = ({ env = {} } = {}) => {
 describe('setupMiddleware (small)', () => {
   test.each([
     {
-      title: 'x-session-token が存在する場合は最優先で採用する',
+      title: 'session_token Cookie が存在する場合は採用する',
       headers: {
-        'x-session-token': 'header-token',
         cookie: 'session_token=cookie-token',
-      },
-      expected: 'header-token',
-    },
-    {
-      title: 'x-session-token が無い場合は session_token Cookie を採用する',
-      headers: {
-        cookie: 'theme=dark; session_token=cookie-token',
       },
       expected: 'cookie-token',
     },
     {
-      title: 'x-session-token と session_token Cookie が無い場合は開発用固定セッションを採用する',
+      title: 'Cookie が無く feature flag が有効なら x-session-token を採用する',
+      headers: {
+        'x-session-token': 'header-token',
+      },
+      env: {
+        allowLegacySessionTokenHeader: 'true',
+      },
+      expected: 'header-token',
+    },
+    {
+      title: 'Cookie と x-session-token が無い場合は開発用固定セッションを採用する',
       headers: {},
       expected: 'dev-token',
     },
-  ])('セッショントークン解決優先順位: $title', ({ headers, expected }) => {
+  ])('セッショントークン解決優先順位: $title', ({ headers, expected, env: overrideEnv = {} }) => {
     const { middleware } = createHarness({
       env: {
         devSessionToken: 'dev-token',
         devSessionUserId: 'admin-dev',
         devSessionTtlMs: 60_000,
         devSessionPaths: ['/screen/entry'],
+        ...overrideEnv,
       },
     });
 
@@ -64,6 +67,29 @@ describe('setupMiddleware (small)', () => {
 
     expect(req.session.session_token).toBe(expected);
     expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  test('feature flag 無効時は x-session-token を無視する', () => {
+    const { middleware } = createHarness({
+      env: {
+        devSessionToken: 'dev-token',
+        devSessionUserId: 'admin-dev',
+        devSessionTtlMs: 60_000,
+        devSessionPaths: ['/screen/entry'],
+        allowLegacySessionTokenHeader: 'false',
+      },
+    });
+
+    const req = createReq({
+      headers: {
+        'x-session-token': 'legacy-token',
+      },
+      path: '/screen/entry',
+    });
+
+    middleware(req, {}, jest.fn());
+
+    expect(req.session.session_token).toBe('dev-token');
   });
 
   test('Cookie 解析: Cookieヘッダの不正要素は無視し、session_token が無い場合は開発用固定セッションへフォールバックする', () => {

--- a/__tests__/small/app/setupMiddleware.test.js
+++ b/__tests__/small/app/setupMiddleware.test.js
@@ -140,4 +140,19 @@ describe('setupMiddleware (small)', () => {
     expect(typeof req.session.regenerate).toBe('function');
     expect(typeof req.session.destroy).toBe('function');
   });
+
+  test('app.locals.env が未設定の場合は setupMiddleware に渡した env を公開する', () => {
+    const app = {
+      locals: {},
+      set: jest.fn(),
+      use: jest.fn(),
+    };
+    const env = {
+      loginSessionTtlMs: 60_000,
+    };
+
+    setupMiddleware(app, { env, dependencies: {} });
+
+    expect(app.locals.env).toBe(env);
+  });
 });

--- a/__tests__/small/controller/api/LoginPostController.test.js
+++ b/__tests__/small/controller/api/LoginPostController.test.js
@@ -18,8 +18,16 @@ describe('LoginPostController', () => {
     return res;
   };
 
-  const execute = async ({ body, session }) => {
-    const req = { body, session };
+  const execute = async ({ body, session, env = {} }) => {
+    const req = {
+      body,
+      session,
+      app: {
+        locals: {
+          env,
+        },
+      },
+    };
     const res = createRes();
 
     await controller.execute(req, res);
@@ -50,6 +58,9 @@ describe('LoginPostController', () => {
     expect(res.cookie).toHaveBeenCalledWith('session_token', 'token-1', {
       httpOnly: true,
       path: '/',
+      secure: false,
+      sameSite: 'lax',
+      maxAge: 86_400_000,
     });
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith({ code: 0 });
@@ -93,5 +104,25 @@ describe('LoginPostController', () => {
 
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith({ code: 1 });
+  });
+
+  it('本番環境では secure=true / sameSite=strict / maxAge=セッションTTL を設定する', async () => {
+    const session = { regenerate: jest.fn() };
+    const { res } = await execute({
+      body: { username: 'admin', password: 'secret' },
+      session,
+      env: {
+        nodeEnv: 'production',
+        loginSessionTtlMs: 120_000,
+      },
+    });
+
+    expect(res.cookie).toHaveBeenCalledWith('session_token', 'token-1', {
+      httpOnly: true,
+      path: '/',
+      secure: true,
+      sameSite: 'strict',
+      maxAge: 120_000,
+    });
   });
 });

--- a/src/app/setupMiddleware.js
+++ b/src/app/setupMiddleware.js
@@ -30,6 +30,8 @@ const parseCookieHeader = cookieHeader => {
     }, {});
 };
 
+const isEnabled = value => String(value || '').toLowerCase() === 'true';
+
 const attachSessionHelpers = req => {
   req.session = req.session ?? {};
   req.session.req = req;
@@ -60,10 +62,12 @@ const setupMiddleware = (app, { env = {}, dependencies: _dependencies } = {}) =>
 
     const sessionToken = req.header('x-session-token');
     const cookies = parseCookieHeader(req.header('cookie'));
-    if (typeof sessionToken === 'string' && sessionToken.length > 0) {
-      req.session.session_token = sessionToken;
-    } else if (typeof cookies.session_token === 'string' && cookies.session_token.length > 0) {
+    const allowLegacySessionHeader = isEnabled(env.allowLegacySessionTokenHeader);
+
+    if (typeof cookies.session_token === 'string' && cookies.session_token.length > 0) {
       req.session.session_token = cookies.session_token;
+    } else if (allowLegacySessionHeader && typeof sessionToken === 'string' && sessionToken.length > 0) {
+      req.session.session_token = sessionToken;
     } else if (shouldApplyDevelopmentSession({ env, requestPath: req.path })) {
       req.session.session_token = env.devSessionToken;
     }

--- a/src/app/setupMiddleware.js
+++ b/src/app/setupMiddleware.js
@@ -48,6 +48,11 @@ const attachSessionHelpers = req => {
 };
 
 const setupMiddleware = (app, { env = {}, dependencies: _dependencies } = {}) => {
+  app.locals = app.locals ?? {};
+  if (typeof app.locals.env === 'undefined') {
+    app.locals.env = env;
+  }
+
   app.set('views', path.join(__dirname, '..', 'views'));
   app.set('view engine', 'ejs');
   if (typeof env.contentRootDirectory === 'string' && env.contentRootDirectory.length > 0) {

--- a/src/controller/api/LoginPostController.js
+++ b/src/controller/api/LoginPostController.js
@@ -37,9 +37,13 @@ class LoginPostController {
       }));
 
       if (result instanceof LoginSucceededResult) {
+        const cookiePolicy = this.#resolveSessionCookiePolicy(req);
         res.cookie('session_token', result.sessionToken, {
           httpOnly: true,
           path: '/',
+          secure: cookiePolicy.secure,
+          sameSite: cookiePolicy.sameSite,
+          maxAge: cookiePolicy.maxAge,
         });
 
         logger?.info('auth.login.success', {
@@ -66,6 +70,24 @@ class LoginPostController {
 
   #isValidCredential(value) {
     return typeof value === 'string' && value.length > 0;
+  }
+
+  #resolveSessionCookiePolicy(req) {
+    const env = req?.app?.locals?.env ?? {};
+    const nodeEnv = String(env.nodeEnv || process.env.NODE_ENV || '').toLowerCase();
+    const isProduction = nodeEnv === 'production';
+    const sessionTtlMs = Number.isFinite(env.loginSessionTtlMs) && env.loginSessionTtlMs > 0
+      ? env.loginSessionTtlMs
+      : 86_400_000;
+
+    return {
+      // ローカル開発(http)では false、本番(https)では true を強制する。
+      secure: isProduction,
+      // 本番は厳しめに strict、非本番は開発しやすさを考慮して lax。
+      sameSite: isProduction ? 'strict' : 'lax',
+      // セッション有効期限と Cookie 期限を一致させる。
+      maxAge: sessionTtlMs,
+    };
   }
 
   #fail(res) {

--- a/src/server.js
+++ b/src/server.js
@@ -9,6 +9,7 @@ const parseSessionPaths = value => (value || '')
   .filter(entry => entry.length > 0);
 
 const createEnv = source => ({
+  nodeEnv: source.NODE_ENV || 'development',
   port: Number.parseInt(source.PORT, 10) || 3000,
   databaseDialect: source.DATABASE_DIALECT || 'sqlite',
   databaseUrl: source.DATABASE_URL || '',
@@ -29,6 +30,7 @@ const createEnv = source => ({
   loginPassword: source.FIXED_LOGIN_PASSWORD || source.LOGIN_PASSWORD || '',
   loginUserId: source.FIXED_LOGIN_USER_ID || source.LOGIN_USER_ID || '',
   loginSessionTtlMs: Number.parseInt(source.LOGIN_SESSION_TTL_MS, 10) || 86_400_000,
+  allowLegacySessionTokenHeader: source.ALLOW_LEGACY_SESSION_TOKEN_HEADER || '',
   logFilePath: source.LOG_FILE_PATH || path.join(process.cwd(), 'var', 'logs', 'mangaviewer.log'),
   logLevel: source.LOG_LEVEL || 'INFO',
   logOutputs: source.LOG_OUTPUTS

--- a/src/views/screen/entry.ejs
+++ b/src/views/screen/entry.ejs
@@ -302,9 +302,7 @@
           try {
             const response = await fetch('/api/media', {
               method: 'POST',
-              headers: {
-                'x-session-token': window.localStorage.getItem('session_token') || '',
-              },
+              credentials: 'same-origin',
               body: payload,
             });
             if (response.status === 401) {


### PR DESCRIPTION
### Motivation
- セッション管理を `localStorage`/ヘッダ依存から HttpOnly Cookie に統一してクライアント側からの直接参照を避けセキュリティを向上させるため。 
- レガシーな `x-session-token` ヘッダ受理は段階的に廃止しつつ、短期的な互換のために feature flag で制御できるようにするため。

### Description
- `src/controller/api/LoginPostController.js` のログイン成功時 `res.cookie('session_token', ...)` に `secure`/`sameSite`/`maxAge` を追加し、環境（`nodeEnv` / `loginSessionTtlMs`）による方針を返す `#resolveSessionCookiePolicy` を導入しました。 
- フロントの登録画面 `src/views/screen/entry.ejs` から `localStorage` 参照と明示的な `x-session-token` ヘッダ送信を削除し、`fetch` に `credentials: 'same-origin'` を設定して Cookie ベース認証へ統一しました。 
- `src/app/setupMiddleware.js` は Cookie を優先し、`x-session-token` の受理は環境変数 `ALLOW_LEGACY_SESSION_TOKEN_HEADER`（`allowLegacySessionTokenHeader`）が `true` の場合のみ有効となる feature-flag 化を追加しました。 
- テストを修正・追加して挙動を明確化し、Cookie 属性の検証と「ログイン後に `/api/media` が Cookie のみで通る」回帰テスト（`__tests__/medium/controller/router/media/cookieAuthMediaPost.integration.test.js`）を追加しました。 

### Testing
- 変更ファイルと該当テストファイルに対して `node --check` による構文チェックを実行し正常でした。 
- ユニット/統合テスト実行は `npm run test:small`（`cross-env` 未存在で失敗）および `npx jest ...`（ネットワークリソース不足により `jest` の取得で 403 エラー）により環境依存で完了できませんでした。 
- テストコードは修正・追加済みでコミット済みのため、CI 環境または依存が揃ったローカル環境で `npm run test:small` / `npm run test:medium` を実行して検証してください。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3c4c15634832ba410e6d14a7c406c)