### PR TITLE
fix: 署名検証・contentIds生成失敗時にアップロード残骸を削除

### DIFF
--- a/__tests__/medium/controller/router/media/cookieAuthMediaPost.integration.test.js
+++ b/__tests__/medium/controller/router/media/cookieAuthMediaPost.integration.test.js
@@ -109,7 +109,7 @@ describe('Cookie認証での /api/media 回帰テスト (medium)', () => {
       .field('tags[0][category]', '作者')
       .field('tags[0][label]', '山田')
       .field('contents[0][position]', '1')
-      .attach('contents[0][file]', Buffer.from('a'), 'first.jpg');
+      .attach('contents[0][file]', Buffer.from([0xff, 0xd8, 0xff, 0xdb]), 'first.jpg');
 
     expect(response.status).toBe(200);
     expect(response.body).toEqual({

--- a/__tests__/small/infrastructure/MulterDiskStorageContentUploadAdapter.test.js
+++ b/__tests__/small/infrastructure/MulterDiskStorageContentUploadAdapter.test.js
@@ -1,3 +1,10 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const express = require('express');
+const request = require('supertest');
+
 const MulterDiskStorageContentUploadAdapter = require('../../../src/infrastructure/MulterDiskStorageContentUploadAdapter');
 
 describe('MulterDiskStorageContentUploadAdapter', () => {
@@ -7,5 +14,37 @@ describe('MulterDiskStorageContentUploadAdapter', () => {
     '',
   ])('rootDirectory が %p の場合は初期化時に例外となる', rootDirectory => {
     expect(() => new MulterDiskStorageContentUploadAdapter({ rootDirectory })).toThrow(Error);
+  });
+
+  test('署名不正時に保存済みファイルと空ディレクトリが残らない', async () => {
+    const rootDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'content-upload-adapter-small-'));
+    const app = express();
+    const adapter = new MulterDiskStorageContentUploadAdapter({ rootDirectory });
+
+    app.post('/api/media', (req, res) => {
+      req.context = {};
+      adapter.execute(req, res, error => {
+        if (error) {
+          res.status(error.status ?? 200).json({ code: 1 });
+          return;
+        }
+
+        res.status(200).json({ code: 0 });
+      });
+    });
+
+    const response = await request(app)
+      .post('/api/media')
+      .field('contents[0][position]', '1')
+      .attach('contents[0][file]', Buffer.from('invalid-jpeg-signature'), {
+        filename: 'fake.jpg',
+        contentType: 'image/jpeg',
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body.code).toBe(1);
+    expect(fs.readdirSync(rootDirectory)).toEqual([]);
+
+    fs.rmSync(rootDirectory, { recursive: true, force: true });
   });
 });

--- a/src/infrastructure/MulterDiskStorageContentUploadAdapter.js
+++ b/src/infrastructure/MulterDiskStorageContentUploadAdapter.js
@@ -198,7 +198,7 @@ module.exports = class MulterDiskStorageContentUploadAdapter extends IContentUpl
       }
 
       try {
-        await fs.promises.rm(currentDirectory, { recursive: false });
+        await fs.promises.rmdir(currentDirectory);
       } catch (error) {
         if (error?.code === 'ENOENT') {
           currentDirectory = path.dirname(currentDirectory);

--- a/src/infrastructure/MulterDiskStorageContentUploadAdapter.js
+++ b/src/infrastructure/MulterDiskStorageContentUploadAdapter.js
@@ -75,7 +75,9 @@ module.exports = class MulterDiskStorageContentUploadAdapter extends IContentUpl
 
   #upload;
 
-  constructor({ rootDirectory }) {
+  #logger;
+
+  constructor({ rootDirectory, logger = console }) {
     super();
 
     if (!(typeof rootDirectory === 'string' && rootDirectory.length > 0)) {
@@ -83,6 +85,7 @@ module.exports = class MulterDiskStorageContentUploadAdapter extends IContentUpl
     }
 
     this.#rootDirectory = rootDirectory;
+    this.#logger = (typeof logger?.warn === 'function') ? logger : console;
     this.#upload = multer({
       storage: multer.diskStorage({
         destination: (_req, file, cb) => {
@@ -142,15 +145,79 @@ module.exports = class MulterDiskStorageContentUploadAdapter extends IContentUpl
         return;
       }
 
+      const uploadedFilePaths = this.#collectUploadedFilePaths(req?.files ?? {});
       try {
         this.#validateFileSignatures(req?.files ?? {});
         req.context = req.context ?? {};
         req.context.contentIds = this.#createContentIds(req);
         cb();
       } catch (processingError) {
-        cb(processingError);
+        this.#cleanupUploadedFiles(uploadedFilePaths)
+          .finally(() => cb(processingError));
       }
     });
+  }
+
+  #collectUploadedFilePaths(filesByField) {
+    return Object.values(filesByField)
+      .flat()
+      .map(file => file?.path)
+      .filter(filePath => typeof filePath === 'string' && filePath.length > 0);
+  }
+
+  async #cleanupUploadedFiles(filePaths) {
+    for (const filePath of new Set(filePaths)) {
+      await this.#cleanupUploadedFile(filePath);
+    }
+  }
+
+  async #cleanupUploadedFile(filePath) {
+    try {
+      await fs.promises.unlink(filePath);
+    } catch (error) {
+      if (error?.code !== 'ENOENT') {
+        this.#logger.warn('failed to remove uploaded file', {
+          filePath,
+          error,
+        });
+        return;
+      }
+    }
+
+    await this.#cleanupEmptyDirectories(path.dirname(filePath));
+  }
+
+  async #cleanupEmptyDirectories(startDirectory) {
+    const rootDirectory = path.resolve(this.#rootDirectory);
+    let currentDirectory = path.resolve(startDirectory);
+
+    while (currentDirectory !== rootDirectory) {
+      const relativePath = path.relative(rootDirectory, currentDirectory);
+      if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+        break;
+      }
+
+      try {
+        await fs.promises.rm(currentDirectory, { recursive: false });
+      } catch (error) {
+        if (error?.code === 'ENOENT') {
+          currentDirectory = path.dirname(currentDirectory);
+          continue;
+        }
+
+        if (error?.code === 'ENOTEMPTY' || error?.code === 'EEXIST') {
+          break;
+        }
+
+        this.#logger.warn('failed to remove empty upload directory', {
+          directory: currentDirectory,
+          error,
+        });
+        break;
+      }
+
+      currentDirectory = path.dirname(currentDirectory);
+    }
   }
 
   #normalizeUploadError(error) {


### PR DESCRIPTION
### Motivation
- 署名検証や `contentIds` 生成の途中で例外が発生した場合に、Multer が既にディスクへ書き出したファイルや空のシャーディングディレクトリが残りストレージ汚染を招く問題を解消するため。\

### Description
- コンストラクタに `logger` パラメータを追加し、`warn` を利用して後始末失敗時の警告出力を行うようにした（既定は `console`）。\
- `execute` 内でアップロード完了直後に `req.files` から保存済みファイルパスを収集する `#collectUploadedFilePaths` を追加し、`#validateFileSignatures`／`#createContentIds` で例外が発生した catch ブロック内で収集済みファイルの削除を実行するようにした。\
- ファイル削除と空シャーディングディレクトリの後始末を行う `#cleanupUploadedFiles`、`#cleanupUploadedFile`、`#cleanupEmptyDirectories` を追加し、ルート配下のみを対象に段階的にディレクトリ削除を試みるようにした。\
- 削除の失敗は元の業務エラーを上書きせず `logger.warn` で記録するのみとし、実装に合わせて小テストを追加した（`__tests__/small/infrastructure/MulterDiskStorageContentUploadAdapter.test.js`）。\

### Testing
- small テストに `署名不正時に保存済みファイルと空ディレクトリが残らない` ケースを追加した（ファイル送信で不正シグネチャを与え `400` を期待し、ルートディレクトリが空であることを検証）。\
- 追加テストのローカル実行を試みたが、実行コマンド `npm run test:small -- MulterDiskStorageContentUploadAdapter.test.js` はこの環境で `cross-env: not found` により実行できなかったためテスト実行は未完了。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3cdddb22c832b916447e4982593c6)