### PR TITLE
アップロード制限・形式検証の強化と関連テスト拡張

### DIFF
--- a/__tests__/large/e2e/edit/edit-update-media.large.test.js
+++ b/__tests__/large/e2e/edit/edit-update-media.large.test.js
@@ -162,7 +162,7 @@ test.describe('large e2e: edit 画面での既存メディア更新', () => {
       `${replacementDirectory}/replacement-3.jpg`,
     ];
     await Promise.all(replacementFiles.map((filePath, index) => {
-      return fs.writeFile(filePath, `replacement-${index + 1}`, { encoding: 'utf8' });
+      return fs.writeFile(filePath, Buffer.from([0xff, 0xd8, 0xff, 0xdb, index]));
     }));
     await page.setInputFiles('#file-input', replacementFiles);
     await expect(page.locator('#media-list .media-item')).toHaveCount(3);

--- a/__tests__/large/e2e/entry/entry-create-media.large.test.js
+++ b/__tests__/large/e2e/entry/entry-create-media.large.test.js
@@ -55,7 +55,7 @@ test.describe('large e2e: エントリー画面でメディアを新規登録で
     const tagLabel = '長編';
 
     const uploadFilePath = path.join(tempRootDirectory, 'entry-upload-1.jpg');
-    await fs.writeFile(uploadFilePath, 'dummy-image-bytes', { encoding: 'utf8' });
+    await fs.writeFile(uploadFilePath, Buffer.from([0xff, 0xd8, 0xff, 0xdb, 0x00, 0x43]));
 
     await login({ baseUrl });
 

--- a/__tests__/medium/controller/middleware/ContentSaveMiddleware.test.js
+++ b/__tests__/medium/controller/middleware/ContentSaveMiddleware.test.js
@@ -18,19 +18,21 @@ describe('ContentSaveMiddleware (middle)', () => {
     fs.rmSync(rootDirectory, { recursive: true, force: true });
   });
 
-  const createApp = ({ adapter }) => {
+  const createApp = ({ adapter, logger = { error: jest.fn() } }) => {
     const app = express();
+    app.locals.dependencies = { logger };
+
     const middleware = new ContentSaveMiddleware({ contentUploadAdapter: adapter });
 
     app.post('/api/media', middleware.execute.bind(middleware), (_req, res) => {
       res.status(200).json({ code: 0 });
     });
 
-    return app;
+    return { app, logger };
   };
 
   test('contents[n].file / position / url の構造で送信し、position順のcontentIdsで後続へ委譲できる', async () => {
-    const app = createApp({
+    const { app } = createApp({
       adapter: new MulterDiskStorageContentUploadAdapter({ rootDirectory }),
     });
 
@@ -39,14 +41,14 @@ describe('ContentSaveMiddleware (middle)', () => {
       .field('contents[0][position]', '2')
       .field('contents[0][id]', 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb')
       .field('contents[1][position]', '1')
-      .attach('contents[1][file]', Buffer.from('a'), 'same-name.jpg');
+      .attach('contents[1][file]', Buffer.from([0xff, 0xd8, 0xff]), 'same-name.jpg');
 
     expect(response.status).toBe(200);
     expect(response.body).toEqual({ code: 0 });
   });
 
   test('contents が未指定の場合は失敗レスポンスを返す', async () => {
-    const app = createApp({
+    const { app } = createApp({
       adapter: new MulterDiskStorageContentUploadAdapter({ rootDirectory }),
     });
 
@@ -59,18 +61,63 @@ describe('ContentSaveMiddleware (middle)', () => {
   });
 
   test('contents[n].position が重複する場合は失敗レスポンスを返す', async () => {
-    const app = createApp({
+    const { app } = createApp({
       adapter: new MulterDiskStorageContentUploadAdapter({ rootDirectory }),
     });
 
     const response = await request(app)
       .post('/api/media')
       .field('contents[0][position]', '1')
-      .attach('contents[0][file]', Buffer.from('a'), 'same-name.jpg')
+      .attach('contents[0][file]', Buffer.from([0xff, 0xd8, 0xff]), 'same-name.jpg')
       .field('contents[1][position]', '1')
       .field('contents[1][id]', 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb');
 
     expect(response.status).toBe(200);
     expect(response.body).toEqual({ code: 1 });
+  });
+
+  test('アップロード制限超過時は4xxとcontent.upload.errorログ(reason=size)を返す', async () => {
+    const { app, logger } = createApp({
+      adapter: new MulterDiskStorageContentUploadAdapter({ rootDirectory }),
+    });
+
+    const oversized = Buffer.concat([
+      Buffer.from([0xff, 0xd8, 0xff]),
+      Buffer.alloc(50 * 1024 * 1024, 0x00),
+    ]);
+
+    const response = await request(app)
+      .post('/api/media')
+      .field('contents[0][position]', '1')
+      .attach('contents[0][file]', oversized, {
+        filename: 'too-big.jpg',
+        contentType: 'image/jpeg',
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({ code: 1 });
+    expect(logger.error).toHaveBeenCalledWith('content.upload.error', expect.objectContaining({
+      reason: 'size',
+    }));
+  }, 30_000);
+
+  test('不正MIMEタイプ時は4xxとcontent.upload.errorログ(reason=type)を返す', async () => {
+    const { app, logger } = createApp({
+      adapter: new MulterDiskStorageContentUploadAdapter({ rootDirectory }),
+    });
+
+    const response = await request(app)
+      .post('/api/media')
+      .field('contents[0][position]', '1')
+      .attach('contents[0][file]', Buffer.from('text payload'), {
+        filename: 'text.txt',
+        contentType: 'text/plain',
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({ code: 1 });
+    expect(logger.error).toHaveBeenCalledWith('content.upload.error', expect.objectContaining({
+      reason: 'type',
+    }));
   });
 });

--- a/__tests__/medium/controller/router/media/setRouterApiMediaPatch.test.js
+++ b/__tests__/medium/controller/router/media/setRouterApiMediaPatch.test.js
@@ -99,7 +99,7 @@ describe('setRouterApiMediaPatch (middle)', () => {
       .field('tags[1][category]', '雑誌')
       .field('tags[1][label]', 'ジャンプ')
       .field('contents[0][position]', '1')
-      .attach('contents[0][file]', Buffer.from('new-image'), 'new.jpg')
+      .attach('contents[0][file]', Buffer.from([0xff, 0xd8, 0xff, 0xdb]), 'new.jpg')
       .field('contents[1][position]', '2')
       .field('contents[1][id]', existingContent2)
       .field('contents[2][position]', '3')

--- a/__tests__/medium/controller/router/media/setRouterApiMediaPost.test.js
+++ b/__tests__/medium/controller/router/media/setRouterApiMediaPost.test.js
@@ -95,7 +95,7 @@ describe('setRouterApiMediaPost (middle)', () => {
       .field('contents[0][position]', '2')
       .field('contents[0][url]', 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb')
       .field('contents[1][position]', '1')
-      .attach('contents[1][file]', Buffer.from('a'), 'first.jpg');
+      .attach('contents[1][file]', Buffer.from([0xff, 0xd8, 0xff]), 'first.jpg');
 
     expect(response.status).toBe(200);
     expect(response.body).toEqual({
@@ -137,7 +137,7 @@ describe('setRouterApiMediaPost (middle)', () => {
       .field('tags[0][category]', '作者')
       .field('tags[0][label]', '山田')
       .field('contents[0][position]', '1')
-      .attach('contents[0][file]', Buffer.from('a'), 'first.jpg');
+      .attach('contents[0][file]', Buffer.from([0xff, 0xd8, 0xff]), 'first.jpg');
 
     expect(response.status).toBe(401);
     expect(response.body).toEqual({

--- a/__tests__/medium/infrastructure/MulterDiskStorageContentUploadAdapter.test.js
+++ b/__tests__/medium/infrastructure/MulterDiskStorageContentUploadAdapter.test.js
@@ -32,7 +32,11 @@ describe('MulterDiskStorageContentUploadAdapter', () => {
       req.context = {};
       adapter.execute(req, res, error => {
         if (error) {
-          res.status(200).json({ code: 1, message: error.message });
+          res.status(error.status ?? 200).json({
+            code: 1,
+            message: error.message,
+            reason: error.uploadReason ?? null,
+          });
           return;
         }
 
@@ -54,7 +58,7 @@ describe('MulterDiskStorageContentUploadAdapter', () => {
       .field('contents[0][position]', '2')
       .field('contents[0][url]', 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb')
       .field('contents[1][position]', '1')
-      .attach('contents[1][file]', Buffer.from('new-content'), 'page1.jpg');
+      .attach('contents[1][file]', Buffer.from([0xff, 0xd8, 0xff, 0xdb]), 'page1.jpg');
 
     expect(response.status).toBe(200);
     expect(response.body.code).toBe(0);
@@ -73,7 +77,6 @@ describe('MulterDiskStorageContentUploadAdapter', () => {
     );
 
     expect(fs.existsSync(savedPath)).toBe(true);
-    expect(fs.readFileSync(savedPath, 'utf8')).toBe('new-content');
   });
 
   test('既存コンテンツに public パスが指定されても contentId として扱える', async () => {
@@ -114,7 +117,7 @@ describe('MulterDiskStorageContentUploadAdapter', () => {
     const response = await request(app)
       .post('/api/media')
       .field('contents[0][position]', '1')
-      .attach('contents[0][file]', Buffer.from('new'), 'page1.jpg');
+      .attach('contents[0][file]', Buffer.from([0xff, 0xd8, 0xff, 0xdb]), 'page1.jpg');
 
     expect(response.status).toBe(200);
     expect(response.body).toEqual({
@@ -131,36 +134,110 @@ describe('MulterDiskStorageContentUploadAdapter', () => {
       'cc',
       'cccccccccccccccccccccccccccccccc'
     );
-    expect(fs.readFileSync(generatedPath, 'utf8')).toBe('new');
+    expect(fs.existsSync(generatedPath)).toBe(true);
 
     randomUUIDSpy.mockRestore();
     expect(crypto.randomUUID).toBe(originalRandomUUID);
   });
 
   test.each([
-    ['position欠落', request => request.attach('contents[0][file]', Buffer.from('a'), 'page1.jpg')],
-    ['fileとurlの両方指定', request => request
+    ['position欠落', req => req.attach('contents[0][file]', Buffer.from([0xff, 0xd8, 0xff]), 'page1.jpg'), 200],
+    ['fileとurlの両方指定', req => req
       .field('contents[0][position]', '1')
       .field('contents[0][url]', 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb')
-      .attach('contents[0][file]', Buffer.from('a'), 'page1.jpg')],
-    ['fileとurlの両方欠落', request => request.field('contents[0][position]', '1')],
-    ['urlが32文字小文字16進数ではない', request => request
+      .attach('contents[0][file]', Buffer.from([0xff, 0xd8, 0xff]), 'page1.jpg'), 200],
+    ['fileとurlの両方欠落', req => req.field('contents[0][position]', '1'), 200],
+    ['urlが32文字小文字16進数ではない', req => req
       .field('contents[0][position]', '1')
-      .field('contents[0][url]', 'INVALID_CONTENT_ID')],
-    ['position重複', request => request
+      .field('contents[0][url]', 'INVALID_CONTENT_ID'), 200],
+    ['position重複', req => req
       .field('contents[0][position]', '1')
-      .attach('contents[0][file]', Buffer.from('a'), 'page1.jpg')
+      .attach('contents[0][file]', Buffer.from([0xff, 0xd8, 0xff]), 'page1.jpg')
       .field('contents[1][position]', '1')
-      .field('contents[1][url]', 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb')],
-    ['file fieldnameが不正', request => request
+      .field('contents[1][url]', 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'), 200],
+    ['file fieldnameが不正', req => req
       .field('contents[0][position]', '1')
-      .attach('contents[0][image]', Buffer.from('a'), 'page1.jpg')],
-  ])('%s場合はcb(error)相当の失敗レスポンスを返す', async (_name, buildRequest) => {
+      .attach('contents[0][image]', Buffer.from([0xff, 0xd8, 0xff]), 'page1.jpg'), 400],
+  ])('%s場合は失敗レスポンスを返す', async (_name, buildRequest, expectedStatus) => {
     const app = createApp();
 
     const response = await buildRequest(request(app).post('/api/media'));
 
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(expectedStatus);
     expect(response.body.code).toBe(1);
   });
+
+  test('MIMEタイプ不正なファイルは type 理由で 400 を返す', async () => {
+    const app = createApp();
+
+    const response = await request(app)
+      .post('/api/media')
+      .field('contents[0][position]', '1')
+      .attach('contents[0][file]', Buffer.from('not-image'), {
+        filename: 'malicious.txt',
+        contentType: 'text/plain',
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toMatchObject({
+      code: 1,
+      reason: 'type',
+    });
+  });
+
+  test('MIMEタイプとシグネチャが不一致なファイルは type 理由で 400 を返す', async () => {
+    const app = createApp();
+
+    const response = await request(app)
+      .post('/api/media')
+      .field('contents[0][position]', '1')
+      .attach('contents[0][file]', Buffer.from('not-jpeg-signature'), {
+        filename: 'fake.jpg',
+        contentType: 'image/jpeg',
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toMatchObject({
+      code: 1,
+      reason: 'type',
+    });
+  });
+
+  test('重複フィールドは count 理由で 400 を返す', async () => {
+    const app = createApp();
+
+    const response = await request(app)
+      .post('/api/media')
+      .field('contents[0][position]', '1')
+      .attach('contents[0][file]', Buffer.from([0xff, 0xd8, 0xff]), 'first.jpg')
+      .attach('contents[0][file]', Buffer.from([0xff, 0xd8, 0xff]), 'second.jpg');
+
+    expect(response.status).toBe(400);
+    expect(response.body).toMatchObject({
+      code: 1,
+      reason: 'count',
+    });
+  });
+
+  test('ファイルサイズ超過は size 理由で 400 を返す', async () => {
+    const app = createApp();
+    const oversized = Buffer.concat([
+      Buffer.from([0xff, 0xd8, 0xff]),
+      Buffer.alloc(50 * 1024 * 1024, 0x00),
+    ]);
+
+    const response = await request(app)
+      .post('/api/media')
+      .field('contents[0][position]', '1')
+      .attach('contents[0][file]', oversized, {
+        filename: 'big.jpg',
+        contentType: 'image/jpeg',
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toMatchObject({
+      code: 1,
+      reason: 'size',
+    });
+  }, 30_000);
 });

--- a/__tests__/small/app/createApp.test.js
+++ b/__tests__/small/app/createApp.test.js
@@ -58,7 +58,7 @@ describe('createApp', () => {
       .field('tags[0][category]', '作者')
       .field('tags[0][label]', '山田')
       .field('contents[0][position]', '1')
-      .attach('contents[0][file]', Buffer.from('a'), 'first.jpg');
+      .attach('contents[0][file]', Buffer.from([0xff, 0xd8, 0xff]), 'first.jpg');
 
     expect(unauthorizedResponse.status).toBe(401);
     expect(unauthorizedResponse.body).toEqual({
@@ -90,7 +90,7 @@ describe('createApp', () => {
       .field('tags[0][category]', '作者')
       .field('tags[0][label]', '山田')
       .field('contents[0][position]', '1')
-      .attach('contents[0][file]', Buffer.from('a'), 'first.jpg');
+      .attach('contents[0][file]', Buffer.from([0xff, 0xd8, 0xff]), 'first.jpg');
 
     expect(mediaResponse.status).toBe(401);
     expect(mediaResponse.body).toEqual({
@@ -138,7 +138,7 @@ describe('createApp', () => {
       .field('tags[0][category]', '作者')
       .field('tags[0][label]', '山田')
       .field('contents[0][position]', '1')
-      .attach('contents[0][file]', Buffer.from('a'), 'first.jpg');
+      .attach('contents[0][file]', Buffer.from([0xff, 0xd8, 0xff]), 'first.jpg');
 
     expect(mediaResponse.status).toBe(200);
     expect(mediaResponse.body).toEqual({

--- a/src/controller/middleware/ContentSaveMiddleware.js
+++ b/src/controller/middleware/ContentSaveMiddleware.js
@@ -25,12 +25,15 @@ class ContentSaveMiddleware {
 
       return undefined;
     } catch (error) {
+      const uploadReason = this.#resolveUploadReason(error);
       logger?.error('content.upload.error', {
         request_id: req?.context?.requestId,
         message: error?.message,
+        reason: uploadReason,
+        code: error?.code,
         error,
       });
-      return this.#fail(res);
+      return this.#fail(res, error);
     }
   }
 
@@ -47,10 +50,35 @@ class ContentSaveMiddleware {
     });
   }
 
-  #fail(res) {
-    return res.status(200).json({
+  #fail(res, error = null) {
+    return res.status(this.#resolveHttpStatus(error)).json({
       code: 1,
     });
+  }
+
+  #resolveHttpStatus(error) {
+    const status = Number(error?.status);
+    if (Number.isInteger(status) && status >= 400 && status < 500) {
+      return status;
+    }
+
+    return 200;
+  }
+
+  #resolveUploadReason(error) {
+    if (typeof error?.uploadReason === 'string' && error.uploadReason.length > 0) {
+      return error.uploadReason;
+    }
+
+    if (error?.code === 'LIMIT_FILE_SIZE') {
+      return 'size';
+    }
+
+    if (error?.code?.startsWith('LIMIT_')) {
+      return 'count';
+    }
+
+    return 'unknown';
   }
 
   #validateContentIds(contentIds) {

--- a/src/infrastructure/MulterDiskStorageContentUploadAdapter.js
+++ b/src/infrastructure/MulterDiskStorageContentUploadAdapter.js
@@ -6,6 +6,70 @@ const multer = require('multer');
 
 const IContentUploadAdapter = require('../controller/middleware/adapter/IContentUploadAdapter');
 
+const MAX_FILES = 100;
+const MAX_FIELDS = 500;
+const MAX_PARTS = 600;
+const MAX_FILE_SIZE = 50 * 1024 * 1024;
+const FILE_FIELD_PATTERN = /^contents\[(\d+)\]\[file\]$/;
+const IMAGE_MIME_TYPES = new Set([
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+]);
+const VIDEO_MIME_TYPES = new Set([
+  'video/mp4',
+  'video/webm',
+  'video/quicktime',
+]);
+const ALLOWED_MIME_TYPES = new Set([...IMAGE_MIME_TYPES, ...VIDEO_MIME_TYPES]);
+
+const SIGNATURE_VALIDATORS = {
+  'image/jpeg': header => header.length >= 3
+    && header[0] === 0xff
+    && header[1] === 0xd8
+    && header[2] === 0xff,
+  'image/png': header => header.length >= 8
+    && header[0] === 0x89
+    && header[1] === 0x50
+    && header[2] === 0x4e
+    && header[3] === 0x47
+    && header[4] === 0x0d
+    && header[5] === 0x0a
+    && header[6] === 0x1a
+    && header[7] === 0x0a,
+  'image/gif': header => header.length >= 6
+    && String.fromCharCode(...header.subarray(0, 6)).match(/^GIF8[79]a$/) !== null,
+  'image/webp': header => header.length >= 12
+    && String.fromCharCode(...header.subarray(0, 4)) === 'RIFF'
+    && String.fromCharCode(...header.subarray(8, 12)) === 'WEBP',
+  'video/mp4': header => header.length >= 12
+    && String.fromCharCode(...header.subarray(4, 8)) === 'ftyp',
+  'video/webm': header => header.length >= 4
+    && header[0] === 0x1a
+    && header[1] === 0x45
+    && header[2] === 0xdf
+    && header[3] === 0xa3,
+  'video/quicktime': header => header.length >= 12
+    && String.fromCharCode(...header.subarray(4, 8)) === 'ftyp'
+    && String.fromCharCode(...header.subarray(8, 12)) === 'qt  ',
+};
+
+const createUploadError = ({ message, status = 400, reason, code }) => {
+  const error = new Error(message);
+  error.status = status;
+  error.uploadReason = reason;
+  if (code) {
+    error.code = code;
+  }
+  return error;
+};
+
+const createAllowedFields = () => Array.from({ length: MAX_FILES }, (_, index) => ({
+  name: `contents[${index}][file]`,
+  maxCount: 1,
+}));
+
 module.exports = class MulterDiskStorageContentUploadAdapter extends IContentUploadAdapter {
   #rootDirectory;
 
@@ -41,17 +105,45 @@ module.exports = class MulterDiskStorageContentUploadAdapter extends IContentUpl
           cb(null, file.generatedContentId);
         },
       }),
-    }).any();
+      limits: {
+        fileSize: MAX_FILE_SIZE,
+        files: MAX_FILES,
+        fields: MAX_FIELDS,
+        parts: MAX_PARTS,
+      },
+      fileFilter: (_req, file, cb) => {
+        if (!FILE_FIELD_PATTERN.test(file.fieldname ?? '')) {
+          cb(createUploadError({
+            message: 'invalid file fieldname',
+            reason: 'count',
+            code: 'LIMIT_UNEXPECTED_FILE',
+          }));
+          return;
+        }
+
+        if (!ALLOWED_MIME_TYPES.has(file.mimetype)) {
+          cb(createUploadError({
+            message: 'invalid mime type',
+            reason: 'type',
+            code: 'LIMIT_UNEXPECTED_FILE',
+          }));
+          return;
+        }
+
+        cb(null, true);
+      },
+    }).fields(createAllowedFields());
   }
 
   execute(req, res, cb) {
     this.#upload(req, res, error => {
       if (error) {
-        cb(error);
+        cb(this.#normalizeUploadError(error));
         return;
       }
 
       try {
+        this.#validateFileSignatures(req?.files ?? {});
         req.context = req.context ?? {};
         req.context.contentIds = this.#createContentIds(req);
         cb();
@@ -61,13 +153,72 @@ module.exports = class MulterDiskStorageContentUploadAdapter extends IContentUpl
     });
   }
 
+  #normalizeUploadError(error) {
+    if (error?.uploadReason) {
+      return error;
+    }
+
+    if (error instanceof multer.MulterError) {
+      if (error.code === 'LIMIT_FILE_SIZE') {
+        return createUploadError({ message: 'file size limit exceeded', reason: 'size', code: error.code });
+      }
+
+      if (error.code === 'LIMIT_FILE_COUNT' || error.code === 'LIMIT_FIELD_COUNT' || error.code === 'LIMIT_PART_COUNT') {
+        return createUploadError({ message: 'upload count limit exceeded', reason: 'count', code: error.code });
+      }
+
+      if (error.code === 'LIMIT_UNEXPECTED_FILE') {
+        return createUploadError({ message: 'unexpected file field', reason: 'count', code: error.code });
+      }
+
+      return createUploadError({ message: error.message, reason: 'count', code: error.code });
+    }
+
+    return error;
+  }
+
+  #validateFileSignatures(filesByField) {
+    const files = Object.values(filesByField).flat();
+
+    for (const file of files) {
+      if (!file?.path || !file?.mimetype) {
+        continue;
+      }
+
+      const validator = SIGNATURE_VALIDATORS[file.mimetype];
+      if (!validator) {
+        continue;
+      }
+
+      const header = this.#readFileHeader(file.path, 16);
+      if (!validator(header)) {
+        throw createUploadError({
+          message: 'invalid file signature',
+          reason: 'type',
+          code: 'INVALID_FILE_SIGNATURE',
+        });
+      }
+    }
+  }
+
+  #readFileHeader(filePath, length) {
+    const fd = fs.openSync(filePath, 'r');
+    try {
+      const buffer = Buffer.alloc(length);
+      const bytesRead = fs.readSync(fd, buffer, 0, length, 0);
+      return buffer.subarray(0, bytesRead);
+    } finally {
+      fs.closeSync(fd);
+    }
+  }
+
   #createContentIds(req) {
     const requestContents = req?.body?.contents;
     if (!requestContents || typeof requestContents !== 'object') {
       throw new Error('contents are required');
     }
 
-    const uploadedFilesByIndex = this.#createUploadedFilesByIndex(req?.files ?? []);
+    const uploadedFilesByIndex = this.#createUploadedFilesByIndex(req?.files ?? {});
     const contents = Object.entries(requestContents).map(([index, content]) => this.#createContent({
       index,
       content,
@@ -88,11 +239,11 @@ module.exports = class MulterDiskStorageContentUploadAdapter extends IContentUpl
       .map(content => content.contentId);
   }
 
-  #createUploadedFilesByIndex(files) {
+  #createUploadedFilesByIndex(filesByField) {
     const uploadedFilesByIndex = new Map();
 
-    for (const file of files) {
-      const matched = file?.fieldname?.match(/^contents\[(\d+)\]\[file\]$/);
+    for (const file of Object.values(filesByField).flat()) {
+      const matched = file?.fieldname?.match(FILE_FIELD_PATTERN);
       if (!matched) {
         throw new Error('invalid file fieldname');
       }


### PR DESCRIPTION
### Motivation
- アップロードで任意フィールドや偽装MIMEのファイルが受け付けられる余地があり、安全性および運用性（原因の特定）が不十分だったため、multer設定と検証を強化する目的です。

### Description
- `MulterDiskStorageContentUploadAdapter` に `limits`（`fileSize`/`files`/`fields`/`parts`）を追加し、`.any()` から `fields(...)` に切り替えて受け付けフィールドを `contents[<index>][file]` のみに限定しました。 
- `fileFilter` で image/video の許可 MIME リストを導入し、保存後にファイル先頭バイトのシグネチャ検証を行って MIME 偽装を拒否するロジックを追加しました。 
- Multer や検証で検出したエラーを `uploadReason`（`size`/`type`/`count`/`unknown`）付きで正規化し、`ContentSaveMiddleware` 側で `content.upload.error` ログへ `reason`/`code` を出力し、`error.status` が 4xx の場合は 4xx を返却するように変更しました。 
- 既存の単体/統合テストを拡張・修正して、ファイルサイズ超過・不正 MIME/シグネチャ・重複フィールドなどのケースを網羅し、テストアップロード用のダミーバッファをシグネチャに合わせて更新しました。 

### Testing
- `node --check` による構文チェックを `src/infrastructure/MulterDiskStorageContentUploadAdapter.js`、`src/controller/middleware/ContentSaveMiddleware.js` および変更したテストファイルに対して実行し、構文エラーは検出されませんでした。 
- `npm test` 実行はスクリプト定義/環境により失敗し、`npx jest` はレジストリアクセス制限により `jest` を取得できず実行できなかったため、実環境でのテスト実行は未完了です。 
- 変更により追加したテストファイル群（`__tests__/medium/infrastructure/MulterDiskStorageContentUploadAdapter.test.js`、`__tests__/medium/controller/middleware/ContentSaveMiddleware.test.js` ほか）は用意済みで、CI/ローカルで `jest` が利用可能な環境での実行を推奨します。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3c4cf38a4832bb7caced645711248)