### PR TITLE
fix: contentId の大文字許容と内部小文字正規化を統一する

### DIFF
--- a/__tests__/small/infrastructure/MulterDiskStorageContentUploadAdapter.test.js
+++ b/__tests__/small/infrastructure/MulterDiskStorageContentUploadAdapter.test.js
@@ -47,4 +47,38 @@ describe('MulterDiskStorageContentUploadAdapter', () => {
 
     fs.rmSync(rootDirectory, { recursive: true, force: true });
   });
+
+  test('大文字を含む contentId でも成功し、小文字に正規化される', async () => {
+    const rootDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'content-upload-adapter-small-'));
+    const app = express();
+    const adapter = new MulterDiskStorageContentUploadAdapter({ rootDirectory });
+
+    app.post('/api/media', (req, res) => {
+      req.context = {};
+      adapter.execute(req, res, error => {
+        if (error) {
+          res.status(error.status ?? 200).json({ code: 1 });
+          return;
+        }
+
+        res.status(200).json({
+          code: 0,
+          contentIds: req.context.contentIds,
+        });
+      });
+    });
+
+    const response = await request(app)
+      .post('/api/media')
+      .field('contents[0][position]', '1')
+      .field('contents[0][url]', '/contents/AA/BB/CC/DD/AABBCCDDEEFF00112233445566778899');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      code: 0,
+      contentIds: ['aabbccddeeff00112233445566778899'],
+    });
+
+    fs.rmSync(rootDirectory, { recursive: true, force: true });
+  });
 });

--- a/src/infrastructure/MulterDiskStorageContentUploadAdapter.js
+++ b/src/infrastructure/MulterDiskStorageContentUploadAdapter.js
@@ -345,25 +345,27 @@ module.exports = class MulterDiskStorageContentUploadAdapter extends IContentUpl
     }
 
     if (hasFile) {
-      if (!(/^[0-9a-f]{32}$/).test(uploadedFile.generatedContentId ?? '')) {
+      const normalizedGeneratedContentId = (uploadedFile.generatedContentId ?? '').toLowerCase();
+      if (!(/^[0-9a-f]{32}$/).test(normalizedGeneratedContentId)) {
         throw new Error('generated contentId is invalid');
       }
 
       return {
         index,
         position,
-        contentId: uploadedFile.generatedContentId,
+        contentId: normalizedGeneratedContentId,
       };
     }
 
-    if (!(/^[0-9a-f]{32}$/).test(contentId)) {
+    const normalizedContentId = contentId.toLowerCase();
+    if (!(/^[0-9a-f]{32}$/).test(normalizedContentId)) {
       throw new Error('contentId is invalid');
     }
 
     return {
       index,
       position,
-      contentId,
+      contentId: normalizedContentId,
     };
   }
 
@@ -385,16 +387,16 @@ module.exports = class MulterDiskStorageContentUploadAdapter extends IContentUpl
     }
 
     const normalized = rawValue.trim();
-    if ((/^[0-9a-f]{32}$/).test(normalized)) {
-      return normalized;
+    if ((/^[0-9a-f]{32}$/i).test(normalized)) {
+      return normalized.toLowerCase();
     }
 
-    const matched = normalized.match(/([0-9a-f]{32})(?:\?.*)?$/);
+    const matched = normalized.match(/([0-9a-f]{32})(?:\?.*)?$/i);
     if (!matched) {
       return normalized;
     }
 
-    return matched[1];
+    return matched[1].toLowerCase();
   }
 
   #createUniqueContentId() {


### PR DESCRIPTION
### Motivation
- クライアントや既存データで16進IDに大文字が含まれる場合があり、従来の小文字限定の検証で不要に弾かれることがあったため、受け入れを広げつつ内部表現を統一して比較や保存の不具合を防止する。 

### Description
- `#extractContentId` の完全一致・末尾抽出の正規表現に `i` フラグを追加して大文字を許容し、抽出成功時は `toLowerCase()` で正規化して返すように変更した。 
- `#createContent` 側で `uploadedFile.generatedContentId` と既存 `contentId` を検証前に `toLowerCase()` で正規化し、検証および返却値を正規化済みの小文字に統一した。 
- 既存の `#generateContentId` の出力は引き続き小文字化された形式のまま維持しており、保存パスの一貫性を確保している。 
- テストとして `__tests__/small/infrastructure/MulterDiskStorageContentUploadAdapter.test.js` に「大文字を含む URL の contentId を受け付け、レスポンスでは小文字に正規化される」ケースを追加した。 

### Testing
- 追加した小規模テストファイルはリポジトリに追加済みだが、ローカル実行は環境に `cross-env`/`jest` が無いため実行できなかった。 
- 実行を試みたコマンドは `npm run test:small -- MulterDiskStorageContentUploadAdapter.test.js`（`cross-env: not found` エラー）と `NODE_ENV=test LOG_OUTPUTS=memory npx jest __tests__/small/infrastructure/MulterDiskStorageContentUploadAdapter.test.js`（`npm error 403` により取得不可）で、どちらも失敗した。 
- テストは環境が整い次第、`jest small` タグで追加ケースを含めて実行して確認可能である。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3d3904cc4832bab2541cc7a21d2fa)