### PR TITLE
固定ログイン認証のKDF化と本番起動時バリデーション強化

### DIFF
--- a/__tests__/large/e2e/detail/detail-favorite-queue-actions.large.test.js
+++ b/__tests__/large/e2e/detail/detail-favorite-queue-actions.large.test.js
@@ -124,12 +124,13 @@ test.describe('large e2e: 詳細画面から favorite/queue の追加と解除�
       method: 'POST',
     });
 
-    await page.click('button[type="submit"]');
+    await Promise.all([
+      page.waitForURL(`${baseUrl}/screen/summary`, { timeout: 30_000 }),
+      page.click('button[type="submit"]'),
+    ]);
 
     const loginResponse = await loginResponsePromise;
     expect(loginResponse.status()).toBe(200);
-
-    await page.waitForNavigation({ waitUntil: 'networkidle' });
     expect(page.url()).toBe(`${baseUrl}/screen/summary`);
 
     await page.goto(`${baseUrl}/screen/detail/${seedMediaId}`, { waitUntil: 'networkidle' });

--- a/__tests__/medium/app/createDependencies.login.test.js
+++ b/__tests__/medium/app/createDependencies.login.test.js
@@ -4,6 +4,7 @@ const path = require('path');
 
 const createDependencies = require('../../../src/app/createDependencies');
 const { Query, LoginSucceededResult } = require('../../../src/application/user/command/LoginService');
+const { hashPassword } = require('../../../src/infrastructure/auth/fixedUserPasswordHasher');
 
 describe('createDependencies login wiring', () => {
   let dependencies;
@@ -15,6 +16,7 @@ describe('createDependencies login wiring', () => {
     contentRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'create-deps-login-content-'));
 
     dependencies = createDependencies({
+      nodeEnv: 'test',
       databaseStoragePath: path.join(databaseRoot, 'data.sqlite'),
       contentRootDirectory: path.join(contentRoot, 'contents'),
       loginUsername: 'admin',
@@ -54,5 +56,51 @@ describe('createDependencies login wiring', () => {
     expect(session.session_token).toBe(result.sessionToken);
 
     await expect(dependencies.authResolver.execute(result.sessionToken)).resolves.toBe('user-001');
+  });
+
+  test('passwordHash 指定時も認証できる', async () => {
+    await dependencies.close();
+    dependencies = createDependencies({
+      nodeEnv: 'test',
+      databaseStoragePath: path.join(databaseRoot, 'data.sqlite'),
+      contentRootDirectory: path.join(contentRoot, 'contents'),
+      loginUsername: 'admin',
+      loginPasswordHash: hashPassword('secret'),
+      loginUserId: 'user-001',
+      loginSessionTtlMs: 60_000,
+    });
+    await dependencies.ready;
+
+    const session = {
+      regenerate: jest.fn((callback) => callback()),
+    };
+
+    const result = await dependencies.loginService.execute(new Query({
+      username: 'admin',
+      password: 'secret',
+      session,
+    }));
+
+    expect(result).toBeInstanceOf(LoginSucceededResult);
+  });
+
+  test('production 環境で loginUsername 未設定は起動エラーになる', () => {
+    expect(() => createDependencies({
+      nodeEnv: 'production',
+      databaseStoragePath: path.join(databaseRoot, 'data.sqlite'),
+      contentRootDirectory: path.join(contentRoot, 'contents'),
+      loginPassword: 'secret',
+      loginUserId: 'user-001',
+    })).toThrow('production環境では LOGIN_USERNAME (または FIXED_LOGIN_USERNAME) の設定が必須です。');
+  });
+
+  test('production 環境で loginPassword 未設定は起動エラーになる', () => {
+    expect(() => createDependencies({
+      nodeEnv: 'production',
+      databaseStoragePath: path.join(databaseRoot, 'data.sqlite'),
+      contentRootDirectory: path.join(contentRoot, 'contents'),
+      loginUsername: 'admin',
+      loginUserId: 'user-001',
+    })).toThrow('production環境では LOGIN_PASSWORD (または FIXED_LOGIN_PASSWORD) の設定が必須です。');
   });
 });

--- a/__tests__/small/infrastructure/StaticLoginAuthenticator.test.js
+++ b/__tests__/small/infrastructure/StaticLoginAuthenticator.test.js
@@ -1,4 +1,7 @@
+const crypto = require('crypto');
+
 const StaticLoginAuthenticator = require('../../../src/infrastructure/StaticLoginAuthenticator');
+const { hashPassword } = require('../../../src/infrastructure/auth/fixedUserPasswordHasher');
 
 describe('StaticLoginAuthenticator', () => {
   test('固定認証情報と一致する場合は userId を返す', async () => {
@@ -12,6 +15,45 @@ describe('StaticLoginAuthenticator', () => {
       username: 'admin',
       password: 'secret',
     })).resolves.toBe('user-1');
+  });
+
+  test('passwordHash(scrypt) を指定した場合も一致時に userId を返す', async () => {
+    const authenticator = new StaticLoginAuthenticator({
+      username: 'admin',
+      passwordHash: hashPassword('secret'),
+      userId: 'user-1',
+    });
+
+    await expect(authenticator.execute({
+      username: 'admin',
+      password: 'secret',
+    })).resolves.toBe('user-1');
+  });
+
+  test('レガシー SHA-256 ハッシュ一致時は認証成功し、再ハッシュ通知を呼び出す', async () => {
+    const onPasswordRehashRequired = jest.fn();
+    const legacyHash = crypto.createHash('sha256').update('secret').digest('hex');
+    const authenticator = new StaticLoginAuthenticator({
+      username: 'admin',
+      passwordHash: legacyHash,
+      userId: 'user-1',
+      onPasswordRehashRequired,
+    });
+
+    await expect(authenticator.execute({
+      username: 'admin',
+      password: 'secret',
+    })).resolves.toBe('user-1');
+
+    expect(onPasswordRehashRequired).toHaveBeenCalledTimes(1);
+    const [event] = onPasswordRehashRequired.mock.calls[0];
+    expect(event).toMatchObject({
+      userId: 'user-1',
+      username: 'admin',
+      legacyFormat: 'legacy-sha256',
+      legacyHash,
+      upgradedHash: expect.stringMatching(/^\$scrypt\$N=/),
+    });
   });
 
   test('固定認証情報と一致しない場合は null を返す', async () => {
@@ -32,6 +74,7 @@ describe('StaticLoginAuthenticator', () => {
     [{ username: 'admin', password: '', userId: 'user-1' }, 'password must be a non-empty string'],
     [{ username: 'admin', password: 'secret', userId: '' }, 'userId must be a non-empty string'],
     [{ username: null, password: 'secret', userId: 'user-1' }, 'username must be a non-empty string'],
+    [{ username: 'admin', password: 'secret', userId: 'user-1', onPasswordRehashRequired: {} }, 'onPasswordRehashRequired must be a function'],
   ])('コンストラクター設定が不正な場合は例外となる: %s', (payload, expectedMessage) => {
     expect(() => new StaticLoginAuthenticator(payload)).toThrow(expectedMessage);
   });

--- a/doc/4_application/app/createDependencies/readme.md
+++ b/doc/4_application/app/createDependencies/readme.md
@@ -15,9 +15,11 @@
 | --- | --- | --- |
 | `databaseStoragePath` | 必須 | SQLite ファイルの保存先。親ディレクトリを自動生成する。 |
 | `contentRootDirectory` | 必須 | メディアコンテンツ保存先。ディレクトリを自動生成する。 |
-| `loginUsername` | 任意 | `StaticLoginAuthenticator` のユーザー名。未指定時は `admin`。 |
-| `loginPassword` | 任意 | `StaticLoginAuthenticator` のパスワード。未指定時は `admin`。 |
-| `loginUserId` | 任意 | ログイン成功時の利用者 ID。未指定時は `admin`。 |
+| `nodeEnv` | 任意 | 実行環境。`production` の場合は固定ログイン認証の必須チェックを有効化する。 |
+| `loginUsername` | 条件付き必須 | `StaticLoginAuthenticator` のユーザー名。`production` では必須。 |
+| `loginPassword` | 条件付き必須 | `StaticLoginAuthenticator` の平文パスワード。`production` では必須。 |
+| `loginPasswordHash` | 任意 | 固定ログイン認証の保存済みハッシュ。指定時は `loginPassword` より優先される。 |
+| `loginUserId` | 任意 | ログイン成功時の利用者 ID。未指定時は `disabled-fixed-login-user`。 |
 | `loginSessionTtlMs` | 任意 | 通常ログインセッションの TTL。未指定時は `86400000`。 |
 | `devSessionToken` | 条件付き | 開発用固定セッションのトークン。 |
 | `devSessionUserId` | 条件付き | 開発用固定セッションの利用者 ID。 |
@@ -32,7 +34,8 @@
 - `SequelizeMediaRepository` / `SequelizeMediaQueryRepository` / `SequelizeUserRepository` を生成する。
 - `InMemorySessionStateStore` を生成する。
 - `MulterDiskStorageContentUploadAdapter` と `UUIDMediaIdValueGenerator` を生成する。
-- `StaticLoginAuthenticator` を `env.loginUsername` / `env.loginPassword` / `env.loginUserId` から生成する。
+- `StaticLoginAuthenticator` を `env.loginUsername` / `env.loginPassword` / `env.loginPasswordHash` / `env.loginUserId` から生成する。
+- `env.nodeEnv === 'production'` では `loginUsername` と `loginPassword` 未設定を起動エラーとして扱う。
 - `SessionStateRegistrar` / `SessionTerminator` / `SessionStateAuthAdapter` を生成する。
 
 ### アプリケーションサービスの生成

--- a/doc/7_infrastructure/StaticLoginAuthenticator/readme.md
+++ b/doc/7_infrastructure/StaticLoginAuthenticator/readme.md
@@ -1,8 +1,8 @@
 # StaticLoginAuthenticator 設計書
 
 ## 概要
-`StaticLoginAuthenticator` は、設定で注入した固定のユーザー名・パスワード・ユーザーIDを用いてログイン可否を判定する簡易認証アダプターです。  
-永続ストアや外部認証基盤へアクセスせず、`execute` 呼び出し時に受け取った資格情報とコンストラクターで保持した固定値を完全一致で比較します。
+`StaticLoginAuthenticator` は、設定で注入した固定のユーザー名・パスワードハッシュ・ユーザーIDを用いてログイン可否を判定する簡易認証アダプターです。  
+永続ストアや外部認証基盤へアクセスせず、`execute` 呼び出し時に受け取った資格情報を KDF（scrypt）で `verify` し、照合します。
 
 ## クラス
 - 配置: `src/infrastructure/StaticLoginAuthenticator.js`
@@ -10,7 +10,7 @@
 
 ## 利用箇所
 - `src/app/createDependencies.js`
-  - `env.loginUsername` / `env.loginPassword` / `env.loginUserId` をもとに `StaticLoginAuthenticator` を生成する
+  - `env.loginUsername` / `env.loginPassword` / `env.loginPasswordHash` / `env.loginUserId` をもとに `StaticLoginAuthenticator` を生成する
   - 生成した `loginAuthenticator` を `LoginService` へ注入する
 - 関連実装: [LoginService](/doc/4_application/user/command/LoginService/readme.md)
 
@@ -28,7 +28,7 @@
 
 ## 責務
 - 固定の認証情報を保持する
-- 入力された `username` / `password` が固定値と一致するかを判定する
+- 入力された `username` / `password` が固定のハッシュ値に一致するかを判定する
 - 一致した場合だけ `userId` を返し、`LoginService` が後続のセッション発行を継続できるようにする
 - 不一致または不足入力の場合は `null` を返し、認証失敗として扱えるようにする
 
@@ -38,7 +38,8 @@
 ```plantuml
 struct Config #pink {
     + username : string
-    + password : string
+    + password : string (or)
+    + passwordHash : string
     + userId : string
 }
 ```
@@ -66,14 +67,14 @@ class Result {
 
 ## 認証成功条件
 - コンストラクターへ渡した `username` が非空文字列である
-- コンストラクターへ渡した `password` が非空文字列である
+- コンストラクターへ渡した `password` または `passwordHash` のどちらかが非空文字列である
 - コンストラクターへ渡した `userId` が非空文字列である
 - `execute({ username, password })` の `username` が保持済みの固定ユーザー名と完全一致する
-- `execute({ username, password })` の `password` が保持済みの固定パスワードと完全一致する
+- `execute({ username, password })` の `password` を KDF で検証し、保持済みの固定ハッシュと一致する
 
 ## 認証失敗条件
 - `execute` に渡した `username` が固定ユーザー名と一致しない
-- `execute` に渡した `password` が固定パスワードと一致しない
+- `execute` に渡した `password` の KDF 検証に失敗する
 - `execute` に `undefined`、不足したオブジェクト、または型不一致の値が渡され、完全一致条件を満たせない
 
 ## 不正入力条件
@@ -102,3 +103,10 @@ else 不一致または不足
   StaticLoginAuthenticator --> LoginService: null
 end
 ```
+
+
+## ハッシュ形式と移行
+- 現行形式: `$scrypt$N=<cost>$r=<block>$p=<parallel>$<salt(base64)>$<derived(base64)>`
+- 旧形式（legacy）: SHA-256 16進64文字列。
+- 旧形式で認証成功した場合は `onPasswordRehashRequired` コールバックへ `upgradedHash` を通知する。
+- 運用手順は [固定ログイン認証ハッシュ移行手順](/doc/7_infrastructure/StaticLoginAuthenticator/運用手順_固定ログイン認証ハッシュ移行.md) を参照。

--- a/doc/7_infrastructure/StaticLoginAuthenticator/運用手順_固定ログイン認証ハッシュ移行.md
+++ b/doc/7_infrastructure/StaticLoginAuthenticator/運用手順_固定ログイン認証ハッシュ移行.md
@@ -1,0 +1,34 @@
+# 固定ログイン認証ハッシュ移行手順
+
+## 目的
+固定ログイン認証のパスワード比較を旧来の SHA-256 直比較から KDF（scrypt）ベースの照合へ移行する。
+
+## 必須環境変数（production）
+`NODE_ENV=production` の場合は下記を必須とする。
+
+- `LOGIN_USERNAME`（または `FIXED_LOGIN_USERNAME`）
+- `LOGIN_PASSWORD`（または `FIXED_LOGIN_PASSWORD`）
+
+未設定の場合、`createDependencies` 初期化時に起動エラーとなる。
+
+## 新しいハッシュ保存形式
+`LOGIN_PASSWORD_HASH`（または `FIXED_LOGIN_PASSWORD_HASH`）へ、下記形式の文字列を保存する。
+
+- 形式: `$scrypt$N=<cost>$r=<block>$p=<parallel>$<salt(base64)>$<derived(base64)>`
+
+## 旧形式ハッシュの検知
+次の条件を満たす `passwordHash` は旧形式（legacy-sha256）として扱う。
+
+- 64 文字の 16 進文字列（`/^[a-f0-9]{64}$/`）
+
+## 再ハッシュ手順（移行期間）
+1. 旧形式ハッシュでログイン成功すると、`auth.fixed_login.password_rehash_required` ログが出力される。
+2. ログの `upgraded_hash` を取得し、`LOGIN_PASSWORD_HASH`（または `FIXED_LOGIN_PASSWORD_HASH`）へ設定する。
+3. 再起動後、同ログが再出力されないことを確認する。
+
+## 例: ハッシュ生成
+```bash
+node -e "const { hashPassword } = require('./src/infrastructure/auth/fixedUserPasswordHasher'); console.log(hashPassword(process.argv[1]));" 'your-password'
+```
+
+生成した文字列を `LOGIN_PASSWORD_HASH` に設定する。

--- a/src/app/createDependencies.js
+++ b/src/app/createDependencies.js
@@ -89,6 +89,17 @@ const createSequelize = env => {
 };
 
 const createDependencies = (env = {}) => {
+  const isProduction = env.nodeEnv === 'production';
+
+  if (isProduction) {
+    if (typeof env.loginUsername !== 'string' || env.loginUsername.length === 0) {
+      throw new Error('production環境では LOGIN_USERNAME (または FIXED_LOGIN_USERNAME) の設定が必須です。');
+    }
+    if (typeof env.loginPassword !== 'string' || env.loginPassword.length === 0) {
+      throw new Error('production環境では LOGIN_PASSWORD (または FIXED_LOGIN_PASSWORD) の設定が必須です。');
+    }
+  }
+
   if (env.databaseDialect !== 'postgres') {
     ensureParentDirectory(env.databaseStoragePath);
   }
@@ -127,10 +138,24 @@ const createDependencies = (env = {}) => {
   const removeQueueService = new RemoveQueueService({ userRepository, unitOfWork });
   const sessionStateRegistrar = new SessionStateRegistrar({ sessionStateStore });
   const sessionTerminator = new SessionTerminator({ sessionStateStore });
+  const hasLoginUsername = typeof env.loginUsername === 'string' && env.loginUsername.length > 0;
+  const hasLoginPassword = typeof env.loginPassword === 'string' && env.loginPassword.length > 0;
+  const hasLoginPasswordHash = typeof env.loginPasswordHash === 'string' && env.loginPasswordHash.length > 0;
   const loginAuthenticator = new StaticLoginAuthenticator({
-    username: env.loginUsername || 'admin',
-    password: env.loginPassword || 'admin',
-    userId: env.loginUserId || 'admin',
+    username: hasLoginUsername ? env.loginUsername : '__disabled_fixed_login_user__',
+    password: hasLoginPassword ? env.loginPassword : '__disabled_fixed_login_password__',
+    passwordHash: hasLoginPasswordHash
+      ? env.loginPasswordHash
+      : undefined,
+    userId: env.loginUserId || 'disabled-fixed-login-user',
+    onPasswordRehashRequired: ({ userId, username, legacyFormat, upgradedHash }) => {
+      logger.warn('auth.fixed_login.password_rehash_required', {
+        user_id: userId,
+        username,
+        legacy_format: legacyFormat,
+        upgraded_hash: upgradedHash,
+      });
+    },
   });
   const updateMediaService = new UpdateMediaService({ mediaRepository, unitOfWork });
   const deleteMediaService = new DeleteMediaService({ mediaRepository, unitOfWork });

--- a/src/infrastructure/StaticLoginAuthenticator.js
+++ b/src/infrastructure/StaticLoginAuthenticator.js
@@ -1,11 +1,15 @@
-const { hashPassword } = require('./auth/fixedUserPasswordHasher');
+const {
+  hashPassword,
+  verifyPassword,
+} = require('./auth/fixedUserPasswordHasher');
 
 class StaticLoginAuthenticator {
   #username;
   #passwordHash;
   #userId;
+  #onPasswordRehashRequired;
 
-  constructor({ username, password, passwordHash, userId } = {}) {
+  constructor({ username, password, passwordHash, userId, onPasswordRehashRequired } = {}) {
     if (!this.#isNonEmptyString(username)) {
       throw new Error('username must be a non-empty string');
     }
@@ -18,9 +22,14 @@ class StaticLoginAuthenticator {
       throw new Error('userId must be a non-empty string');
     }
 
+    if (onPasswordRehashRequired && typeof onPasswordRehashRequired !== 'function') {
+      throw new Error('onPasswordRehashRequired must be a function');
+    }
+
     this.#username = username;
     this.#passwordHash = this.#isNonEmptyString(passwordHash) ? passwordHash : hashPassword(password);
     this.#userId = userId;
+    this.#onPasswordRehashRequired = onPasswordRehashRequired || null;
   }
 
   async execute({ username, password } = {}) {
@@ -28,11 +37,26 @@ class StaticLoginAuthenticator {
       return null;
     }
 
-    if (hashPassword(password) === this.#passwordHash) {
-      return this.#userId;
+    const verification = verifyPassword({
+      password,
+      storedHash: this.#passwordHash,
+    });
+
+    if (!verification.verified) {
+      return null;
     }
 
-    return null;
+    if (verification.needsRehash && this.#onPasswordRehashRequired) {
+      await this.#onPasswordRehashRequired({
+        userId: this.#userId,
+        username: this.#username,
+        legacyFormat: verification.format,
+        legacyHash: this.#passwordHash,
+        upgradedHash: verification.newHash,
+      });
+    }
+
+    return this.#userId;
   }
 
   #isNonEmptyString(value) {

--- a/src/infrastructure/auth/fixedUserPasswordHasher.js
+++ b/src/infrastructure/auth/fixedUserPasswordHasher.js
@@ -1,13 +1,130 @@
 const crypto = require('crypto');
 
-const hashPassword = password => {
+const LEGACY_SHA256_REGEX = /^[a-f0-9]{64}$/;
+const SCRYPT_PREFIX = '$scrypt$';
+const DEFAULT_SCRYPT_CONFIG = {
+  N: 16384,
+  r: 8,
+  p: 1,
+  keylen: 64,
+};
+
+const assertNonEmptyPassword = password => {
   if (typeof password !== 'string' || password.length === 0) {
     throw new Error('password must be a non-empty string');
   }
+};
 
-  return crypto.createHash('sha256').update(password).digest('hex');
+const hashPassword = password => {
+  assertNonEmptyPassword(password);
+
+  const salt = crypto.randomBytes(16);
+  const derived = crypto.scryptSync(password, salt, DEFAULT_SCRYPT_CONFIG.keylen, {
+    N: DEFAULT_SCRYPT_CONFIG.N,
+    r: DEFAULT_SCRYPT_CONFIG.r,
+    p: DEFAULT_SCRYPT_CONFIG.p,
+  });
+
+  return [
+    SCRYPT_PREFIX.slice(0, -1),
+    `N=${DEFAULT_SCRYPT_CONFIG.N}`,
+    `r=${DEFAULT_SCRYPT_CONFIG.r}`,
+    `p=${DEFAULT_SCRYPT_CONFIG.p}`,
+    salt.toString('base64'),
+    derived.toString('base64'),
+  ].join('$');
+};
+
+const isLegacySha256Hash = value => (
+  typeof value === 'string' && LEGACY_SHA256_REGEX.test(value)
+);
+
+const parseScryptHash = storedHash => {
+  if (typeof storedHash !== 'string' || !storedHash.startsWith(SCRYPT_PREFIX)) {
+    return null;
+  }
+
+  const parts = storedHash.slice(SCRYPT_PREFIX.length).split('$');
+  if (parts.length !== 5) {
+    return null;
+  }
+
+  const [nToken, rToken, pToken, saltBase64, hashBase64] = parts;
+  const N = Number.parseInt(nToken.replace('N=', ''), 10);
+  const r = Number.parseInt(rToken.replace('r=', ''), 10);
+  const p = Number.parseInt(pToken.replace('p=', ''), 10);
+
+  if (!Number.isInteger(N) || !Number.isInteger(r) || !Number.isInteger(p) || N <= 0 || r <= 0 || p <= 0) {
+    return null;
+  }
+
+  try {
+    const salt = Buffer.from(saltBase64, 'base64');
+    const hash = Buffer.from(hashBase64, 'base64');
+    if (salt.length === 0 || hash.length === 0) {
+      return null;
+    }
+    return {
+      N,
+      r,
+      p,
+      salt,
+      hash,
+    };
+  } catch (error) {
+    return null;
+  }
+};
+
+const verifyPassword = ({ password, storedHash } = {}) => {
+  assertNonEmptyPassword(password);
+
+  if (typeof storedHash !== 'string' || storedHash.length === 0) {
+    return {
+      verified: false,
+      needsRehash: false,
+      newHash: null,
+      format: 'invalid',
+    };
+  }
+
+  const scryptHash = parseScryptHash(storedHash);
+  if (scryptHash) {
+    const derived = crypto.scryptSync(password, scryptHash.salt, scryptHash.hash.length, {
+      N: scryptHash.N,
+      r: scryptHash.r,
+      p: scryptHash.p,
+    });
+    return {
+      verified: crypto.timingSafeEqual(derived, scryptHash.hash),
+      needsRehash: false,
+      newHash: null,
+      format: 'scrypt',
+    };
+  }
+
+  if (isLegacySha256Hash(storedHash)) {
+    const legacyHash = crypto.createHash('sha256').update(password).digest('hex');
+    const verified = legacyHash === storedHash;
+
+    return {
+      verified,
+      needsRehash: verified,
+      newHash: verified ? hashPassword(password) : null,
+      format: 'legacy-sha256',
+    };
+  }
+
+  return {
+    verified: false,
+    needsRehash: false,
+    newHash: null,
+    format: 'unknown',
+  };
 };
 
 module.exports = {
   hashPassword,
+  verifyPassword,
+  isLegacySha256Hash,
 };

--- a/src/server.js
+++ b/src/server.js
@@ -10,6 +10,7 @@ const parseSessionPaths = value => (value || '')
 
 const createEnv = source => ({
   port: Number.parseInt(source.PORT, 10) || 3000,
+  nodeEnv: source.NODE_ENV || 'development',
   databaseDialect: source.DATABASE_DIALECT || 'sqlite',
   databaseUrl: source.DATABASE_URL || '',
   databaseHost: source.DATABASE_HOST || '',
@@ -27,6 +28,7 @@ const createEnv = source => ({
   devSessionPaths: parseSessionPaths(source.DEV_SESSION_PATHS),
   loginUsername: source.FIXED_LOGIN_USERNAME || source.LOGIN_USERNAME || '',
   loginPassword: source.FIXED_LOGIN_PASSWORD || source.LOGIN_PASSWORD || '',
+  loginPasswordHash: source.FIXED_LOGIN_PASSWORD_HASH || source.LOGIN_PASSWORD_HASH || '',
   loginUserId: source.FIXED_LOGIN_USER_ID || source.LOGIN_USER_ID || '',
   loginSessionTtlMs: Number.parseInt(source.LOGIN_SESSION_TTL_MS, 10) || 86_400_000,
   logFilePath: source.LOG_FILE_PATH || path.join(process.cwd(), 'var', 'logs', 'mangaviewer.log'),


### PR DESCRIPTION
### Motivation
- 本番環境で `admin/admin` の既定値による誤った認証成立を防ぐため、固定ログインの必須設定を厳格化する。 
- 平文や単純な SHA-256 比較は安全性が不十分なため、KDF（scrypt）ベースのハッシュ保存・検証へ移行する。 
- 既存運用中の旧形式ハッシュ（legacy SHA-256）を段階的に移行できるよう再ハッシュ検出と手順を用意する。 

### Description
- `src/app/createDependencies.js` に `nodeEnv` 判定を導入して `nodeEnv === 'production'` の場合は `loginUsername` / `loginPassword` 未設定で起動エラーとし、`admin/admin` フォールバックを廃止して固定ログイン設定を無効化する実装を追加した。 
- `src/server.js` の `createEnv` に `nodeEnv` と `loginPasswordHash` の解決を追加して起動時にハッシュを渡せるようにした。 
- `src/infrastructure/auth/fixedUserPasswordHasher.js` を scrypt ベースのハッシュ生成 (`hashPassword`) と検証 (`verifyPassword`) に差し替え、保存文字列形式を `$scrypt$N=...$r=...$p=...$<salt>$<derived>` として旧 SHA-256 フォーマットの検知ロジックと再ハッシュ生成を実装した。 
- `src/infrastructure/StaticLoginAuthenticator.js` を平文／単純ハッシュ比較から `verifyPassword` ベースへ変更し、旧形式ハッシュで成功した場合に `onPasswordRehashRequired` コールバックで `upgradedHash`（新形式）を通知する移行フックを追加した。 
- テストを更新して `__tests__/small/infrastructure/StaticLoginAuthenticator.test.js` と `__tests__/medium/app/createDependencies.login.test.js` に KDF ハッシュ照合、legacy SHA-256 からの再ハッシュ通知、`loginPasswordHash` 利用ケース、production 起動バリデーションを追加した。 
- ドキュメントを更新／追加し、`doc/4_application/app/createDependencies/readme.md` と `doc/7_infrastructure/StaticLoginAuthenticator/readme.md` を KDF仕様に合わせて更新し、`doc/7_infrastructure/StaticLoginAuthenticator/運用手順_固定ログイン認証ハッシュ移行.md` を新規追加して移行手順を明記した。 

### Testing
- `node` スクリプトによるハッシュの簡易検証で `hashPassword` による scrypt 文字列生成と `verifyPassword` の検証が成功することを確認した（成功）。 
- `StaticLoginAuthenticator` を直接呼び出すスクリプトで legacy SHA-256 を与えた場合に認証成功し `onPasswordRehashRequired` が呼ばれることを確認した（成功）。 
- CI 相当の `jest` 実行は環境の `cross-env` が存在しないため実行できず（`cross-env: not found`）、自動テストスイートは未実行となった（未実行）。 
- 依存追加（`bcryptjs` 等）はレジストリアクセスで `403 Forbidden` が発生し導入できなかったため、組み込み KDF の scrypt を採用して実装した（パッケージ導入失敗）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3c4a6b7c8832b903cc77cbb84477c)