### PR TITLE
fix: contentId検証で大文字16進文字を許容し小文字正規化を統一する

### DIFF
--- a/__tests__/medium/controller/router/media/cookieAuthMediaPost.integration.test.js
+++ b/__tests__/medium/controller/router/media/cookieAuthMediaPost.integration.test.js
@@ -16,6 +16,8 @@ const SequelizeUnitOfWork = require('../../../../../src/infrastructure/Sequelize
 const MulterDiskStorageContentUploadAdapter = require('../../../../../src/infrastructure/MulterDiskStorageContentUploadAdapter');
 const { LoginService } = require('../../../../../src/application/user/command/LoginService');
 
+const MINIMAL_JPEG_HEADER = Buffer.from([0xff, 0xd8, 0xff, 0xdb]);
+
 class FixedMediaIdValueGenerator {
   generate() {
     return 'abcdefabcdefabcdefabcdefabcdefab';
@@ -109,7 +111,7 @@ describe('Cookie認証での /api/media 回帰テスト (medium)', () => {
       .field('tags[0][category]', '作者')
       .field('tags[0][label]', '山田')
       .field('contents[0][position]', '1')
-      .attach('contents[0][file]', Buffer.from('a'), 'first.jpg');
+      .attach('contents[0][file]', MINIMAL_JPEG_HEADER, 'first.jpg');
 
     expect(response.status).toBe(200);
     expect(response.body).toEqual({

--- a/__tests__/small/infrastructure/MulterDiskStorageContentUploadAdapter.test.js
+++ b/__tests__/small/infrastructure/MulterDiskStorageContentUploadAdapter.test.js
@@ -8,4 +8,43 @@ describe('MulterDiskStorageContentUploadAdapter', () => {
   ])('rootDirectory が %p の場合は初期化時に例外となる', rootDirectory => {
     expect(() => new MulterDiskStorageContentUploadAdapter({ rootDirectory })).toThrow(Error);
   });
+
+  test('大文字のcontentIdでも正規化されて成功する', done => {
+    jest.isolateModules(() => {
+      jest.doMock('multer', () => {
+        const multer = () => ({
+          fields: () => (req, _res, cb) => cb(),
+        });
+        multer.diskStorage = options => options;
+        multer.MulterError = class MulterError extends Error {};
+        return multer;
+      });
+
+      // eslint-disable-next-line global-require
+      const Adapter = require('../../../src/infrastructure/MulterDiskStorageContentUploadAdapter');
+      const adapter = new Adapter({ rootDirectory: '/tmp' });
+
+      const req = {
+        body: {
+          contents: {
+            0: {
+              position: '1',
+              id: 'ABCDEF0123456789ABCDEF0123456789',
+            },
+          },
+        },
+        files: {},
+      };
+
+      adapter.execute(req, {}, error => {
+        try {
+          expect(error).toBeUndefined();
+          expect(req.context.contentIds).toEqual(['abcdef0123456789abcdef0123456789']);
+          done();
+        } catch (assertionError) {
+          done(assertionError);
+        }
+      });
+    });
+  });
 });

--- a/__tests__/small/infrastructure/MulterDiskStorageContentUploadAdapter.test.js
+++ b/__tests__/small/infrastructure/MulterDiskStorageContentUploadAdapter.test.js
@@ -1,6 +1,22 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const express = require('express');
+const request = require('supertest');
+
 const MulterDiskStorageContentUploadAdapter = require('../../../src/infrastructure/MulterDiskStorageContentUploadAdapter');
 
 describe('MulterDiskStorageContentUploadAdapter', () => {
+  let rootDirectory;
+
+  beforeEach(() => {
+    rootDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'multer-disk-storage-content-upload-adapter-small-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(rootDirectory, { recursive: true, force: true });
+  });
+
   test.each([
     undefined,
     null,
@@ -9,42 +25,29 @@ describe('MulterDiskStorageContentUploadAdapter', () => {
     expect(() => new MulterDiskStorageContentUploadAdapter({ rootDirectory })).toThrow(Error);
   });
 
-  test('大文字のcontentIdでも正規化されて成功する', done => {
-    jest.isolateModules(() => {
-      jest.doMock('multer', () => {
-        const multer = () => ({
-          fields: () => (req, _res, cb) => cb(),
-        });
-        multer.diskStorage = options => options;
-        multer.MulterError = class MulterError extends Error {};
-        return multer;
-      });
+  test('大文字のcontentIdでも正規化されて成功する', async () => {
+    const adapter = new MulterDiskStorageContentUploadAdapter({ rootDirectory });
+    const app = express();
 
-      // eslint-disable-next-line global-require
-      const Adapter = require('../../../src/infrastructure/MulterDiskStorageContentUploadAdapter');
-      const adapter = new Adapter({ rootDirectory: '/tmp' });
-
-      const req = {
-        body: {
-          contents: {
-            0: {
-              position: '1',
-              id: 'ABCDEF0123456789ABCDEF0123456789',
-            },
-          },
-        },
-        files: {},
-      };
-
-      adapter.execute(req, {}, error => {
-        try {
-          expect(error).toBeUndefined();
-          expect(req.context.contentIds).toEqual(['abcdef0123456789abcdef0123456789']);
-          done();
-        } catch (assertionError) {
-          done(assertionError);
+    app.post('/upload', (req, res) => {
+      adapter.execute(req, res, error => {
+        if (error) {
+          res.status(error.status ?? 500).json({ message: error.message });
+          return;
         }
+
+        res.status(200).json({ contentIds: req.context.contentIds });
       });
+    });
+
+    const response = await request(app)
+      .post('/upload')
+      .field('contents[0][position]', '1')
+      .field('contents[0][id]', 'ABCDEF0123456789ABCDEF0123456789');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      contentIds: ['abcdef0123456789abcdef0123456789'],
     });
   });
 });

--- a/src/infrastructure/MulterDiskStorageContentUploadAdapter.js
+++ b/src/infrastructure/MulterDiskStorageContentUploadAdapter.js
@@ -278,25 +278,27 @@ module.exports = class MulterDiskStorageContentUploadAdapter extends IContentUpl
     }
 
     if (hasFile) {
-      if (!(/^[0-9a-f]{32}$/).test(uploadedFile.generatedContentId ?? '')) {
+      const normalizedGeneratedContentId = (uploadedFile.generatedContentId ?? '').toLowerCase();
+      if (!(/^[0-9a-f]{32}$/i).test(normalizedGeneratedContentId)) {
         throw new Error('generated contentId is invalid');
       }
 
       return {
         index,
         position,
-        contentId: uploadedFile.generatedContentId,
+        contentId: normalizedGeneratedContentId,
       };
     }
 
-    if (!(/^[0-9a-f]{32}$/).test(contentId)) {
+    const normalizedContentId = contentId.toLowerCase();
+    if (!(/^[0-9a-f]{32}$/i).test(normalizedContentId)) {
       throw new Error('contentId is invalid');
     }
 
     return {
       index,
       position,
-      contentId,
+      contentId: normalizedContentId,
     };
   }
 
@@ -318,16 +320,16 @@ module.exports = class MulterDiskStorageContentUploadAdapter extends IContentUpl
     }
 
     const normalized = rawValue.trim();
-    if ((/^[0-9a-f]{32}$/).test(normalized)) {
-      return normalized;
+    if ((/^[0-9a-f]{32}$/i).test(normalized)) {
+      return normalized.toLowerCase();
     }
 
-    const matched = normalized.match(/([0-9a-f]{32})(?:\?.*)?$/);
+    const matched = normalized.match(/([0-9a-f]{32})(?:\?.*)?$/i);
     if (!matched) {
       return normalized;
     }
 
-    return matched[1];
+    return matched[1].toLowerCase();
   }
 
   #createUniqueContentId() {


### PR DESCRIPTION
### Motivation
- クライアントや既存データで contentId の大文字/小文字が混在する可能性があるため、大小判定で不要なバリデーションエラーや比較不整合を防止する目的です。

### Description
- `#createContent` 内で `generatedContentId` と `contentId` の検証正規表現を大文字許容（`i` フラグ）へ変更し、返却前に `toLowerCase()` で正規化するようにしました (`src/infrastructure/MulterDiskStorageContentUploadAdapter.js`).
- `#extractContentId` の完全一致と末尾抽出の正規表現を大文字許容に統一し、抽出成功時は小文字化して返すようにしました (`src/infrastructure/MulterDiskStorageContentUploadAdapter.js`).
- 大文字の contentId を入力しても成功し、小文字で正規化されることを確認するテストを追加しました (`__tests__/small/infrastructure/MulterDiskStorageContentUploadAdapter.test.js`).
- アップロード時に生成される `generatedContentId` についても内部で小文字化して扱うように変更しました.

### Testing
- 実行: `npm test -- __tests__/small/infrastructure/MulterDiskStorageContentUploadAdapter.test.js` はプロジェクトに `test` スクリプトが存在しないため失敗しました。
- 実行: `npm run test:small -- MulterDiskStorageContentUploadAdapter.test.js` は環境で `cross-env` が見つからず失敗しました（`sh: 1: cross-env: not found`）。
- 追加した単体テストはリポジトリに追加済みで、環境依存のツールが利用可能な環境で実行すれば回帰検出が可能です。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3cdd85d2c832b8ad05d35de3214f4)