### PR TITLE
feat: 固定ログインのハッシュ方式を識別し旧SHA-256から新方式へ移行可能にする

### DIFF
--- a/__tests__/medium/controller/router/media/cookieAuthMediaPost.integration.test.js
+++ b/__tests__/medium/controller/router/media/cookieAuthMediaPost.integration.test.js
@@ -16,6 +16,13 @@ const SequelizeUnitOfWork = require('../../../../../src/infrastructure/Sequelize
 const MulterDiskStorageContentUploadAdapter = require('../../../../../src/infrastructure/MulterDiskStorageContentUploadAdapter');
 const { LoginService } = require('../../../../../src/application/user/command/LoginService');
 
+const createMinimalJpegBuffer = () => Buffer.from([
+  0xff, 0xd8, 0xff, 0xdb,
+  0x00, 0x43, 0x00, 0x08,
+  0x06, 0x06, 0x07, 0x06,
+  0x05, 0x08, 0x07, 0x07,
+]);
+
 class FixedMediaIdValueGenerator {
   generate() {
     return 'abcdefabcdefabcdefabcdefabcdefab';
@@ -109,7 +116,7 @@ describe('Cookie認証での /api/media 回帰テスト (medium)', () => {
       .field('tags[0][category]', '作者')
       .field('tags[0][label]', '山田')
       .field('contents[0][position]', '1')
-      .attach('contents[0][file]', Buffer.from('a'), 'first.jpg');
+      .attach('contents[0][file]', createMinimalJpegBuffer(), 'first.jpg');
 
     expect(response.status).toBe(200);
     expect(response.body).toEqual({

--- a/__tests__/small/infrastructure/StaticLoginAuthenticator.test.js
+++ b/__tests__/small/infrastructure/StaticLoginAuthenticator.test.js
@@ -42,7 +42,7 @@ describe('StaticLoginAuthenticator', () => {
       userId: 'user-1',
       username: 'admin',
       previousScheme: 'legacy-sha256',
-      passwordHash: expect.stringMatching(new RegExp(`^${BCRYPT_PBKDF_PREFIX}`)),
+      passwordHash: expect.stringContaining(BCRYPT_PBKDF_PREFIX),
     }));
   });
 

--- a/__tests__/small/infrastructure/StaticLoginAuthenticator.test.js
+++ b/__tests__/small/infrastructure/StaticLoginAuthenticator.test.js
@@ -1,11 +1,16 @@
 const StaticLoginAuthenticator = require('../../../src/infrastructure/StaticLoginAuthenticator');
+const {
+  BCRYPT_PBKDF_PREFIX,
+  hashPassword,
+} = require('../../../src/infrastructure/auth/fixedUserPasswordHasher');
 
 describe('StaticLoginAuthenticator', () => {
-  test('固定認証情報と一致する場合は userId を返す', async () => {
+  test('新方式ハッシュで固定認証情報と一致する場合は userId を返す', async () => {
     const authenticator = new StaticLoginAuthenticator({
       username: 'admin',
       password: 'secret',
       userId: 'user-1',
+      passwordHashOptions: { bcryptCost: 4 },
     });
 
     await expect(authenticator.execute({
@@ -14,10 +19,37 @@ describe('StaticLoginAuthenticator', () => {
     })).resolves.toBe('user-1');
   });
 
-  test('固定認証情報と一致しない場合は null を返す', async () => {
+  test('旧SHA-256ハッシュとの互換検証ができ、成功時に再ハッシュが行われる', async () => {
+    const legacySha256Hash = '2bb80d537b1da3e38bd30361aa855686bde0eacd7162fef6a25fe97bf527a25b';
+    const upgradedHashes = [];
     const authenticator = new StaticLoginAuthenticator({
       username: 'admin',
+      passwordHash: legacySha256Hash,
+      userId: 'user-1',
+      passwordHashOptions: { bcryptCost: 4 },
+      passwordHashUpdater: async payload => {
+        upgradedHashes.push(payload);
+      },
+    });
+
+    await expect(authenticator.execute({
+      username: 'admin',
       password: 'secret',
+    })).resolves.toBe('user-1');
+
+    expect(upgradedHashes).toHaveLength(1);
+    expect(upgradedHashes[0]).toEqual(expect.objectContaining({
+      userId: 'user-1',
+      username: 'admin',
+      previousScheme: 'legacy-sha256',
+      passwordHash: expect.stringMatching(new RegExp(`^${BCRYPT_PBKDF_PREFIX}`)),
+    }));
+  });
+
+  test('不正パスワードは拒否される', async () => {
+    const authenticator = new StaticLoginAuthenticator({
+      username: 'admin',
+      passwordHash: hashPassword('secret', { bcryptCost: 4 }),
       userId: 'user-1',
     });
 
@@ -32,6 +64,7 @@ describe('StaticLoginAuthenticator', () => {
     [{ username: 'admin', password: '', userId: 'user-1' }, 'password must be a non-empty string'],
     [{ username: 'admin', password: 'secret', userId: '' }, 'userId must be a non-empty string'],
     [{ username: null, password: 'secret', userId: 'user-1' }, 'username must be a non-empty string'],
+    [{ username: 'admin', password: 'secret', userId: 'user-1', passwordHashUpdater: 'invalid' }, 'passwordHashUpdater must be a function'],
   ])('コンストラクター設定が不正な場合は例外となる: %s', (payload, expectedMessage) => {
     expect(() => new StaticLoginAuthenticator(payload)).toThrow(expectedMessage);
   });
@@ -46,6 +79,7 @@ describe('StaticLoginAuthenticator', () => {
       username: 'admin',
       password: 'secret',
       userId: 'user-1',
+      passwordHashOptions: { bcryptCost: 4 },
     });
 
     await expect(authenticator.execute(payload)).resolves.toBeNull();

--- a/__tests__/small/infrastructure/auth/fixedUserPasswordHasher.test.js
+++ b/__tests__/small/infrastructure/auth/fixedUserPasswordHasher.test.js
@@ -9,7 +9,7 @@ describe('fixedUserPasswordHasher', () => {
   test('新方式ハッシュを生成して検証できる', () => {
     const passwordHash = hashPassword('secret', { bcryptCost: 4 });
 
-    expect(passwordHash).toEqual(expect.stringMatching(new RegExp(`^${BCRYPT_PBKDF_PREFIX}`)));
+    expect(passwordHash.startsWith(BCRYPT_PBKDF_PREFIX)).toBe(true);
 
     expect(verifyPassword({
       password: 'secret',

--- a/__tests__/small/infrastructure/auth/fixedUserPasswordHasher.test.js
+++ b/__tests__/small/infrastructure/auth/fixedUserPasswordHasher.test.js
@@ -1,0 +1,50 @@
+const {
+  BCRYPT_PBKDF_PREFIX,
+  detectHashScheme,
+  hashPassword,
+  verifyPassword,
+} = require('../../../../src/infrastructure/auth/fixedUserPasswordHasher');
+
+describe('fixedUserPasswordHasher', () => {
+  test('新方式ハッシュを生成して検証できる', () => {
+    const passwordHash = hashPassword('secret', { bcryptCost: 4 });
+
+    expect(passwordHash).toEqual(expect.stringMatching(new RegExp(`^${BCRYPT_PBKDF_PREFIX}`)));
+
+    expect(verifyPassword({
+      password: 'secret',
+      passwordHash,
+    })).toEqual({
+      verified: true,
+      scheme: 'bcrypt-pbkdf',
+      needsRehash: false,
+    });
+  });
+
+  test('旧SHA-256形式の判別と検証互換を提供する', () => {
+    const legacySha256Hash = '2bb80d537b1da3e38bd30361aa855686bde0eacd7162fef6a25fe97bf527a25b';
+
+    expect(detectHashScheme(legacySha256Hash)).toBe('legacy-sha256');
+    expect(verifyPassword({
+      password: 'secret',
+      passwordHash: legacySha256Hash,
+    })).toEqual({
+      verified: true,
+      scheme: 'legacy-sha256',
+      needsRehash: true,
+    });
+  });
+
+  test('不正パスワードは拒否される', () => {
+    const passwordHash = hashPassword('secret', { bcryptCost: 4 });
+
+    expect(verifyPassword({
+      password: 'wrong',
+      passwordHash,
+    })).toEqual({
+      verified: false,
+      scheme: 'bcrypt-pbkdf',
+      needsRehash: false,
+    });
+  });
+});

--- a/__tests__/small/server/createEnv.test.js
+++ b/__tests__/small/server/createEnv.test.js
@@ -1,0 +1,14 @@
+const { createEnv } = require('../../../src/server');
+
+describe('server.createEnv', () => {
+  test('ハッシュ関連パラメータが未指定の場合に安全なデフォルトを設定する', () => {
+    const env = createEnv({});
+
+    expect(env.loginPasswordHashAlgorithm).toBe('bcrypt');
+    expect(env.loginPasswordHashMemoryCost).toBe(65_536);
+    expect(env.loginPasswordHashIterations).toBe(3);
+    expect(env.loginPasswordHashParallelism).toBe(1);
+    expect(env.loginPasswordHashTimeCost).toBe(3);
+    expect(env.loginPasswordHashBcryptCost).toBe(12);
+  });
+});

--- a/__tests__/small/server/createEnv.test.js
+++ b/__tests__/small/server/createEnv.test.js
@@ -1,4 +1,4 @@
-const { createEnv } = require('../../../src/server');
+const { createEnv } = require('../../../src/app/createEnv');
 
 describe('server.createEnv', () => {
   test('ハッシュ関連パラメータが未指定の場合に安全なデフォルトを設定する', () => {

--- a/src/app/createDependencies.js
+++ b/src/app/createDependencies.js
@@ -130,7 +130,16 @@ const createDependencies = (env = {}) => {
   const loginAuthenticator = new StaticLoginAuthenticator({
     username: env.loginUsername || 'admin',
     password: env.loginPassword || 'admin',
+    passwordHash: env.loginPasswordHash || '',
     userId: env.loginUserId || 'admin',
+    passwordHashOptions: {
+      algorithm: env.loginPasswordHashAlgorithm || 'bcrypt',
+      memoryCost: env.loginPasswordHashMemoryCost || 65_536,
+      iterations: env.loginPasswordHashIterations || 3,
+      parallelism: env.loginPasswordHashParallelism || 1,
+      timeCost: env.loginPasswordHashTimeCost || 3,
+      bcryptCost: env.loginPasswordHashBcryptCost || 12,
+    },
   });
   const updateMediaService = new UpdateMediaService({ mediaRepository, unitOfWork });
   const deleteMediaService = new DeleteMediaService({ mediaRepository, unitOfWork });

--- a/src/app/createEnv.js
+++ b/src/app/createEnv.js
@@ -1,0 +1,46 @@
+const path = require('path');
+
+const parseSessionPaths = value => (value || '')
+  .split(',')
+  .map(entry => entry.trim())
+  .filter(entry => entry.length > 0);
+
+const createEnv = source => ({
+  nodeEnv: source.NODE_ENV || 'development',
+  port: Number.parseInt(source.PORT, 10) || 3000,
+  databaseDialect: source.DATABASE_DIALECT || 'sqlite',
+  databaseUrl: source.DATABASE_URL || '',
+  databaseHost: source.DATABASE_HOST || '',
+  databasePort: Number.parseInt(source.DATABASE_PORT, 10) || 5432,
+  databaseName: source.DATABASE_NAME || '',
+  databaseUsername: source.DATABASE_USERNAME || '',
+  databasePassword: source.DATABASE_PASSWORD || '',
+  databaseStoragePath: source.DATABASE_STORAGE_PATH
+    || path.join(process.cwd(), 'var', 'data', 'mangaviewer.sqlite'),
+  contentRootDirectory: source.CONTENT_ROOT_DIRECTORY
+    || path.join(process.cwd(), 'public', 'contents'),
+  devSessionToken: source.DEV_SESSION_TOKEN || '',
+  devSessionUserId: source.DEV_SESSION_USER_ID || '',
+  devSessionTtlMs: Number.parseInt(source.DEV_SESSION_TTL_MS, 10) || 0,
+  devSessionPaths: parseSessionPaths(source.DEV_SESSION_PATHS),
+  loginUsername: source.FIXED_LOGIN_USERNAME || source.LOGIN_USERNAME || '',
+  loginPassword: source.FIXED_LOGIN_PASSWORD || source.LOGIN_PASSWORD || '',
+  loginPasswordHash: source.FIXED_LOGIN_PASSWORD_HASH || source.LOGIN_PASSWORD_HASH || '',
+  loginUserId: source.FIXED_LOGIN_USER_ID || source.LOGIN_USER_ID || '',
+  loginSessionTtlMs: Number.parseInt(source.LOGIN_SESSION_TTL_MS, 10) || 86_400_000,
+  loginPasswordHashAlgorithm: source.LOGIN_PASSWORD_HASH_ALGORITHM || 'bcrypt',
+  loginPasswordHashMemoryCost: Number.parseInt(source.LOGIN_PASSWORD_HASH_MEMORY_COST, 10) || 65_536,
+  loginPasswordHashIterations: Number.parseInt(source.LOGIN_PASSWORD_HASH_ITERATIONS, 10) || 3,
+  loginPasswordHashParallelism: Number.parseInt(source.LOGIN_PASSWORD_HASH_PARALLELISM, 10) || 1,
+  loginPasswordHashTimeCost: Number.parseInt(source.LOGIN_PASSWORD_HASH_TIME_COST, 10) || 3,
+  loginPasswordHashBcryptCost: Number.parseInt(source.LOGIN_PASSWORD_HASH_BCRYPT_COST, 10) || 12,
+  allowLegacySessionTokenHeader: source.ALLOW_LEGACY_SESSION_TOKEN_HEADER || '',
+  logFilePath: source.LOG_FILE_PATH || path.join(process.cwd(), 'var', 'logs', 'mangaviewer.log'),
+  logLevel: source.LOG_LEVEL || 'INFO',
+  logOutputs: source.LOG_OUTPUTS
+    || (source.NODE_ENV === 'test' ? 'memory' : 'console,file'),
+});
+
+module.exports = {
+  createEnv,
+};

--- a/src/infrastructure/StaticLoginAuthenticator.js
+++ b/src/infrastructure/StaticLoginAuthenticator.js
@@ -1,11 +1,20 @@
-const { hashPassword } = require('./auth/fixedUserPasswordHasher');
+const { hashPassword, verifyPassword } = require('./auth/fixedUserPasswordHasher');
 
 class StaticLoginAuthenticator {
   #username;
   #passwordHash;
   #userId;
+  #passwordHashUpdater;
+  #passwordHashOptions;
 
-  constructor({ username, password, passwordHash, userId } = {}) {
+  constructor({
+    username,
+    password,
+    passwordHash,
+    userId,
+    passwordHashUpdater,
+    passwordHashOptions,
+  } = {}) {
     if (!this.#isNonEmptyString(username)) {
       throw new Error('username must be a non-empty string');
     }
@@ -18,9 +27,17 @@ class StaticLoginAuthenticator {
       throw new Error('userId must be a non-empty string');
     }
 
+    if (passwordHashUpdater !== undefined && typeof passwordHashUpdater !== 'function') {
+      throw new Error('passwordHashUpdater must be a function');
+    }
+
     this.#username = username;
-    this.#passwordHash = this.#isNonEmptyString(passwordHash) ? passwordHash : hashPassword(password);
+    this.#passwordHash = this.#isNonEmptyString(passwordHash)
+      ? passwordHash
+      : hashPassword(password, passwordHashOptions);
     this.#userId = userId;
+    this.#passwordHashUpdater = passwordHashUpdater;
+    this.#passwordHashOptions = passwordHashOptions;
   }
 
   async execute({ username, password } = {}) {
@@ -28,11 +45,26 @@ class StaticLoginAuthenticator {
       return null;
     }
 
-    if (hashPassword(password) === this.#passwordHash) {
-      return this.#userId;
+    const verifyResult = verifyPassword({ password, passwordHash: this.#passwordHash });
+    if (!verifyResult.verified) {
+      return null;
     }
 
-    return null;
+    if (verifyResult.needsRehash) {
+      const upgradedPasswordHash = hashPassword(password, this.#passwordHashOptions);
+      this.#passwordHash = upgradedPasswordHash;
+
+      if (this.#passwordHashUpdater) {
+        await this.#passwordHashUpdater({
+          userId: this.#userId,
+          username: this.#username,
+          passwordHash: upgradedPasswordHash,
+          previousScheme: verifyResult.scheme,
+        });
+      }
+    }
+
+    return this.#userId;
   }
 
   #isNonEmptyString(value) {

--- a/src/infrastructure/auth/fixedUserPasswordHasher.js
+++ b/src/infrastructure/auth/fixedUserPasswordHasher.js
@@ -1,13 +1,132 @@
 const crypto = require('crypto');
+const { pbkdf: bcryptPbkdf } = require('bcrypt-pbkdf');
 
-const hashPassword = password => {
-  if (typeof password !== 'string' || password.length === 0) {
+const DEFAULT_BCRYPT_PBKDF_ROUNDS = 12;
+const DEFAULT_BCRYPT_PBKDF_KEY_LENGTH = 32;
+const BCRYPT_PBKDF_PREFIX = 'bcryptpbkdf$';
+const SHA256_PREFIX = 'sha256$';
+const LEGACY_SHA256_HEX_PATTERN = /^[0-9a-f]{64}$/;
+
+const isNonEmptyString = value => typeof value === 'string' && value.length > 0;
+
+const sha256 = password => crypto.createHash('sha256').update(password).digest('hex');
+
+const normalizeBcryptRounds = value => {
+  const parsed = Number.parseInt(value, 10);
+  if (Number.isNaN(parsed)) {
+    return DEFAULT_BCRYPT_PBKDF_ROUNDS;
+  }
+  return Math.max(4, Math.min(32, parsed));
+};
+
+const deriveBcryptPbkdf = ({ password, salt, rounds, keyLength }) => {
+  const key = Buffer.alloc(keyLength);
+  const result = bcryptPbkdf(
+    Buffer.from(password, 'utf8'),
+    Buffer.byteLength(password, 'utf8'),
+    salt,
+    salt.length,
+    key,
+    keyLength,
+    rounds,
+  );
+
+  if (result !== 0) {
+    throw new Error('failed to derive password hash');
+  }
+
+  return key;
+};
+
+const detectHashScheme = passwordHash => {
+  if (!isNonEmptyString(passwordHash)) {
+    return 'unknown';
+  }
+
+  if (passwordHash.startsWith(BCRYPT_PBKDF_PREFIX)) {
+    return 'bcrypt-pbkdf';
+  }
+
+  if (passwordHash.startsWith(SHA256_PREFIX)) {
+    return 'sha256';
+  }
+
+  if (LEGACY_SHA256_HEX_PATTERN.test(passwordHash)) {
+    return 'legacy-sha256';
+  }
+
+  return 'unknown';
+};
+
+const hashPassword = (password, options = {}) => {
+  if (!isNonEmptyString(password)) {
     throw new Error('password must be a non-empty string');
   }
 
-  return crypto.createHash('sha256').update(password).digest('hex');
+  const rounds = normalizeBcryptRounds(options.bcryptCost);
+  const keyLength = DEFAULT_BCRYPT_PBKDF_KEY_LENGTH;
+  const salt = crypto.randomBytes(16);
+  const derivedKey = deriveBcryptPbkdf({ password, salt, rounds, keyLength });
+
+  return `${BCRYPT_PBKDF_PREFIX}${rounds}$${salt.toString('hex')}$${derivedKey.toString('hex')}`;
+};
+
+const verifyPassword = ({ password, passwordHash } = {}) => {
+  if (!isNonEmptyString(password)) {
+    return { verified: false, scheme: 'invalid-password', needsRehash: false };
+  }
+
+  const scheme = detectHashScheme(passwordHash);
+
+  if (scheme === 'bcrypt-pbkdf') {
+    const [roundsRaw, saltHex, hashHex] = passwordHash.slice(BCRYPT_PBKDF_PREFIX.length).split('$');
+    const rounds = normalizeBcryptRounds(roundsRaw);
+    if (!saltHex || !hashHex) {
+      return { verified: false, scheme, needsRehash: false };
+    }
+
+    const salt = Buffer.from(saltHex, 'hex');
+    const expected = Buffer.from(hashHex, 'hex');
+    const actual = deriveBcryptPbkdf({
+      password,
+      salt,
+      rounds,
+      keyLength: expected.length,
+    });
+
+    const verified = expected.length === actual.length && crypto.timingSafeEqual(expected, actual);
+    return {
+      verified,
+      scheme,
+      needsRehash: false,
+    };
+  }
+
+  if (scheme === 'sha256') {
+    const hash = passwordHash.slice(SHA256_PREFIX.length);
+    return {
+      verified: sha256(password) === hash,
+      scheme,
+      needsRehash: true,
+    };
+  }
+
+  if (scheme === 'legacy-sha256') {
+    return {
+      verified: sha256(password) === passwordHash,
+      scheme,
+      needsRehash: true,
+    };
+  }
+
+  return { verified: false, scheme: 'unknown', needsRehash: false };
 };
 
 module.exports = {
+  BCRYPT_PBKDF_PREFIX,
+  SHA256_PREFIX,
+  DEFAULT_BCRYPT_PBKDF_ROUNDS,
+  detectHashScheme,
   hashPassword,
+  verifyPassword,
 };

--- a/src/server.js
+++ b/src/server.js
@@ -1,6 +1,5 @@
 const path = require('path');
 
-const createApp = require('./app');
 const { hasDevelopmentSession } = require('./app/developmentSession');
 
 const parseSessionPaths = value => (value || '')
@@ -28,8 +27,15 @@ const createEnv = source => ({
   devSessionPaths: parseSessionPaths(source.DEV_SESSION_PATHS),
   loginUsername: source.FIXED_LOGIN_USERNAME || source.LOGIN_USERNAME || '',
   loginPassword: source.FIXED_LOGIN_PASSWORD || source.LOGIN_PASSWORD || '',
+  loginPasswordHash: source.FIXED_LOGIN_PASSWORD_HASH || source.LOGIN_PASSWORD_HASH || '',
   loginUserId: source.FIXED_LOGIN_USER_ID || source.LOGIN_USER_ID || '',
   loginSessionTtlMs: Number.parseInt(source.LOGIN_SESSION_TTL_MS, 10) || 86_400_000,
+  loginPasswordHashAlgorithm: source.LOGIN_PASSWORD_HASH_ALGORITHM || 'bcrypt',
+  loginPasswordHashMemoryCost: Number.parseInt(source.LOGIN_PASSWORD_HASH_MEMORY_COST, 10) || 65_536,
+  loginPasswordHashIterations: Number.parseInt(source.LOGIN_PASSWORD_HASH_ITERATIONS, 10) || 3,
+  loginPasswordHashParallelism: Number.parseInt(source.LOGIN_PASSWORD_HASH_PARALLELISM, 10) || 1,
+  loginPasswordHashTimeCost: Number.parseInt(source.LOGIN_PASSWORD_HASH_TIME_COST, 10) || 3,
+  loginPasswordHashBcryptCost: Number.parseInt(source.LOGIN_PASSWORD_HASH_BCRYPT_COST, 10) || 12,
   allowLegacySessionTokenHeader: source.ALLOW_LEGACY_SESSION_TOKEN_HEADER || '',
   logFilePath: source.LOG_FILE_PATH || path.join(process.cwd(), 'var', 'logs', 'mangaviewer.log'),
   logLevel: source.LOG_LEVEL || 'INFO',
@@ -38,6 +44,7 @@ const createEnv = source => ({
 });
 
 const startServer = async () => {
+  const createApp = require('./app');
   const env = createEnv(process.env);
   const app = createApp(env);
 
@@ -67,7 +74,9 @@ const startServer = async () => {
   });
 };
 
-startServer();
+if (require.main === module) {
+  startServer();
+}
 
 module.exports = {
   createEnv,

--- a/src/server.js
+++ b/src/server.js
@@ -1,50 +1,8 @@
-const path = require('path');
-
+const createApp = require('./app');
+const { createEnv } = require('./app/createEnv');
 const { hasDevelopmentSession } = require('./app/developmentSession');
 
-const parseSessionPaths = value => (value || '')
-  .split(',')
-  .map(entry => entry.trim())
-  .filter(entry => entry.length > 0);
-
-const createEnv = source => ({
-  nodeEnv: source.NODE_ENV || 'development',
-  port: Number.parseInt(source.PORT, 10) || 3000,
-  databaseDialect: source.DATABASE_DIALECT || 'sqlite',
-  databaseUrl: source.DATABASE_URL || '',
-  databaseHost: source.DATABASE_HOST || '',
-  databasePort: Number.parseInt(source.DATABASE_PORT, 10) || 5432,
-  databaseName: source.DATABASE_NAME || '',
-  databaseUsername: source.DATABASE_USERNAME || '',
-  databasePassword: source.DATABASE_PASSWORD || '',
-  databaseStoragePath: source.DATABASE_STORAGE_PATH
-    || path.join(process.cwd(), 'var', 'data', 'mangaviewer.sqlite'),
-  contentRootDirectory: source.CONTENT_ROOT_DIRECTORY
-    || path.join(process.cwd(), 'public', 'contents'),
-  devSessionToken: source.DEV_SESSION_TOKEN || '',
-  devSessionUserId: source.DEV_SESSION_USER_ID || '',
-  devSessionTtlMs: Number.parseInt(source.DEV_SESSION_TTL_MS, 10) || 0,
-  devSessionPaths: parseSessionPaths(source.DEV_SESSION_PATHS),
-  loginUsername: source.FIXED_LOGIN_USERNAME || source.LOGIN_USERNAME || '',
-  loginPassword: source.FIXED_LOGIN_PASSWORD || source.LOGIN_PASSWORD || '',
-  loginPasswordHash: source.FIXED_LOGIN_PASSWORD_HASH || source.LOGIN_PASSWORD_HASH || '',
-  loginUserId: source.FIXED_LOGIN_USER_ID || source.LOGIN_USER_ID || '',
-  loginSessionTtlMs: Number.parseInt(source.LOGIN_SESSION_TTL_MS, 10) || 86_400_000,
-  loginPasswordHashAlgorithm: source.LOGIN_PASSWORD_HASH_ALGORITHM || 'bcrypt',
-  loginPasswordHashMemoryCost: Number.parseInt(source.LOGIN_PASSWORD_HASH_MEMORY_COST, 10) || 65_536,
-  loginPasswordHashIterations: Number.parseInt(source.LOGIN_PASSWORD_HASH_ITERATIONS, 10) || 3,
-  loginPasswordHashParallelism: Number.parseInt(source.LOGIN_PASSWORD_HASH_PARALLELISM, 10) || 1,
-  loginPasswordHashTimeCost: Number.parseInt(source.LOGIN_PASSWORD_HASH_TIME_COST, 10) || 3,
-  loginPasswordHashBcryptCost: Number.parseInt(source.LOGIN_PASSWORD_HASH_BCRYPT_COST, 10) || 12,
-  allowLegacySessionTokenHeader: source.ALLOW_LEGACY_SESSION_TOKEN_HEADER || '',
-  logFilePath: source.LOG_FILE_PATH || path.join(process.cwd(), 'var', 'logs', 'mangaviewer.log'),
-  logLevel: source.LOG_LEVEL || 'INFO',
-  logOutputs: source.LOG_OUTPUTS
-    || (source.NODE_ENV === 'test' ? 'memory' : 'console,file'),
-});
-
 const startServer = async () => {
-  const createApp = require('./app');
   const env = createEnv(process.env);
   const app = createApp(env);
 
@@ -74,9 +32,7 @@ const startServer = async () => {
   });
 };
 
-if (require.main === module) {
-  startServer();
-}
+startServer();
 
 module.exports = {
   createEnv,


### PR DESCRIPTION
### Motivation
- 固定ユーザーのパスワードをより安全なハッシュ方式に移行するため、ハッシュ文字列に方式識別子を含めて方式判定できるようにするための変更です。 
- 旧来のSHA-256ハッシュと互換性を保ちつつ、旧方式での認証成功時に新方式へ再ハッシュして更新する導線を用意するためです。 
- 環境変数でハッシュ生成パラメータを設定可能にし、未指定時は安全なデフォルトを採用することで運用時の調整を容易にするためです。

### Description
- `src/infrastructure/auth/fixedUserPasswordHasher.js` を追加/拡張し、方式識別子付きの新ハッシュ（`bcryptpbkdf$...`）の生成・検証、旧 `sha256`（生hex）判別（`legacy-sha256`）および `needsRehash` フラグを実装しました。 
- `src/infrastructure/StaticLoginAuthenticator.js` を認証フローを「方式判定 -> 検証」に変更し、旧方式で認証成功した場合に `hashPassword` で再ハッシュして任意の `passwordHashUpdater` コールバックへ更新情報を渡す経路を追加しました。 
- DI 側（`src/app/createDependencies.js`）と起動設定（`src/server.js` の `createEnv`）で `loginPasswordHash` と `LOGIN_PASSWORD_HASH_*` 系のパラメータを読み取り、`StaticLoginAuthenticator` に `passwordHashOptions` として渡すようにしました。 
- テストを追加/更新し、`__tests__/small/infrastructure/auth/fixedUserPasswordHasher.test.js`、`__tests__/small/infrastructure/StaticLoginAuthenticator.test.js`、`__tests__/small/server/createEnv.test.js` にて新方式生成/検証、旧SHA-256互換、不正パスワード拒否、再ハッシュトリガー、envデフォルトのカバレッジを追加しました。

### Testing
- `node --check` による構文検査で `src` および追加テストファイルの構文チェックは成功しました。 
- `node -e` / スクリプトによる単体実行で `hashPassword` / `verifyPassword` の新方式・旧方式検証と不正パスワード拒否の動作を確認し期待通りに成功しました。 
- `StaticLoginAuthenticator` の旧SHA-256成功時の再ハッシュと `passwordHashUpdater` 呼び出しはスクリプト実行で確認でき期待通りに成功しました。 
- `npm run test:small` 等の `jest` 実行は実行環境で `cross-env` または `jest` バイナリが無いため失敗したため、フルなテストスイートは実行できていません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3ccf901a0832b85a6065ad5eb8299)