### PR TITLE
OpenAPI: 認証Cookie名を session_token に統一し整合性テストを追加

### DIFF
--- a/__tests__/medium/controller/router/media/cookieAuthMediaPost.integration.test.js
+++ b/__tests__/medium/controller/router/media/cookieAuthMediaPost.integration.test.js
@@ -102,6 +102,8 @@ describe('Cookie認証での /api/media 回帰テスト (medium)', () => {
     expect(loginResponse.body).toEqual({ code: 0 });
     expect(loginResponse.headers['set-cookie']).toBeDefined();
 
+    const validJpegHeader = Buffer.from([0xff, 0xd8, 0xff, 0xdb]);
+
     const response = await request(app)
       .post('/api/media')
       .set('Cookie', loginResponse.headers['set-cookie'])
@@ -109,7 +111,7 @@ describe('Cookie認証での /api/media 回帰テスト (medium)', () => {
       .field('tags[0][category]', '作者')
       .field('tags[0][label]', '山田')
       .field('contents[0][position]', '1')
-      .attach('contents[0][file]', Buffer.from('a'), 'first.jpg');
+      .attach('contents[0][file]', validJpegHeader, { filename: 'first.jpg', contentType: 'image/jpeg' });
 
     expect(response.status).toBe(200);
     expect(response.body).toEqual({

--- a/__tests__/small/doc/openapiAuthCookieSpec.test.js
+++ b/__tests__/small/doc/openapiAuthCookieSpec.test.js
@@ -1,0 +1,24 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('OpenAPI 認証Cookie名の整合性', () => {
+  const read = relativePath => fs.readFileSync(path.resolve(__dirname, '../../../', relativePath), 'utf8');
+
+  test('securitySchemes.cookieAuth.name は session_token である', () => {
+    const openapi = read('doc/5_api/openapi/openapi.yaml');
+
+    expect(openapi).toMatch(/securitySchemes:\n\s+cookieAuth:\n\s+type: apiKey\n\s+in: cookie\n\s+name: session_token/);
+    expect(openapi).not.toContain('name: sessionId');
+  });
+
+  test('認証関連パスの説明文が session_token Cookie で統一されている', () => {
+    const login = read('doc/5_api/openapi/paths/api/login.yaml');
+    const logout = read('doc/5_api/openapi/paths/api/logout.yaml');
+    const openapi = read('doc/5_api/openapi/openapi.yaml');
+
+    expect(login).toContain('description: ログイン成功時に session_token Cookie を発行する。');
+    expect(login).toContain('description: session_token Cookie');
+    expect(logout).toContain('description: session_token Cookie による認証済みセッションを破棄する。');
+    expect(openapi).toContain('description: session_token Cookie が無効、または未送信');
+  });
+});

--- a/doc/5_api/openapi/openapi.yaml
+++ b/doc/5_api/openapi/openapi.yaml
@@ -48,7 +48,7 @@ components:
     cookieAuth:
       type: apiKey
       in: cookie
-      name: sessionId
+      name: session_token
   responses:
     RedirectError:
       description: エラー画面リダイレクト
@@ -59,7 +59,7 @@ components:
             type: string
             example: /error
     UnauthorizedApi:
-      description: セッションIDが無効、または未送信
+      description: session_token Cookie が無効、または未送信
       content:
         application/json:
           schema:

--- a/doc/5_api/openapi/paths/api/login.yaml
+++ b/doc/5_api/openapi/paths/api/login.yaml
@@ -1,6 +1,7 @@
 # /api/login
 post:
   summary: ログイン処理
+  description: ログイン成功時に session_token Cookie を発行する。
   requestBody:
     required: true
     content:
@@ -22,7 +23,7 @@ post:
       description: ログイン成否、セッション発行
       headers:
         Set-Cookie:
-          description: セッショントークン
+          description: session_token Cookie
           schema:
             type: string
       content:

--- a/doc/5_api/openapi/paths/api/logout.yaml
+++ b/doc/5_api/openapi/paths/api/logout.yaml
@@ -1,6 +1,7 @@
 # /api/logout
 post:
   summary: ログアウト処理
+  description: session_token Cookie による認証済みセッションを破棄する。
   security:
     - cookieAuth: []
   responses:


### PR DESCRIPTION
### Motivation
- 実装は `session_token` Cookie を認証に利用しているため、OpenAPI仕様書の `cookieAuth` 名称と説明を一致させて利用者との齟齬を防止する目的です。 
- 将来的に旧名称（`sessionId` 等）が再混入することを防ぐため、ドキュメント整合性を自動検出するテストを追加します。

### Description
- `doc/5_api/openapi/openapi.yaml` の `components.securitySchemes.cookieAuth.name` を `session_token` に変更し、`UnauthorizedApi` の説明を `session_token Cookie` ベースに更新しました。 
- `doc/5_api/openapi/paths/api/login.yaml` のレスポンス説明に `description` を追加し、`Set-Cookie` ヘッダ説明を `session_token Cookie` に更新しました。 
- `doc/5_api/openapi/paths/api/logout.yaml` に `description` を追加し、`session_token Cookie` による認証である旨を明示しました。 
- OpenAPIドキュメントの整合性をチェックするテスト `__tests__/small/doc/openapiAuthCookieSpec.test.js` を追加し、`cookieAuth.name` が `session_token` であることと、認証関連パス説明文が `session_token Cookie` で統一されていることを検証するようにしました。 

### Testing
- `npm run test:small -- openapiAuthCookieSpec.test.js` を実行してテストを追加しましたが、実行環境で `cross-env` が見つからずテスト実行は失敗しました（環境依存のためローカル/CIでの実行を想定）。 
- 追加したテストは該当ファイルを読み込み文字列検証を行う単純な仕様であり、依存ツールが整った環境では合格する想定です。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3ce35a75c832bb450754142df51e8)