### PR TITLE
本番環境で認証設定未指定時は起動失敗にし、非本番でデフォルト資格情報利用時に警告を出す

### DIFF
--- a/__tests__/medium/app/createDependencies.login.test.js
+++ b/__tests__/medium/app/createDependencies.login.test.js
@@ -55,4 +55,46 @@ describe('createDependencies login wiring', () => {
 
     await expect(dependencies.authResolver.execute(result.sessionToken)).resolves.toBe('user-001');
   });
+
+  test('production で認証設定が不足している場合は初期化失敗する', () => {
+    expect(() => createDependencies({
+      nodeEnv: 'production',
+      databaseStoragePath: path.join(databaseRoot, 'production.sqlite'),
+      contentRootDirectory: path.join(contentRoot, 'production-contents'),
+      loginUsername: 'admin',
+      loginPassword: '',
+      loginUserId: '',
+    })).toThrow('本番環境ではログイン認証設定が必須です');
+  });
+
+  test('non-production で認証設定が不足していてもデフォルト資格情報でログインできる', async () => {
+    if (dependencies) {
+      await dependencies.close();
+      dependencies = undefined;
+    }
+
+    dependencies = createDependencies({
+      nodeEnv: 'development',
+      databaseStoragePath: path.join(databaseRoot, 'development.sqlite'),
+      contentRootDirectory: path.join(contentRoot, 'development-contents'),
+      loginUsername: '',
+      loginPassword: '',
+      loginUserId: '',
+      loginSessionTtlMs: 60_000,
+    });
+    await dependencies.ready;
+
+    const session = {
+      regenerate: jest.fn((callback) => callback()),
+    };
+
+    const result = await dependencies.loginService.execute(new Query({
+      username: 'admin',
+      password: 'admin',
+      session,
+    }));
+
+    expect(result).toBeInstanceOf(LoginSucceededResult);
+    await expect(dependencies.authResolver.execute(result.sessionToken)).resolves.toBe('admin');
+  });
 });

--- a/__tests__/medium/app/developmentSession.integration.test.js
+++ b/__tests__/medium/app/developmentSession.integration.test.js
@@ -106,4 +106,42 @@ describe('developmentSession wiring', () => {
     expect(errorSpy).not.toHaveBeenCalled();
     expect(exitSpy).not.toHaveBeenCalled();
   });
+
+  test('server.js 相当の初期化では非本番かつデフォルト資格情報使用時に警告ログを出力する', async () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit should not be called');
+    });
+    const listenMock = jest.fn((port, callback) => {
+      callback();
+      return { on: jest.fn() };
+    });
+
+    process.env.NODE_ENV = 'development';
+    process.env.PORT = '3457';
+    process.env.FIXED_LOGIN_USERNAME = '';
+    process.env.FIXED_LOGIN_PASSWORD = '';
+    process.env.FIXED_LOGIN_USER_ID = '';
+    process.env.LOGIN_USERNAME = '';
+    process.env.LOGIN_PASSWORD = '';
+    process.env.LOGIN_USER_ID = '';
+
+    jest.doMock('../../../src/app', () => jest.fn(() => ({
+      locals: {
+        ready: Promise.resolve(),
+      },
+      listen: listenMock,
+    })));
+
+    require('../../../src/server');
+    await Promise.resolve();
+
+    expect(listenMock).toHaveBeenCalledWith(3457, expect.any(Function));
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('非本番向けデフォルト資格情報'));
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('サーバーを起動しました'));
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
 });

--- a/__tests__/medium/controller/router/media/cookieAuthMediaPost.integration.test.js
+++ b/__tests__/medium/controller/router/media/cookieAuthMediaPost.integration.test.js
@@ -23,6 +23,12 @@ class FixedMediaIdValueGenerator {
 }
 
 describe('Cookie認証での /api/media 回帰テスト (medium)', () => {
+  const createJpegBuffer = () => Buffer.from([
+    0xff, 0xd8, 0xff, 0xdb,
+    0x00, 0x43, 0x00, 0x08,
+    0x06, 0x06, 0x07, 0x06,
+  ]);
+
   let sequelize;
   let unitOfWork;
   let mediaRepository;
@@ -109,7 +115,10 @@ describe('Cookie認証での /api/media 回帰テスト (medium)', () => {
       .field('tags[0][category]', '作者')
       .field('tags[0][label]', '山田')
       .field('contents[0][position]', '1')
-      .attach('contents[0][file]', Buffer.from('a'), 'first.jpg');
+      .attach('contents[0][file]', createJpegBuffer(), {
+        filename: 'first.jpg',
+        contentType: 'image/jpeg',
+      });
 
     expect(response.status).toBe(200);
     expect(response.body).toEqual({

--- a/src/app/createDependencies.js
+++ b/src/app/createDependencies.js
@@ -61,6 +61,41 @@ const parseLogOutputs = value => String(value || '')
   .map(entry => entry.trim())
   .filter(entry => entry.length > 0);
 
+const isConfiguredValue = value => String(value || '').trim().length > 0;
+
+const isProductionEnv = env => String(env.nodeEnv || '').toLowerCase() === 'production';
+
+const resolveLoginAuthConfig = env => {
+  const rawConfig = {
+    username: env.loginUsername,
+    password: env.loginPassword,
+    userId: env.loginUserId,
+  };
+  const missingKeys = Object.entries(rawConfig)
+    .filter(([, value]) => !isConfiguredValue(value))
+    .map(([key]) => key);
+
+  if (isProductionEnv(env) && missingKeys.length > 0) {
+    throw new Error([
+      '本番環境ではログイン認証設定が必須です',
+      `missing=${missingKeys.join(',')}`,
+    ].join(': '));
+  }
+
+  const defaults = {
+    username: 'admin',
+    password: 'admin',
+    userId: 'admin',
+  };
+
+  return {
+    username: isConfiguredValue(rawConfig.username) ? rawConfig.username : defaults.username,
+    password: isConfiguredValue(rawConfig.password) ? rawConfig.password : defaults.password,
+    userId: isConfiguredValue(rawConfig.userId) ? rawConfig.userId : defaults.userId,
+    isUsingDefaultCredentials: missingKeys.length > 0,
+  };
+};
+
 const createSequelize = env => {
   if (env.databaseDialect === 'postgres') {
     if (env.databaseUrl) {
@@ -127,10 +162,11 @@ const createDependencies = (env = {}) => {
   const removeQueueService = new RemoveQueueService({ userRepository, unitOfWork });
   const sessionStateRegistrar = new SessionStateRegistrar({ sessionStateStore });
   const sessionTerminator = new SessionTerminator({ sessionStateStore });
+  const loginAuthConfig = resolveLoginAuthConfig(env);
   const loginAuthenticator = new StaticLoginAuthenticator({
-    username: env.loginUsername || 'admin',
-    password: env.loginPassword || 'admin',
-    userId: env.loginUserId || 'admin',
+    username: loginAuthConfig.username,
+    password: loginAuthConfig.password,
+    userId: loginAuthConfig.userId,
   });
   const updateMediaService = new UpdateMediaService({ mediaRepository, unitOfWork });
   const deleteMediaService = new DeleteMediaService({ mediaRepository, unitOfWork });
@@ -213,3 +249,4 @@ const createDependencies = (env = {}) => {
 };
 
 module.exports = createDependencies;
+module.exports.resolveLoginAuthConfig = resolveLoginAuthConfig;

--- a/src/server.js
+++ b/src/server.js
@@ -1,6 +1,7 @@
 const path = require('path');
 
 const createApp = require('./app');
+const { resolveLoginAuthConfig } = require('./app/createDependencies');
 const { hasDevelopmentSession } = require('./app/developmentSession');
 
 const parseSessionPaths = value => (value || '')
@@ -39,6 +40,10 @@ const createEnv = source => ({
 
 const startServer = async () => {
   const env = createEnv(process.env);
+  const loginAuthConfig = resolveLoginAuthConfig(env);
+  if (String(env.nodeEnv || '').toLowerCase() !== 'production' && loginAuthConfig.isUsingDefaultCredentials) {
+    console.warn('ログイン認証情報が未設定のため、非本番向けデフォルト資格情報 (admin/admin) を使用します');
+  }
   const app = createApp(env);
 
   try {


### PR DESCRIPTION
### Motivation
- 本番環境で環境変数が不足している場合に既知のデフォルト資格情報で起動するリスクを排除するため。 
- 非本番では開発しやすさのためデフォルト資格情報を残すが、その利用を明示して設定漏れを早期発見しやすくするため。 

### Description
- `src/app/createDependencies.js` に `resolveLoginAuthConfig` を追加し、`loginUsername` / `loginPassword` / `loginUserId` の設定解決と本番時の必須バリデーションを実装した。 
- `StaticLoginAuthenticator` の初期化で無条件の `admin` フォールバックを削除し、`resolveLoginAuthConfig` の解決結果を渡すようにした（解決済み設定のみに依存）。 
- `resolveLoginAuthConfig` を `module.exports` に追加して `src/server.js` 側で利用し、非本番かつデフォルト資格情報を使用している場合に `console.warn` で警告を出力するようにした。 
- 回帰テストを追加して `createDependencies` とサーバ起動時の挙動を固定化した（`__tests__/medium/app/createDependencies.login.test.js` と `__tests__/medium/app/developmentSession.integration.test.js` を更新）。 

### Testing
- 追加したテストは `__tests__/medium/app/createDependencies.login.test.js`（production + env不足 -> 初期化失敗、non-production + env不足 -> デフォルト許可）と `__tests__/medium/app/developmentSession.integration.test.js`（非本番でデフォルト利用時に警告ログ出力）である。 
- `npm run test:medium` を試行したが環境で `cross-env` 実行が見つからなかったため失敗した。 
- 依存インストールを試みたが npm レジストリ制約により `403 Forbidden` 等のエラーが発生し、テスト実行および依存再インストールが完了しなかったためテストはこの環境では未実行である。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3ce2dee74832bbb8500d1d6d94505)