### PR TITLE
refactor: セッション認証入力をCookie専用へ統一しlegacyヘッダを監査ログ化

### DIFF
--- a/__tests__/helpers/extractSessionTokenFromCookie.js
+++ b/__tests__/helpers/extractSessionTokenFromCookie.js
@@ -1,0 +1,21 @@
+const extractSessionTokenFromCookie = cookieHeader => {
+  if (typeof cookieHeader !== 'string' || cookieHeader.length === 0) {
+    return undefined;
+  }
+
+  const pair = cookieHeader
+    .split(';')
+    .map(entry => entry.trim())
+    .find(entry => entry.startsWith('session_token='));
+
+  if (!pair) {
+    return undefined;
+  }
+
+  const [, value = ''] = pair.split('=');
+  return value || undefined;
+};
+
+module.exports = {
+  extractSessionTokenFromCookie,
+};

--- a/__tests__/medium/app/setupMiddleware.integration.test.js
+++ b/__tests__/medium/app/setupMiddleware.integration.test.js
@@ -8,7 +8,7 @@ const createApp = () => {
   const app = express();
   const authAdapter = {
     execute: jest.fn(async token => {
-      if (token === 'header-token' || token === 'cookie-token' || token === 'dev-token') {
+      if (token === 'cookie-token' || token === 'dev-token') {
         return `user:${token}`;
       }
       return null;
@@ -22,7 +22,6 @@ const createApp = () => {
       devSessionUserId: 'admin-dev',
       devSessionTtlMs: 60_000,
       devSessionPaths: ['/protected'],
-      allowLegacySessionTokenHeader: 'true',
     },
     dependencies: {},
   });
@@ -42,21 +41,14 @@ const createApp = () => {
 describe('setupMiddleware と SessionAuthMiddleware の接続 (medium)', () => {
   test.each([
     {
-      title: 'session_token Cookie を優先して採用する',
+      title: 'session_token Cookie を採用する',
       headers: {
         cookie: 'session_token=cookie-token',
       },
       expected: 'cookie-token',
     },
     {
-      title: 'Cookie が無い場合は feature flag で x-session-token を採用できる',
-      headers: {
-        'x-session-token': 'header-token',
-      },
-      expected: 'header-token',
-    },
-    {
-      title: 'ヘッダ/Cookie が無い場合は DevelopmentSession を採用する',
+      title: 'Cookie が無い場合は DevelopmentSession を採用する',
       headers: {},
       expected: 'dev-token',
     },

--- a/__tests__/medium/controller/middleware/SessionAuthMiddleware.test.js
+++ b/__tests__/medium/controller/middleware/SessionAuthMiddleware.test.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const request = require('supertest');
+const { extractSessionTokenFromCookie } = require('../../../helpers/extractSessionTokenFromCookie');
 
 const SessionAuthMiddleware = require('../../../../src/controller/middleware/SessionAuthMiddleware');
 
@@ -9,7 +10,7 @@ const createApp = ({ authAdapter, withSession = true, presetContext } = {}) => {
 
   app.use((req, _res, next) => {
     if (withSession) {
-      req.session = { session_token: req.header('x-session-token') };
+      req.session = { session_token: extractSessionTokenFromCookie(req.header('cookie')) };
     }
     if (presetContext !== undefined) {
       req.context = presetContext;
@@ -37,7 +38,7 @@ describe('SessionAuthMiddleware (middle)', () => {
 
     const response = await request(app)
       .get('/protected')
-      .set('x-session-token', 'valid-token');
+      .set('cookie', 'session_token=valid-token');
 
     expect(response.status).toBe(200);
     expect(response.body).toEqual({
@@ -56,7 +57,7 @@ describe('SessionAuthMiddleware (middle)', () => {
 
     const response = await request(app)
       .get('/protected')
-      .set('x-session-token', 'valid-token');
+      .set('cookie', 'session_token=valid-token');
 
     expect(response.status).toBe(401);
     expect(response.body).toEqual({ message: '認証に失敗しました' });
@@ -73,7 +74,7 @@ describe('SessionAuthMiddleware (middle)', () => {
 
     const response = await request(app)
       .get('/protected')
-      .set('x-session-token', 'valid-token');
+      .set('cookie', 'session_token=valid-token');
 
     expect(response.status).toBe(401);
     expect(response.body).toEqual({ message: '認証に失敗しました' });

--- a/__tests__/medium/controller/router/media/cookieAuthMediaPost.integration.test.js
+++ b/__tests__/medium/controller/router/media/cookieAuthMediaPost.integration.test.js
@@ -49,12 +49,7 @@ describe('Cookie認証での /api/media 回帰テスト (medium)', () => {
     const router = express.Router();
     const sessionStateStore = new InMemorySessionStateStore();
 
-    setupMiddleware(app, {
-      env: {
-        allowLegacySessionTokenHeader: 'false',
-      },
-      dependencies: {},
-    });
+    setupMiddleware(app, { env: {}, dependencies: {} });
 
     setRouterApiLogin({
       router,
@@ -90,7 +85,7 @@ describe('Cookie認証での /api/media 回帰テスト (medium)', () => {
     };
   };
 
-  test('ログイン後は Cookie のみで /api/media に成功し、x-session-token なしでも認証できる', async () => {
+  test('ログイン後は Cookie のみで /api/media に成功し、ヘッダ不要で認証できる', async () => {
     const { app, authResolver } = createApp();
 
     const loginResponse = await request(app)

--- a/__tests__/medium/controller/router/media/cookieAuthMediaPost.integration.test.js
+++ b/__tests__/medium/controller/router/media/cookieAuthMediaPost.integration.test.js
@@ -104,7 +104,7 @@ describe('Cookie認証での /api/media 回帰テスト (medium)', () => {
       .field('tags[0][category]', '作者')
       .field('tags[0][label]', '山田')
       .field('contents[0][position]', '1')
-      .attach('contents[0][file]', Buffer.from('a'), 'first.jpg');
+      .attach('contents[0][file]', Buffer.from([0xff, 0xd8, 0xff]), 'first.jpg');
 
     expect(response.status).toBe(200);
     expect(response.body).toEqual({

--- a/__tests__/medium/controller/router/media/setRouterApiMediaDelete.test.js
+++ b/__tests__/medium/controller/router/media/setRouterApiMediaDelete.test.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const request = require('supertest');
 const { Sequelize } = require('sequelize');
+const { extractSessionTokenFromCookie } = require('../../../../helpers/extractSessionTokenFromCookie');
 
 const setRouterApiMediaDelete = require('../../../../../src/controller/router/media/setRouterApiMediaDelete');
 const SessionStateAuthAdapter = require('../../../../../src/infrastructure/SessionStateAuthAdapter');
@@ -60,7 +61,7 @@ describe('setRouterApiMediaDelete (middle)', () => {
     const router = express.Router();
 
     app.use((req, _res, next) => {
-      req.session = { session_token: req.header('x-session-token') };
+      req.session = { session_token: extractSessionTokenFromCookie(req.header('cookie')) };
       req.context = {};
       next();
     });
@@ -82,7 +83,7 @@ describe('setRouterApiMediaDelete (middle)', () => {
 
     const response = await request(app)
       .delete(`/api/media/${mediaId}`)
-      .set('x-session-token', 'valid-token');
+      .set('cookie', 'session_token=valid-token');
 
     expect(response.status).toBe(200);
     expect(response.body).toEqual({ code: 0 });
@@ -96,7 +97,7 @@ describe('setRouterApiMediaDelete (middle)', () => {
 
     const response = await request(app)
       .delete('/api/media/ffffffffffffffffffffffffffffffff')
-      .set('x-session-token', 'valid-token');
+      .set('cookie', 'session_token=valid-token');
 
     expect(response.status).toBe(200);
     expect(response.body).toEqual({ code: 1 });
@@ -107,7 +108,7 @@ describe('setRouterApiMediaDelete (middle)', () => {
 
     const response = await request(app)
       .delete(`/api/media/${mediaId}`)
-      .set('x-session-token', 'invalid-token');
+      .set('cookie', 'session_token=invalid-token');
 
     expect(response.status).toBe(401);
     expect(response.body).toEqual({

--- a/__tests__/medium/controller/router/media/setRouterApiMediaPatch.test.js
+++ b/__tests__/medium/controller/router/media/setRouterApiMediaPatch.test.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const { Sequelize } = require('sequelize');
+const { extractSessionTokenFromCookie } = require('../../../../helpers/extractSessionTokenFromCookie');
 
 const setRouterApiMediaPatch = require('../../../../../src/controller/router/media/setRouterApiMediaPatch');
 const SessionStateAuthAdapter = require('../../../../../src/infrastructure/SessionStateAuthAdapter');
@@ -69,7 +70,7 @@ describe('setRouterApiMediaPatch (middle)', () => {
     const router = express.Router();
 
     app.use((req, _res, next) => {
-      req.session = { session_token: req.header('x-session-token') };
+      req.session = { session_token: extractSessionTokenFromCookie(req.header('cookie')) };
       req.context = {};
       next();
     });
@@ -92,7 +93,7 @@ describe('setRouterApiMediaPatch (middle)', () => {
 
     const response = await request(app)
       .patch(`/api/media/${mediaId}`)
-      .set('x-session-token', 'valid-token')
+      .set('cookie', 'session_token=valid-token')
       .field('title', 'after title')
       .field('tags[0][category]', '作者')
       .field('tags[0][label]', '新作者')
@@ -133,7 +134,7 @@ describe('setRouterApiMediaPatch (middle)', () => {
 
     const response = await request(app)
       .patch(`/api/media/${mediaId}`)
-      .set('x-session-token', 'valid-token')
+      .set('cookie', 'session_token=valid-token')
       .field('title', '')
       .field('tags[0][category]', '作者')
       .field('tags[0][label]', '新作者')

--- a/__tests__/medium/controller/router/media/setRouterApiMediaPost.test.js
+++ b/__tests__/medium/controller/router/media/setRouterApiMediaPost.test.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const { Sequelize } = require('sequelize');
+const { extractSessionTokenFromCookie } = require('../../../../helpers/extractSessionTokenFromCookie');
 
 const setRouterApiMediaPost = require('../../../../../src/controller/router/media/setRouterApiMediaPost');
 const SessionStateAuthAdapter = require('../../../../../src/infrastructure/SessionStateAuthAdapter');
@@ -56,7 +57,7 @@ describe('setRouterApiMediaPost (middle)', () => {
 
     app.use((req, _res, next) => {
       req.session = {
-        session_token: req.header('x-session-token'),
+        session_token: extractSessionTokenFromCookie(req.header('cookie')),
       };
       req.context = {};
       next();
@@ -84,7 +85,7 @@ describe('setRouterApiMediaPost (middle)', () => {
 
     const response = await request(app)
       .post('/api/media')
-      .set('x-session-token', 'valid-token')
+      .set('cookie', 'session_token=valid-token')
       .field('title', 'sample title')
       .field('tags[0][category]', '作者')
       .field('tags[0][label]', '山田')
@@ -132,7 +133,7 @@ describe('setRouterApiMediaPost (middle)', () => {
 
     const response = await request(app)
       .post('/api/media')
-      .set('x-session-token', 'invalid-token')
+      .set('cookie', 'session_token=invalid-token')
       .field('title', 'sample title')
       .field('tags[0][category]', '作者')
       .field('tags[0][label]', '山田')

--- a/__tests__/medium/controller/router/screen/setRouterRootGet.test.js
+++ b/__tests__/medium/controller/router/screen/setRouterRootGet.test.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const { extractSessionTokenFromCookie } = require('../../../../helpers/extractSessionTokenFromCookie');
 
 const setRouterRootGet = require('../../../../../src/controller/router/screen/setRouterRootGet');
 const SessionStateAuthAdapter = require('../../../../../src/infrastructure/SessionStateAuthAdapter');
@@ -53,7 +54,7 @@ describe('setRouterRootGet (middle)', () => {
 
     app.use((req, _res, next) => {
       req.session = {
-        session_token: req.header('x-session-token'),
+        session_token: extractSessionTokenFromCookie(req.header('cookie')),
       };
       next();
     });
@@ -93,7 +94,7 @@ describe('setRouterRootGet (middle)', () => {
       method: 'GET',
       targetPath: '/',
       headers: {
-        'x-session-token': 'valid-token',
+        cookie: 'session_token=valid-token',
       },
     });
 

--- a/__tests__/medium/controller/router/screen/setRouterScreenDetailGet.test.js
+++ b/__tests__/medium/controller/router/screen/setRouterScreenDetailGet.test.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const path = require('path');
 const { Sequelize } = require('sequelize');
+const { extractSessionTokenFromCookie } = require('../../../../helpers/extractSessionTokenFromCookie');
 
 const setRouterScreenDetailGet = require('../../../../../src/controller/router/screen/setRouterScreenDetailGet');
 const SessionStateAuthAdapter = require('../../../../../src/infrastructure/SessionStateAuthAdapter');
@@ -81,7 +82,7 @@ describe('setRouterScreenDetailGet (middle)', () => {
     app.set('view engine', 'ejs');
 
     app.use((req, _res, next) => {
-      req.session = { session_token: req.header('x-session-token') };
+      req.session = { session_token: extractSessionTokenFromCookie(req.header('cookie')) };
       req.context = {};
       next();
     });
@@ -102,7 +103,7 @@ describe('setRouterScreenDetailGet (middle)', () => {
     const response = await requestApp({
       app: createApp(),
       targetPath: '/screen/detail/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-      headers: { 'x-session-token': 'valid-token' },
+      headers: { cookie: 'session_token=valid-token' },
     });
 
     expect(response.status).toBe(200);

--- a/__tests__/medium/controller/router/screen/setRouterScreenEditGet.test.js
+++ b/__tests__/medium/controller/router/screen/setRouterScreenEditGet.test.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const path = require('path');
+const { extractSessionTokenFromCookie } = require('../../../../helpers/extractSessionTokenFromCookie');
 
 const setRouterScreenEditGet = require('../../../../../src/controller/router/screen/setRouterScreenEditGet');
 const SessionStateAuthAdapter = require('../../../../../src/infrastructure/SessionStateAuthAdapter');
@@ -63,7 +64,7 @@ describe('setRouterScreenEditGet (middle)', () => {
 
     app.use((req, _res, next) => {
       req.session = {
-        session_token: req.header('x-session-token'),
+        session_token: extractSessionTokenFromCookie(req.header('cookie')),
       };
       req.context = {};
       next();
@@ -101,7 +102,7 @@ describe('setRouterScreenEditGet (middle)', () => {
       method: 'GET',
       targetPath: '/screen/edit/media-001',
       headers: {
-        'x-session-token': 'valid-token',
+        cookie: 'session_token=valid-token',
       },
     });
 

--- a/__tests__/medium/controller/router/screen/setRouterScreenEntryGet.test.js
+++ b/__tests__/medium/controller/router/screen/setRouterScreenEntryGet.test.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const path = require('path');
+const { extractSessionTokenFromCookie } = require('../../../../helpers/extractSessionTokenFromCookie');
 
 const setRouterScreenEntryGet = require('../../../../../src/controller/router/screen/setRouterScreenEntryGet');
 const SessionStateAuthAdapter = require('../../../../../src/infrastructure/SessionStateAuthAdapter');
@@ -63,7 +64,7 @@ describe('setRouterScreenEntryGet (middle)', () => {
 
     app.use((req, _res, next) => {
       req.session = {
-        session_token: req.header('x-session-token'),
+        session_token: extractSessionTokenFromCookie(req.header('cookie')),
       };
       req.context = {};
       next();
@@ -90,7 +91,7 @@ describe('setRouterScreenEntryGet (middle)', () => {
       method: 'GET',
       targetPath: '/screen/entry',
       headers: {
-        'x-session-token': 'valid-token',
+        cookie: 'session_token=valid-token',
       },
     });
 

--- a/__tests__/medium/controller/router/screen/setRouterScreenFavoriteGet.test.js
+++ b/__tests__/medium/controller/router/screen/setRouterScreenFavoriteGet.test.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const path = require('path');
 const { Sequelize } = require('sequelize');
+const { extractSessionTokenFromCookie } = require('../../../../helpers/extractSessionTokenFromCookie');
 
 const setRouterScreenFavoriteGet = require('../../../../../src/controller/router/screen/setRouterScreenFavoriteGet');
 const SessionStateAuthAdapter = require('../../../../../src/infrastructure/SessionStateAuthAdapter');
@@ -117,7 +118,7 @@ describe('setRouterScreenFavoriteGet (middle)', () => {
     });
 
     app.use((req, _res, next) => {
-      req.session = { session_token: req.header('x-session-token') };
+      req.session = { session_token: extractSessionTokenFromCookie(req.header('cookie')) };
       req.context = {};
       next();
     });
@@ -138,7 +139,7 @@ describe('setRouterScreenFavoriteGet (middle)', () => {
     const response = await requestApp({
       app: createApp(),
       targetPath: '/screen/favorite',
-      headers: { 'x-session-token': 'valid-token' },
+      headers: { cookie: 'session_token=valid-token' },
     });
 
     expect(response.status).toBe(200);
@@ -154,7 +155,7 @@ describe('setRouterScreenFavoriteGet (middle)', () => {
     const response = await requestApp({
       app: createApp(),
       targetPath: '/screen/favorite?sort=title_asc&page=1',
-      headers: { 'x-session-token': 'valid-token' },
+      headers: { cookie: 'session_token=valid-token' },
     });
 
     expect(response.bodyText).toContain('titles=あいうえお,かきくけこ,さしすせそ');
@@ -183,7 +184,7 @@ describe('setRouterScreenFavoriteGet (middle)', () => {
     const response = await requestApp({
       app: createApp(),
       targetPath: '/screen/favorite?sort=date_desc&page=2',
-      headers: { 'x-session-token': 'valid-token' },
+      headers: { cookie: 'session_token=valid-token' },
     });
 
     expect(response.bodyText).toContain('page=2');
@@ -194,7 +195,7 @@ describe('setRouterScreenFavoriteGet (middle)', () => {
     const response = await requestApp({
       app: createApp(),
       targetPath: '/screen/favorite?sort=title_desc&page=1',
-      headers: { 'x-session-token': 'valid-token' },
+      headers: { cookie: 'session_token=valid-token' },
     });
 
     expect(response.bodyText).toContain('/screen/summary?summaryPage=1&sort=title_desc&tags=');

--- a/__tests__/medium/controller/router/screen/setRouterScreenQueueGet.test.js
+++ b/__tests__/medium/controller/router/screen/setRouterScreenQueueGet.test.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const path = require('path');
+const { extractSessionTokenFromCookie } = require('../../../../helpers/extractSessionTokenFromCookie');
 
 const setRouterScreenQueueGet = require('../../../../../src/controller/router/screen/setRouterScreenQueueGet');
 const SessionStateAuthAdapter = require('../../../../../src/infrastructure/SessionStateAuthAdapter');
@@ -69,7 +70,7 @@ describe('setRouterScreenQueueGet (middle)', () => {
 
     app.use((req, _res, next) => {
       req.session = {
-        session_token: req.header('x-session-token'),
+        session_token: extractSessionTokenFromCookie(req.header('cookie')),
       };
       req.context = {};
       next();
@@ -96,7 +97,7 @@ describe('setRouterScreenQueueGet (middle)', () => {
       app,
       targetPath: '/screen/queue?sort=title_desc&queuePage=2',
       headers: {
-        'x-session-token': 'valid-token',
+        cookie: 'session_token=valid-token',
       },
     });
 

--- a/__tests__/medium/controller/router/screen/setRouterScreenSearchGet.test.js
+++ b/__tests__/medium/controller/router/screen/setRouterScreenSearchGet.test.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const path = require('path');
+const { extractSessionTokenFromCookie } = require('../../../../helpers/extractSessionTokenFromCookie');
 
 const setRouterScreenSearchGet = require('../../../../../src/controller/router/screen/setRouterScreenSearchGet');
 const SessionStateAuthAdapter = require('../../../../../src/infrastructure/SessionStateAuthAdapter');
@@ -63,7 +64,7 @@ describe('setRouterScreenSearchGet (middle)', () => {
 
     app.use((req, _res, next) => {
       req.session = {
-        session_token: req.header('x-session-token'),
+        session_token: extractSessionTokenFromCookie(req.header('cookie')),
       };
       req.context = {};
       next();
@@ -90,7 +91,7 @@ describe('setRouterScreenSearchGet (middle)', () => {
       method: 'GET',
       targetPath: '/screen/search',
       headers: {
-        'x-session-token': 'valid-token',
+        cookie: 'session_token=valid-token',
       },
     });
 

--- a/__tests__/medium/controller/router/screen/setRouterScreenSummaryGet.test.js
+++ b/__tests__/medium/controller/router/screen/setRouterScreenSummaryGet.test.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const path = require('path');
+const { extractSessionTokenFromCookie } = require('../../../../helpers/extractSessionTokenFromCookie');
 
 const setRouterScreenSummaryGet = require('../../../../../src/controller/router/screen/setRouterScreenSummaryGet');
 const SessionStateAuthAdapter = require('../../../../../src/infrastructure/SessionStateAuthAdapter');
@@ -60,7 +61,7 @@ describe('setRouterScreenSummaryGet (middle)', () => {
     });
 
     app.use((req, _res, next) => {
-      req.session = { session_token: req.header('x-session-token') };
+      req.session = { session_token: extractSessionTokenFromCookie(req.header('cookie')) };
       req.context = {};
       next();
     });
@@ -82,7 +83,7 @@ describe('setRouterScreenSummaryGet (middle)', () => {
     const response = await requestApp({
       app,
       targetPath: '/screen/summary?summaryPage=1&start=11&size=5&title=%E5%A4%AA%E9%83%8E&tags=%E4%BD%9C%E8%80%85%3A%E5%B1%B1%E7%94%B0&tags=%E4%B8%8D%E6%AD%A3&sort=title_desc',
-      headers: { 'x-session-token': 'valid-token' },
+      headers: { cookie: 'session_token=valid-token' },
     });
 
     expect(response.status).toBe(200);

--- a/__tests__/medium/controller/router/screen/setRouterScreenViewerGet.test.js
+++ b/__tests__/medium/controller/router/screen/setRouterScreenViewerGet.test.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const path = require('path');
+const { extractSessionTokenFromCookie } = require('../../../../helpers/extractSessionTokenFromCookie');
 
 const setRouterScreenViewerGet = require('../../../../../src/controller/router/screen/setRouterScreenViewerGet');
 const SessionStateAuthAdapter = require('../../../../../src/infrastructure/SessionStateAuthAdapter');
@@ -69,7 +70,7 @@ describe('setRouterScreenViewerGet (middle)', () => {
 
     app.use((req, _res, next) => {
       req.session = {
-        session_token: req.header('x-session-token'),
+        session_token: extractSessionTokenFromCookie(req.header('cookie')),
       };
       req.context = {};
       next();
@@ -104,7 +105,7 @@ describe('setRouterScreenViewerGet (middle)', () => {
       app,
       method: 'GET',
       targetPath: '/screen/viewer/media-001/2',
-      headers: { 'x-session-token': 'valid-token' },
+      headers: { cookie: 'session_token=valid-token' },
     });
 
     expect(response.status).toBe(200);
@@ -128,7 +129,7 @@ describe('setRouterScreenViewerGet (middle)', () => {
       app,
       method: 'GET',
       targetPath: '/screen/viewer/media-001/1',
-      headers: { 'x-session-token': 'valid-token' },
+      headers: { cookie: 'session_token=valid-token' },
     });
 
     expect(response.status).toBe(200);
@@ -148,7 +149,7 @@ describe('setRouterScreenViewerGet (middle)', () => {
       app,
       method: 'GET',
       targetPath: '/screen/viewer/media-001/1',
-      headers: { 'x-session-token': 'valid-token' },
+      headers: { cookie: 'session_token=valid-token' },
     });
 
     expect(response.status).toBe(200);
@@ -165,7 +166,7 @@ describe('setRouterScreenViewerGet (middle)', () => {
       app,
       method: 'GET',
       targetPath: '/screen/viewer/media-404/99',
-      headers: { 'x-session-token': 'valid-token' },
+      headers: { cookie: 'session_token=valid-token' },
     });
 
     expect(response.status).toBe(301);

--- a/__tests__/medium/controller/router/user/setRouterApiFavoriteAndQueue.test.js
+++ b/__tests__/medium/controller/router/user/setRouterApiFavoriteAndQueue.test.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const request = require('supertest');
 const { Sequelize } = require('sequelize');
+const { extractSessionTokenFromCookie } = require('../../../../helpers/extractSessionTokenFromCookie');
 
 const setRouterApiFavoriteAndQueue = require('../../../../../src/controller/router/user/setRouterApiFavoriteAndQueue');
 const SessionStateAuthAdapter = require('../../../../../src/infrastructure/SessionStateAuthAdapter');
@@ -71,7 +72,7 @@ describe('setRouterApiFavoriteAndQueue (middle)', () => {
     const router = express.Router();
 
     app.use((req, _res, next) => {
-      req.session = { session_token: req.header('x-session-token') };
+      req.session = { session_token: extractSessionTokenFromCookie(req.header('cookie')) };
       req.context = {};
       next();
     });
@@ -96,12 +97,12 @@ describe('setRouterApiFavoriteAndQueue (middle)', () => {
 
     await request(app)
       .put('/api/favorite/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
-      .set('x-session-token', 'valid-token')
+      .set('cookie', 'session_token=valid-token')
       .expect(200, { code: 0 });
 
     await request(app)
       .put('/api/queue/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb')
-      .set('x-session-token', 'valid-token')
+      .set('cookie', 'session_token=valid-token')
       .expect(200, { code: 0 });
 
     let favoriteResult = await mediaQueryRepository.findOverviewsByMediaIds(['aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa']);
@@ -115,12 +116,12 @@ describe('setRouterApiFavoriteAndQueue (middle)', () => {
 
     await request(app)
       .delete('/api/favorite/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
-      .set('x-session-token', 'valid-token')
+      .set('cookie', 'session_token=valid-token')
       .expect(200, { code: 0 });
 
     await request(app)
       .delete('/api/queue/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb')
-      .set('x-session-token', 'valid-token')
+      .set('cookie', 'session_token=valid-token')
       .expect(200, { code: 0 });
 
     const userAfterDelete = await userRepository.findByUserId(new UserId('user001'));
@@ -133,7 +134,7 @@ describe('setRouterApiFavoriteAndQueue (middle)', () => {
 
     await request(app)
       .put('/api/favorite/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
-      .set('x-session-token', 'invalid-token')
+      .set('cookie', 'session_token=invalid-token')
       .expect(401, { message: '認証に失敗しました' });
 
     const user = await userRepository.findByUserId(new UserId('user001'));

--- a/__tests__/small/app/setupMiddleware.test.js
+++ b/__tests__/small/app/setupMiddleware.test.js
@@ -3,9 +3,28 @@ const setupMiddleware = require('../../../src/app/setupMiddleware');
 const createReq = ({
   headers = {},
   path = '/screen/entry',
+  ip = '127.0.0.1',
 } = {}) => ({
   path,
+  ip,
+  socket: { remoteAddress: ip },
   header: name => headers[name.toLowerCase()],
+  app: {
+    locals: {
+      dependencies: {
+        logger: {
+          debug: jest.fn(),
+          info: jest.fn(),
+          warn: jest.fn(),
+        },
+      },
+    },
+  },
+});
+
+const createRes = () => ({
+  setHeader: jest.fn(),
+  on: jest.fn(),
 });
 
 const createHarness = ({ env = {} } = {}) => {
@@ -35,61 +54,59 @@ describe('setupMiddleware (small)', () => {
       expected: 'cookie-token',
     },
     {
-      title: 'Cookie が無く feature flag が有効なら x-session-token を採用する',
-      headers: {
-        'x-session-token': 'header-token',
-      },
-      env: {
-        allowLegacySessionTokenHeader: 'true',
-      },
-      expected: 'header-token',
-    },
-    {
-      title: 'Cookie と x-session-token が無い場合は開発用固定セッションを採用する',
+      title: 'Cookie が無い場合は開発用固定セッションを採用する',
       headers: {},
       expected: 'dev-token',
     },
-  ])('セッショントークン解決優先順位: $title', ({ headers, expected, env: overrideEnv = {} }) => {
+  ])('セッショントークン解決優先順位: $title', ({ headers, expected }) => {
     const { middleware } = createHarness({
       env: {
         devSessionToken: 'dev-token',
         devSessionUserId: 'admin-dev',
         devSessionTtlMs: 60_000,
         devSessionPaths: ['/screen/entry'],
-        ...overrideEnv,
       },
     });
 
     const req = createReq({ headers, path: '/screen/entry' });
     const next = jest.fn();
 
-    middleware(req, {}, next);
+    middleware(req, createRes(), next);
 
     expect(req.session.session_token).toBe(expected);
     expect(next).toHaveBeenCalledTimes(1);
   });
 
-  test('feature flag 無効時は x-session-token を無視する', () => {
+  test('x-session-token はセッションへ反映せず監査ログのみ記録する', () => {
     const { middleware } = createHarness({
       env: {
         devSessionToken: 'dev-token',
         devSessionUserId: 'admin-dev',
         devSessionTtlMs: 60_000,
         devSessionPaths: ['/screen/entry'],
-        allowLegacySessionTokenHeader: 'false',
       },
     });
 
     const req = createReq({
       headers: {
         'x-session-token': 'legacy-token',
+        'user-agent': 'jest-agent/1.0',
       },
       path: '/screen/entry',
+      ip: '10.0.0.1',
     });
 
-    middleware(req, {}, jest.fn());
+    middleware(req, createRes(), jest.fn());
 
     expect(req.session.session_token).toBe('dev-token');
+    expect(req.app.locals.dependencies.logger.warn).toHaveBeenCalledWith(
+      'auth.legacy_session_token_header.detected',
+      {
+        count: 1,
+        source_ip: '10.0.0.1',
+        user_agent: 'jest-agent/1.0',
+      },
+    );
   });
 
   test('Cookie 解析: Cookieヘッダの不正要素は無視し、session_token が無い場合は開発用固定セッションへフォールバックする', () => {
@@ -109,7 +126,7 @@ describe('setupMiddleware (small)', () => {
       path: '/screen/entry',
     });
 
-    middleware(req, {}, jest.fn());
+    middleware(req, createRes(), jest.fn());
 
     expect(req.session.session_token).toBe('dev-token');
   });
@@ -118,7 +135,7 @@ describe('setupMiddleware (small)', () => {
     const { middleware } = createHarness();
     const req = createReq();
 
-    middleware(req, {}, jest.fn());
+    middleware(req, createRes(), jest.fn());
     req.session.custom = 'kept';
 
     const regenerateCallback = jest.fn();

--- a/__tests__/small/controller/router/screen/setRouterScreenFavoriteGet.test.js
+++ b/__tests__/small/controller/router/screen/setRouterScreenFavoriteGet.test.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const path = require('path');
+const { extractSessionTokenFromCookie } = require('../../../../helpers/extractSessionTokenFromCookie');
 
 const setRouterScreenFavoriteGet = require('../../../../../src/controller/router/screen/setRouterScreenFavoriteGet');
 const SessionStateAuthAdapter = require('../../../../../src/infrastructure/SessionStateAuthAdapter');
@@ -34,7 +35,7 @@ describe('setRouterScreenFavoriteGet', () => {
     app.set('views', path.join(process.cwd(), 'src', 'views'));
     app.set('view engine', 'ejs');
     app.use((req, _res, next) => {
-      req.session = { session_token: req.header('x-session-token') };
+      req.session = { session_token: extractSessionTokenFromCookie(req.header('cookie')) };
       req.context = {};
       next();
     });
@@ -52,7 +53,7 @@ describe('setRouterScreenFavoriteGet', () => {
     await new Promise(resolve => server.once('listening', resolve));
     const { port } = server.address();
     const response = await fetch(`http://127.0.0.1:${port}/screen/favorite?sort=title_desc&page=2`, {
-      headers: { 'x-session-token': 'valid-token' },
+      headers: { cookie: 'session_token=valid-token' },
     });
     const bodyText = await response.text();
     await new Promise(resolve => server.close(resolve));
@@ -80,7 +81,7 @@ describe('setRouterScreenFavoriteGet', () => {
     app.set('views', path.join(process.cwd(), 'src', 'views'));
     app.set('view engine', 'ejs');
     app.use((req, _res, next) => {
-      req.session = { session_token: req.header('x-session-token') };
+      req.session = { session_token: extractSessionTokenFromCookie(req.header('cookie')) };
       req.context = {};
       next();
     });
@@ -98,7 +99,7 @@ describe('setRouterScreenFavoriteGet', () => {
     await new Promise(resolve => server.once('listening', resolve));
     const { port } = server.address();
     await fetch(`http://127.0.0.1:${port}/screen/favorite?sort=invalid&page=0`, {
-      headers: { 'x-session-token': 'valid-token' },
+      headers: { cookie: 'session_token=valid-token' },
     });
     await new Promise(resolve => server.close(resolve));
 

--- a/__tests__/small/controller/router/screen/setRouterScreenQueueGet.test.js
+++ b/__tests__/small/controller/router/screen/setRouterScreenQueueGet.test.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const path = require('path');
+const { extractSessionTokenFromCookie } = require('../../../../helpers/extractSessionTokenFromCookie');
 
 const setRouterScreenQueueGet = require('../../../../../src/controller/router/screen/setRouterScreenQueueGet');
 const SessionStateAuthAdapter = require('../../../../../src/infrastructure/SessionStateAuthAdapter');
@@ -46,7 +47,7 @@ describe('setRouterScreenQueueGet', () => {
     app.set('views', path.join(process.cwd(), 'src', 'views'));
     app.set('view engine', 'ejs');
     app.use((req, _res, next) => {
-      req.session = { session_token: req.header('x-session-token') };
+      req.session = { session_token: extractSessionTokenFromCookie(req.header('cookie')) };
       req.context = {};
       next();
     });
@@ -64,7 +65,7 @@ describe('setRouterScreenQueueGet', () => {
     await new Promise(resolve => server.once('listening', resolve));
     const { port } = server.address();
     const response = await fetch(`http://127.0.0.1:${port}/screen/queue?sort=title_asc&queuePage=2`, {
-      headers: { 'x-session-token': 'valid-token' },
+      headers: { cookie: 'session_token=valid-token' },
     });
     const bodyText = await response.text();
     await new Promise(resolve => server.close(resolve));

--- a/__tests__/small/controller/router/screen/setRouterScreenSummaryGet.test.js
+++ b/__tests__/small/controller/router/screen/setRouterScreenSummaryGet.test.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const path = require('path');
+const { extractSessionTokenFromCookie } = require('../../../../helpers/extractSessionTokenFromCookie');
 
 const setRouterScreenSummaryGet = require('../../../../../src/controller/router/screen/setRouterScreenSummaryGet');
 const SessionStateAuthAdapter = require('../../../../../src/infrastructure/SessionStateAuthAdapter');
@@ -26,7 +27,7 @@ describe('setRouterScreenSummaryGet', () => {
     app.set('views', path.join(process.cwd(), 'src', 'views'));
     app.set('view engine', 'ejs');
     app.use((req, _res, next) => {
-      req.session = { session_token: req.header('x-session-token') };
+      req.session = { session_token: extractSessionTokenFromCookie(req.header('cookie')) };
       req.context = {};
       next();
     });
@@ -61,7 +62,7 @@ describe('setRouterScreenSummaryGet', () => {
     await new Promise(resolve => server.once('listening', resolve));
     const { port } = server.address();
     const response = await fetch(`http://127.0.0.1:${port}/screen/summary?summaryPage=2&start=41&size=5&title=太郎&tags=%E4%BD%9C%E8%80%85%3A%E5%B1%B1%E7%94%B0&sort=title_desc`, {
-      headers: { 'x-session-token': 'valid-token' },
+      headers: { cookie: 'session_token=valid-token' },
     });
     const bodyText = await response.text();
     await new Promise(resolve => server.close(resolve));
@@ -87,7 +88,7 @@ describe('setRouterScreenSummaryGet', () => {
     await new Promise(resolve => server.once('listening', resolve));
     const { port } = server.address();
     const response = await fetch(`http://127.0.0.1:${port}/screen/summary?summaryPage=3&size=10`, {
-      headers: { 'x-session-token': 'valid-token' },
+      headers: { cookie: 'session_token=valid-token' },
     });
     await response.text();
     await new Promise(resolve => server.close(resolve));

--- a/doc/5_api/controller/middleware/setupMiddleware/readme.md
+++ b/doc/5_api/controller/middleware/setupMiddleware/readme.md
@@ -3,7 +3,7 @@
 ## 概要
 - `src/app/setupMiddleware.js` は、Express アプリケーション全体へ共通適用するミドルウェアを登録する。
 - ビュー設定、JSON / form-urlencoded パーサー、簡易 `req.session` ヘルパー生成、セッショントークンの入力正規化を担当する。
-- `SessionAuthMiddleware` が参照する `req.session.session_token` を、ヘッダ・Cookie・開発用固定セッションの優先順位に従って補完する。
+- `SessionAuthMiddleware` が参照する `req.session.session_token` を、Cookie と開発用固定セッションの優先順位に従って補完する。
 
 ## 対象実装
 - 実装: `src/app/setupMiddleware.js`
@@ -39,16 +39,15 @@
 ## セッショントークン解決優先順位
 `req.session.session_token` は次の優先順位で 1 つだけ採用する。
 
-1. `x-session-token` リクエストヘッダ
-2. `Cookie` ヘッダ内の `session_token` Cookie
-3. 開発用固定セッション (`DevelopmentSession`)
+1. `Cookie` ヘッダ内の `session_token` Cookie
+2. 開発用固定セッション (`DevelopmentSession`)
 
 ### 優先順位詳細
-- `x-session-token` が非空文字列なら、その値を最優先で採用する。
-- ヘッダが無く、`session_token` Cookie が非空文字列なら、その値を採用する。
-- ヘッダ・Cookie のいずれも無い場合に限り、`shouldApplyDevelopmentSession({ env, requestPath: req.path })` を評価する。
+- `session_token` Cookie が非空文字列なら、その値を採用する。
+- Cookie が無い場合に限り、`shouldApplyDevelopmentSession({ env, requestPath: req.path })` を評価する。
 - `shouldApplyDevelopmentSession(...)` が `true` のときのみ `env.devSessionToken` を補完する。
-- したがって、開発用固定セッションは明示指定された通常セッションを上書きしない。
+- したがって、開発用固定セッションは Cookie で明示指定された通常セッションを上書きしない。
+- 互換期間中は `x-session-token` を検知した場合のみ監査ログ (`auth.legacy_session_token_header.detected`) を出力する。ログには件数・送信元IP・User-Agentのみを含み、トークン値は記録しない。
 
 ## Cookie 解析
 - `parseCookieHeader(cookieHeader)` は `Cookie` ヘッダを `;` 区切りで分解し、`key=value` 形式だけを採用する。

--- a/doc/5_api/openapi/openapi.yaml
+++ b/doc/5_api/openapi/openapi.yaml
@@ -48,7 +48,7 @@ components:
     cookieAuth:
       type: apiKey
       in: cookie
-      name: sessionId
+      name: session_token
   responses:
     RedirectError:
       description: エラー画面リダイレクト

--- a/doc/5_api/openapi/paths/api/login.yaml
+++ b/doc/5_api/openapi/paths/api/login.yaml
@@ -22,7 +22,7 @@ post:
       description: ログイン成否、セッション発行
       headers:
         Set-Cookie:
-          description: セッショントークン
+          description: セッショントークン (`session_token` Cookie)
           schema:
             type: string
       content:

--- a/src/app/setupMiddleware.js
+++ b/src/app/setupMiddleware.js
@@ -30,8 +30,6 @@ const parseCookieHeader = cookieHeader => {
     }, {});
 };
 
-const isEnabled = value => String(value || '').toLowerCase() === 'true';
-
 const attachSessionHelpers = req => {
   req.session = req.session ?? {};
   req.session.req = req;
@@ -65,19 +63,24 @@ const setupMiddleware = (app, { env = {}, dependencies: _dependencies } = {}) =>
     req.context = req.context ?? {};
     attachSessionHelpers(req);
 
-    const sessionToken = req.header('x-session-token');
     const cookies = parseCookieHeader(req.header('cookie'));
-    const allowLegacySessionHeader = isEnabled(env.allowLegacySessionTokenHeader);
+    const legacySessionToken = req.header('x-session-token');
 
     if (typeof cookies.session_token === 'string' && cookies.session_token.length > 0) {
       req.session.session_token = cookies.session_token;
-    } else if (allowLegacySessionHeader && typeof sessionToken === 'string' && sessionToken.length > 0) {
-      req.session.session_token = sessionToken;
     } else if (shouldApplyDevelopmentSession({ env, requestPath: req.path })) {
       req.session.session_token = env.devSessionToken;
     }
 
     const logger = req.app?.locals?.dependencies?.logger;
+
+    if (typeof legacySessionToken === 'string' && legacySessionToken.length > 0) {
+      logger?.warn('auth.legacy_session_token_header.detected', {
+        count: 1,
+        source_ip: req.ip || req.socket?.remoteAddress || null,
+        user_agent: req.header('user-agent') || '',
+      });
+    }
     const startedAt = Date.now();
     const requestId = req.header('x-request-id') || crypto.randomUUID();
     req.context.requestId = requestId;

--- a/src/server.js
+++ b/src/server.js
@@ -30,7 +30,6 @@ const createEnv = source => ({
   loginPassword: source.FIXED_LOGIN_PASSWORD || source.LOGIN_PASSWORD || '',
   loginUserId: source.FIXED_LOGIN_USER_ID || source.LOGIN_USER_ID || '',
   loginSessionTtlMs: Number.parseInt(source.LOGIN_SESSION_TTL_MS, 10) || 86_400_000,
-  allowLegacySessionTokenHeader: source.ALLOW_LEGACY_SESSION_TOKEN_HEADER || '',
   logFilePath: source.LOG_FILE_PATH || path.join(process.cwd(), 'var', 'logs', 'mangaviewer.log'),
   logLevel: source.LOG_LEVEL || 'INFO',
   logOutputs: source.LOG_OUTPUTS


### PR DESCRIPTION
### Motivation
- 認証入力経路をヘッダ経由から Cookie（`session_token`）のみに一本化して運用誤用を防止するため。 
- 既存の互換性のために legacy ヘッダの即時排除ではなく、トークン値を残さず検知のみを監査ログ化して移行状況を把握できるようにするため。 
- 環境変数やドキュメント・テストも Cookie 前提へ揃え、実装と仕様の整合性を確保するため。 

### Description
- `src/app/setupMiddleware.js` から `x-session-token` による `req.session.session_token` 補完を削除し、`session_token` Cookie →（未設定時のみ）開発用固定セッションの順で採用するよう変更した。 
- 互換期間として `x-session-token` を検知した場合にトークン値を出力せず `count`・送信元IP・`User-Agent` のみを `auth.legacy_session_token_header.detected` ログで監査する処理を追加した。 
- `src/server.js` から `ALLOW_LEGACY_SESSION_TOKEN_HEADER` 環境変数の読み取りを削除した。 
- API 設計書を Cookie 前提へ更新し、OpenAPI の securitySchemes とログイン応答 `Set-Cookie` 説明を `session_token` Cookie に合わせて修正した。 
- `x-session-token` 前提だったテスト群を Cookie ベースへ置換し、共通の抽出ヘルパー `__tests__/helpers/extractSessionTokenFromCookie.js` を追加して多数の small/medium router テストを更新した。 

### Testing
- 変更した JS ファイル群に対して `node --check` による構文チェックを実行し成功した。 
- 小〜中規模の Jest 実行は実行環境で `cross-env` 等の開発依存が未導入のため実行できず、`npm run test:small` は `cross-env: not found` により失敗した。 
- `npm ci` を実行して依存導入を試みたが環境上で依存解決／インストール完了まで実行できなかったため、フルテストは未実行である。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3ccffdf20832b81f462392aa7b40c)