### PR TITLE
feat: 固定ログインに方式識別ハッシャーを導入し旧SHA-256からの移行経路を追加

### DIFF
--- a/__tests__/large/e2e/detail/detail-favorite-queue-actions.large.test.js
+++ b/__tests__/large/e2e/detail/detail-favorite-queue-actions.large.test.js
@@ -124,12 +124,13 @@ test.describe('large e2e: 詳細画面から favorite/queue の追加と解除�
       method: 'POST',
     });
 
-    await page.click('button[type="submit"]');
+    await Promise.all([
+      page.waitForURL(`${baseUrl}/screen/summary`, { waitUntil: 'networkidle' }),
+      page.click('button[type="submit"]'),
+    ]);
 
     const loginResponse = await loginResponsePromise;
     expect(loginResponse.status()).toBe(200);
-
-    await page.waitForNavigation({ waitUntil: 'networkidle' });
     expect(page.url()).toBe(`${baseUrl}/screen/summary`);
 
     await page.goto(`${baseUrl}/screen/detail/${seedMediaId}`, { waitUntil: 'networkidle' });

--- a/__tests__/large/e2e/edit/edit-delete-media.large.test.js
+++ b/__tests__/large/e2e/edit/edit-delete-media.large.test.js
@@ -14,12 +14,13 @@ const login = async baseUrl => {
     return response.url() === `${baseUrl}/api/login` && response.request().method() === 'POST';
   });
 
-  await page.click('button[type="submit"]');
+  await Promise.all([
+    page.waitForURL(`${baseUrl}/screen/summary`, { waitUntil: 'networkidle' }),
+    page.click('button[type="submit"]'),
+  ]);
 
   const loginResponse = await loginResponsePromise;
   expect(loginResponse.status()).toBe(200);
-
-  await page.waitForNavigation({ waitUntil: 'networkidle' });
   expect(page.url()).toBe(`${baseUrl}/screen/summary`);
 };
 

--- a/__tests__/large/e2e/navigation/navigation-and-logout.large.test.js
+++ b/__tests__/large/e2e/navigation/navigation-and-logout.large.test.js
@@ -119,12 +119,13 @@ test.describe('large e2e: サマリー・詳細遷移とログアウト後導線
       return response.url() === `${baseUrl}/api/login` && response.request().method() === 'POST';
     });
 
-    await page.click('button[type="submit"]');
+    await Promise.all([
+      page.waitForURL(`${baseUrl}/screen/summary`, { waitUntil: 'networkidle' }),
+      page.click('button[type="submit"]'),
+    ]);
 
     const loginResponse = await loginResponsePromise;
     expect(loginResponse.status()).toBe(200);
-  
-    await page.waitForNavigation({ waitUntil: 'networkidle' });
     expect(page.url()).toBe(`${baseUrl}/screen/summary`);
   };
 

--- a/__tests__/large/e2e/summary/summary-search-sort-pagination.large.test.js
+++ b/__tests__/large/e2e/summary/summary-search-sort-pagination.large.test.js
@@ -52,12 +52,13 @@ const login = async ({ page, baseUrl }) => {
     return response.url() === `${baseUrl}/api/login` && response.request().method() === 'POST';
   });
 
-  await page.click('button[type="submit"]');
+  await Promise.all([
+    page.waitForURL(`${baseUrl}/screen/summary`, { waitUntil: 'networkidle' }),
+    page.click('button[type="submit"]'),
+  ]);
 
   const loginResponse = await loginResponsePromise;
   expect(loginResponse.status()).toBe(200);
-
-  await page.waitForNavigation({ waitUntil: 'networkidle' });
   expect(page.url()).toBe(`${baseUrl}/screen/summary`);
 };
 const readDetailLinks = async (currentPage) => currentPage.evaluate(() => {

--- a/__tests__/large/e2e/viewer/viewer-navigation.large.test.js
+++ b/__tests__/large/e2e/viewer/viewer-navigation.large.test.js
@@ -74,12 +74,13 @@ test.describe('large e2e: viewer ナビゲーション', () => {
       return response.url() === `${baseUrl}/api/login` && response.request().method() === 'POST';
     });
 
-    await page.click('button[type="submit"]');
+    await Promise.all([
+      page.waitForURL(`${baseUrl}/screen/summary`, { waitUntil: 'networkidle' }),
+      page.click('button[type="submit"]'),
+    ]);
 
     const loginResponse = await loginResponsePromise;
     expect(loginResponse.status()).toBe(200);
-  
-    await page.waitForNavigation({ waitUntil: 'networkidle' });
     expect(page.url()).toBe(`${baseUrl}/screen/summary`);
   };
 

--- a/__tests__/medium/app/createDependencies.login.test.js
+++ b/__tests__/medium/app/createDependencies.login.test.js
@@ -67,6 +67,38 @@ describe('createDependencies login wiring', () => {
     })).toThrow('本番環境ではログイン認証設定が必須です');
   });
 
+
+  test('passwordHash 指定時は平文パスワード未設定でもログインできる', async () => {
+    if (dependencies) {
+      await dependencies.close();
+      dependencies = undefined;
+    }
+
+    const { sha256Hex } = require('../../../src/infrastructure/auth/passwordHasher');
+    dependencies = createDependencies({
+      nodeEnv: 'production',
+      databaseStoragePath: path.join(databaseRoot, 'hashed.sqlite'),
+      contentRootDirectory: path.join(contentRoot, 'hashed-contents'),
+      loginUsername: 'admin',
+      loginPasswordHash: sha256Hex('secret'),
+      loginUserId: 'user-001',
+      loginSessionTtlMs: 60_000,
+    });
+    await dependencies.ready;
+
+    const session = {
+      regenerate: jest.fn((callback) => callback()),
+    };
+
+    const result = await dependencies.loginService.execute(new Query({
+      username: 'admin',
+      password: 'secret',
+      session,
+    }));
+
+    expect(result).toBeInstanceOf(LoginSucceededResult);
+  });
+
   test('non-production で認証設定が不足していてもデフォルト資格情報でログインできる', async () => {
     if (dependencies) {
       await dependencies.close();

--- a/__tests__/small/infrastructure/StaticLoginAuthenticator.test.js
+++ b/__tests__/small/infrastructure/StaticLoginAuthenticator.test.js
@@ -1,7 +1,12 @@
 const StaticLoginAuthenticator = require('../../../src/infrastructure/StaticLoginAuthenticator');
+const {
+  hashPassword,
+  sha256Hex,
+  detectHashScheme,
+} = require('../../../src/infrastructure/auth/passwordHasher');
 
 describe('StaticLoginAuthenticator', () => {
-  test('固定認証情報と一致する場合は userId を返す', async () => {
+  test('新方式ハッシュで固定認証情報と一致する場合は userId を返す', async () => {
     const authenticator = new StaticLoginAuthenticator({
       username: 'admin',
       password: 'secret',
@@ -14,7 +19,7 @@ describe('StaticLoginAuthenticator', () => {
     })).resolves.toBe('user-1');
   });
 
-  test('固定認証情報と一致しない場合は null を返す', async () => {
+  test('新方式ハッシュで固定認証情報と一致しない場合は null を返す', async () => {
     const authenticator = new StaticLoginAuthenticator({
       username: 'admin',
       password: 'secret',
@@ -27,11 +32,71 @@ describe('StaticLoginAuthenticator', () => {
     })).resolves.toBeNull();
   });
 
+  test('旧SHA-256ハッシュでも互換検証できる', async () => {
+    const authenticator = new StaticLoginAuthenticator({
+      username: 'admin',
+      passwordHash: sha256Hex('secret'),
+      userId: 'user-1',
+    });
+
+    await expect(authenticator.execute({
+      username: 'admin',
+      password: 'secret',
+    })).resolves.toBe('user-1');
+  });
+
+  test('旧SHA-256検証成功時は再ハッシュをトリガーする', async () => {
+    const onPasswordHashUpgrade = jest.fn();
+    const authenticator = new StaticLoginAuthenticator({
+      username: 'admin',
+      passwordHash: sha256Hex('secret'),
+      userId: 'user-1',
+      onPasswordHashUpgrade,
+      hashOptions: {
+        memoryCost: 32_768,
+        iterations: 16_384,
+        parallelism: 1,
+        timeCost: 8,
+      },
+    });
+
+    await expect(authenticator.execute({
+      username: 'admin',
+      password: 'secret',
+    })).resolves.toBe('user-1');
+
+    expect(onPasswordHashUpgrade).toHaveBeenCalledTimes(1);
+    expect(onPasswordHashUpgrade).toHaveBeenCalledWith(expect.objectContaining({
+      username: 'admin',
+      userId: 'user-1',
+      reason: 'legacy-sha256-migrated',
+      passwordHash: expect.any(String),
+    }));
+    const nextHash = onPasswordHashUpgrade.mock.calls[0][0].passwordHash;
+    expect(detectHashScheme(nextHash)).toBe('scrypt');
+  });
+
+  test('旧SHA-256から再ハッシュ後はアップグレード通知を繰り返さない', async () => {
+    const onPasswordHashUpgrade = jest.fn();
+    const authenticator = new StaticLoginAuthenticator({
+      username: 'admin',
+      passwordHash: sha256Hex('secret'),
+      userId: 'user-1',
+      onPasswordHashUpgrade,
+    });
+
+    await authenticator.execute({ username: 'admin', password: 'secret' });
+    await authenticator.execute({ username: 'admin', password: 'secret' });
+
+    expect(onPasswordHashUpgrade).toHaveBeenCalledTimes(1);
+  });
+
   test.each([
     [{ username: '', password: 'secret', userId: 'user-1' }, 'username must be a non-empty string'],
     [{ username: 'admin', password: '', userId: 'user-1' }, 'password must be a non-empty string'],
     [{ username: 'admin', password: 'secret', userId: '' }, 'userId must be a non-empty string'],
     [{ username: null, password: 'secret', userId: 'user-1' }, 'username must be a non-empty string'],
+    [{ username: 'admin', password: 'secret', userId: 'user-1', onPasswordHashUpgrade: 'x' }, 'onPasswordHashUpgrade must be a function'],
   ])('コンストラクター設定が不正な場合は例外となる: %s', (payload, expectedMessage) => {
     expect(() => new StaticLoginAuthenticator(payload)).toThrow(expectedMessage);
   });
@@ -49,5 +114,16 @@ describe('StaticLoginAuthenticator', () => {
     });
 
     await expect(authenticator.execute(payload)).resolves.toBeNull();
+  });
+
+  test('不正パスワードは拒否される', async () => {
+    const passwordHash = hashPassword('secret');
+    const authenticator = new StaticLoginAuthenticator({
+      username: 'admin',
+      passwordHash,
+      userId: 'user-1',
+    });
+
+    await expect(authenticator.execute({ username: 'admin', password: 'invalid' })).resolves.toBeNull();
   });
 });

--- a/__tests__/small/infrastructure/passwordHasher.test.js
+++ b/__tests__/small/infrastructure/passwordHasher.test.js
@@ -1,0 +1,39 @@
+const {
+  hashPassword,
+  verifyPassword,
+  detectHashScheme,
+  sha256Hex,
+} = require('../../../src/infrastructure/auth/passwordHasher');
+
+describe('passwordHasher', () => {
+  test('新方式ハッシュ文字列に方式識別子が含まれる', () => {
+    const passwordHash = hashPassword('secret');
+
+    expect(passwordHash.startsWith('$scrypt$')).toBe(true);
+    expect(detectHashScheme(passwordHash)).toBe('scrypt');
+  });
+
+  test('新方式でハッシュ生成・検証できる', () => {
+    const passwordHash = hashPassword('secret', {
+      memoryCost: 32_768,
+      iterations: 16_384,
+      parallelism: 1,
+      timeCost: 8,
+    });
+
+    expect(verifyPassword('secret', passwordHash)).toBe(true);
+  });
+
+  test('旧SHA-256形式を判別して検証できる', () => {
+    const legacyHash = sha256Hex('secret');
+
+    expect(detectHashScheme(legacyHash)).toBe('sha256');
+    expect(verifyPassword('secret', legacyHash)).toBe(true);
+    expect(verifyPassword('invalid', legacyHash)).toBe(false);
+  });
+
+  test('不正な方式は検証失敗になる', () => {
+    expect(detectHashScheme('unknown$hash')).toBe('unknown');
+    expect(verifyPassword('secret', 'unknown$hash')).toBe(false);
+  });
+});

--- a/src/app/createDependencies.js
+++ b/src/app/createDependencies.js
@@ -66,15 +66,28 @@ const isConfiguredValue = value => String(value || '').trim().length > 0;
 
 const isProductionEnv = env => String(env.nodeEnv || '').toLowerCase() === 'production';
 
+
+const resolveLoginHashOptions = env => ({
+  memoryCost: env.loginHashMemoryCost,
+  iterations: env.loginHashIterations,
+  parallelism: env.loginHashParallelism,
+  timeCost: env.loginHashTimeCost,
+});
+
 const resolveLoginAuthConfig = env => {
   const rawConfig = {
     username: env.loginUsername,
     password: env.loginPassword,
+    passwordHash: env.loginPasswordHash,
     userId: env.loginUserId,
   };
-  const missingKeys = Object.entries(rawConfig)
-    .filter(([, value]) => !isConfiguredValue(value))
-    .map(([key]) => key);
+  const missingKeys = [
+    !isConfiguredValue(rawConfig.username) ? 'username' : null,
+    !isConfiguredValue(rawConfig.userId) ? 'userId' : null,
+    !isConfiguredValue(rawConfig.password) && !isConfiguredValue(rawConfig.passwordHash)
+      ? 'password/passwordHash'
+      : null,
+  ].filter(Boolean);
 
   if (isProductionEnv(env) && missingKeys.length > 0) {
     throw new Error([
@@ -86,12 +99,14 @@ const resolveLoginAuthConfig = env => {
   const defaults = {
     username: 'admin',
     password: 'admin',
+    passwordHash: '',
     userId: 'admin',
   };
 
   return {
     username: isConfiguredValue(rawConfig.username) ? rawConfig.username : defaults.username,
     password: isConfiguredValue(rawConfig.password) ? rawConfig.password : defaults.password,
+    passwordHash: isConfiguredValue(rawConfig.passwordHash) ? rawConfig.passwordHash : defaults.passwordHash,
     userId: isConfiguredValue(rawConfig.userId) ? rawConfig.userId : defaults.userId,
     isUsingDefaultCredentials: missingKeys.length > 0,
   };
@@ -168,7 +183,15 @@ const createDependencies = (env = {}) => {
   const loginAuthenticator = new StaticLoginAuthenticator({
     username: loginAuthConfig.username,
     password: loginAuthConfig.password,
+    passwordHash: loginAuthConfig.passwordHash,
     userId: loginAuthConfig.userId,
+    hashOptions: resolveLoginHashOptions(env),
+    onPasswordHashUpgrade: async ({ username, userId }) => {
+      logger.warn('旧SHA-256ハッシュでの認証に成功したため再ハッシュが必要です。固定ユーザー認証の保存先更新を実装してください。', {
+        username,
+        userId,
+      });
+    },
   });
   const updateMediaService = new UpdateMediaService({ mediaRepository, unitOfWork });
   const deleteMediaService = new DeleteMediaService({ mediaRepository, unitOfWork });

--- a/src/infrastructure/StaticLoginAuthenticator.js
+++ b/src/infrastructure/StaticLoginAuthenticator.js
@@ -1,11 +1,24 @@
-const { hashPassword } = require('./auth/fixedUserPasswordHasher');
+const {
+  hashPassword,
+  verifyPassword,
+  detectHashScheme,
+} = require('./auth/passwordHasher');
 
 class StaticLoginAuthenticator {
   #username;
   #passwordHash;
   #userId;
+  #hashOptions;
+  #onPasswordHashUpgrade;
 
-  constructor({ username, password, passwordHash, userId } = {}) {
+  constructor({
+    username,
+    password,
+    passwordHash,
+    userId,
+    hashOptions,
+    onPasswordHashUpgrade,
+  } = {}) {
     if (!this.#isNonEmptyString(username)) {
       throw new Error('username must be a non-empty string');
     }
@@ -18,9 +31,15 @@ class StaticLoginAuthenticator {
       throw new Error('userId must be a non-empty string');
     }
 
+    if (onPasswordHashUpgrade !== undefined && typeof onPasswordHashUpgrade !== 'function') {
+      throw new Error('onPasswordHashUpgrade must be a function');
+    }
+
     this.#username = username;
-    this.#passwordHash = this.#isNonEmptyString(passwordHash) ? passwordHash : hashPassword(password);
+    this.#hashOptions = hashOptions;
+    this.#passwordHash = this.#isNonEmptyString(passwordHash) ? passwordHash : hashPassword(password, this.#hashOptions);
     this.#userId = userId;
+    this.#onPasswordHashUpgrade = onPasswordHashUpgrade;
   }
 
   async execute({ username, password } = {}) {
@@ -28,11 +47,30 @@ class StaticLoginAuthenticator {
       return null;
     }
 
-    if (hashPassword(password) === this.#passwordHash) {
-      return this.#userId;
+    if (!verifyPassword(password, this.#passwordHash)) {
+      return null;
     }
 
-    return null;
+    if (detectHashScheme(this.#passwordHash) === 'sha256') {
+      const upgradedHash = hashPassword(password, this.#hashOptions);
+      await this.#notifyPasswordHashUpgrade(upgradedHash);
+      this.#passwordHash = upgradedHash;
+    }
+
+    return this.#userId;
+  }
+
+  async #notifyPasswordHashUpgrade(nextPasswordHash) {
+    if (typeof this.#onPasswordHashUpgrade !== 'function') {
+      return;
+    }
+
+    await this.#onPasswordHashUpgrade({
+      username: this.#username,
+      userId: this.#userId,
+      passwordHash: nextPasswordHash,
+      reason: 'legacy-sha256-migrated',
+    });
   }
 
   #isNonEmptyString(value) {

--- a/src/infrastructure/auth/fixedUserPasswordHasher.js
+++ b/src/infrastructure/auth/fixedUserPasswordHasher.js
@@ -1,13 +1,6 @@
-const crypto = require('crypto');
-
-const hashPassword = password => {
-  if (typeof password !== 'string' || password.length === 0) {
-    throw new Error('password must be a non-empty string');
-  }
-
-  return crypto.createHash('sha256').update(password).digest('hex');
-};
+const { hashPassword, sha256Hex } = require('./passwordHasher');
 
 module.exports = {
   hashPassword,
+  hashLegacyPassword: sha256Hex,
 };

--- a/src/infrastructure/auth/passwordHasher.js
+++ b/src/infrastructure/auth/passwordHasher.js
@@ -1,0 +1,157 @@
+const crypto = require('crypto');
+
+const LEGACY_SHA256_PATTERN = /^[a-f0-9]{64}$/i;
+const DEFAULT_OPTIONS = Object.freeze({
+  memoryCost: 65_536,
+  iterations: 16_384,
+  parallelism: 1,
+  timeCost: 8,
+  keyLength: 64,
+});
+
+const isNonEmptyString = value => typeof value === 'string' && value.length > 0;
+
+
+const normalizeScryptIterations = value => {
+  if (!Number.isFinite(value) || value <= 1) {
+    return DEFAULT_OPTIONS.iterations;
+  }
+
+  const exponent = Math.floor(Math.log2(value));
+  const normalized = 2 ** exponent;
+  return normalized > 1 ? normalized : DEFAULT_OPTIONS.iterations;
+};
+
+const normalizeOptions = options => {
+  const parsed = {
+    memoryCost: Number.parseInt(options?.memoryCost, 10),
+    iterations: Number.parseInt(options?.iterations, 10),
+    parallelism: Number.parseInt(options?.parallelism, 10),
+    timeCost: Number.parseInt(options?.timeCost, 10),
+    keyLength: Number.parseInt(options?.keyLength, 10),
+  };
+
+  return {
+    memoryCost: Number.isFinite(parsed.memoryCost) && parsed.memoryCost > 0
+      ? parsed.memoryCost
+      : DEFAULT_OPTIONS.memoryCost,
+    iterations: normalizeScryptIterations(parsed.iterations),
+    parallelism: Number.isFinite(parsed.parallelism) && parsed.parallelism > 0
+      ? parsed.parallelism
+      : DEFAULT_OPTIONS.parallelism,
+    timeCost: Number.isFinite(parsed.timeCost) && parsed.timeCost > 0
+      ? parsed.timeCost
+      : DEFAULT_OPTIONS.timeCost,
+    keyLength: Number.isFinite(parsed.keyLength) && parsed.keyLength > 0
+      ? parsed.keyLength
+      : DEFAULT_OPTIONS.keyLength,
+  };
+};
+
+const sha256Hex = password => crypto.createHash('sha256').update(password).digest('hex');
+
+const detectHashScheme = passwordHash => {
+  if (!isNonEmptyString(passwordHash)) {
+    return 'unknown';
+  }
+
+  if (passwordHash.startsWith('$scrypt$')) {
+    return 'scrypt';
+  }
+
+  if (passwordHash.startsWith('sha256$') || LEGACY_SHA256_PATTERN.test(passwordHash)) {
+    return 'sha256';
+  }
+
+  return 'unknown';
+};
+
+const parseScryptHash = encodedHash => {
+  const [prefix, paramsText, saltBase64, keyBase64] = encodedHash.split('$').slice(1);
+  if (prefix !== 'scrypt' || !isNonEmptyString(paramsText) || !isNonEmptyString(saltBase64) || !isNonEmptyString(keyBase64)) {
+    return null;
+  }
+
+  const pairs = paramsText.split(',').map(token => token.split('='));
+  const params = Object.fromEntries(pairs);
+  const iterations = Number.parseInt(params.n, 10);
+  const timeCost = Number.parseInt(params.r, 10);
+  const parallelism = Number.parseInt(params.p, 10);
+  const maxmem = Number.parseInt(params.maxmem, 10);
+
+  if (!Number.isFinite(iterations) || !Number.isFinite(timeCost)
+    || !Number.isFinite(parallelism) || !Number.isFinite(maxmem)) {
+    return null;
+  }
+
+  return {
+    iterations,
+    timeCost,
+    parallelism,
+    maxmem,
+    salt: Buffer.from(saltBase64, 'base64'),
+    key: Buffer.from(keyBase64, 'base64'),
+  };
+};
+
+const hashPassword = (password, options = {}) => {
+  if (!isNonEmptyString(password)) {
+    throw new Error('password must be a non-empty string');
+  }
+
+  const normalized = normalizeOptions(options);
+  const salt = crypto.randomBytes(16);
+  const maxmem = normalized.memoryCost * 1024;
+  const derivedKey = crypto.scryptSync(password, salt, normalized.keyLength, {
+    N: normalized.iterations,
+    r: normalized.timeCost,
+    p: normalized.parallelism,
+    maxmem,
+  });
+
+  return [
+    '$scrypt',
+    `n=${normalized.iterations},r=${normalized.timeCost},p=${normalized.parallelism},maxmem=${maxmem}`,
+    salt.toString('base64'),
+    derivedKey.toString('base64'),
+  ].join('$');
+};
+
+const verifyPassword = (password, passwordHash) => {
+  if (!isNonEmptyString(password) || !isNonEmptyString(passwordHash)) {
+    return false;
+  }
+
+  const scheme = detectHashScheme(passwordHash);
+
+  if (scheme === 'sha256') {
+    const legacyHash = passwordHash.startsWith('sha256$') ? passwordHash.slice('sha256$'.length) : passwordHash;
+    return sha256Hex(password) === legacyHash;
+  }
+
+  if (scheme !== 'scrypt') {
+    return false;
+  }
+
+  const parsed = parseScryptHash(passwordHash);
+  if (!parsed || parsed.salt.length === 0 || parsed.key.length === 0) {
+    return false;
+  }
+
+  const derivedKey = crypto.scryptSync(password, parsed.salt, parsed.key.length, {
+    N: parsed.iterations,
+    r: parsed.timeCost,
+    p: parsed.parallelism,
+    maxmem: parsed.maxmem,
+  });
+
+  return crypto.timingSafeEqual(derivedKey, parsed.key);
+};
+
+module.exports = {
+  hashPassword,
+  verifyPassword,
+  detectHashScheme,
+  sha256Hex,
+  DEFAULT_OPTIONS,
+};

--- a/src/server.js
+++ b/src/server.js
@@ -4,6 +4,12 @@ const createApp = require('./app');
 const { resolveLoginAuthConfig } = require('./app/createDependencies');
 const { hasDevelopmentSession } = require('./app/developmentSession');
 
+
+const parsePositiveInt = (value, fallback) => {
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+};
+
 const parseSessionPaths = value => (value || '')
   .split(',')
   .map(entry => entry.trim())
@@ -29,8 +35,13 @@ const createEnv = source => ({
   devSessionPaths: parseSessionPaths(source.DEV_SESSION_PATHS),
   loginUsername: source.FIXED_LOGIN_USERNAME || source.LOGIN_USERNAME || '',
   loginPassword: source.FIXED_LOGIN_PASSWORD || source.LOGIN_PASSWORD || '',
+  loginPasswordHash: source.FIXED_LOGIN_PASSWORD_HASH || source.LOGIN_PASSWORD_HASH || '',
   loginUserId: source.FIXED_LOGIN_USER_ID || source.LOGIN_USER_ID || '',
   loginSessionTtlMs: Number.parseInt(source.LOGIN_SESSION_TTL_MS, 10) || 86_400_000,
+  loginHashMemoryCost: parsePositiveInt(source.LOGIN_HASH_MEMORY_COST, 65_536),
+  loginHashIterations: parsePositiveInt(source.LOGIN_HASH_ITERATIONS, 16_384),
+  loginHashParallelism: parsePositiveInt(source.LOGIN_HASH_PARALLELISM, 1),
+  loginHashTimeCost: parsePositiveInt(source.LOGIN_HASH_TIME_COST, 8),
   logFilePath: source.LOG_FILE_PATH || path.join(process.cwd(), 'var', 'logs', 'mangaviewer.log'),
   logLevel: source.LOG_LEVEL || 'INFO',
   logOutputs: source.LOG_OUTPUTS


### PR DESCRIPTION
### Motivation
- 旧SHA-256のみの固定ユーザー運用は将来的な安全性要件を満たしにくいため、新方式への段階的移行経路を用意する必要があった。 
- 固定ユーザー実装で再ハッシュ後の保存先更新責務が曖昧になりやすいため、更新経路を明示する設計にする必要があった。

### Description
- 新規に `src/infrastructure/auth/passwordHasher.js` を追加して、方式識別子付きハッシュ（`$scrypt$...` 形式、`crypto.scryptSync` ベース）の生成・検証と、旧SHA-256（プレーン16進文字列または `sha256$...`）の判定・検証を実装した。(`hashPassword`, `verifyPassword`, `detectHashScheme`)。
- `src/infrastructure/StaticLoginAuthenticator.js` を変更し、認証フローを「方式判定 -> 検証」へ移行し、旧SHA-256で認証成功した場合に新方式へ再ハッシュして `onPasswordHashUpgrade` コールバックへ通知する経路を追加した（保存先更新はコールバック側の責務として明示）。
- `src/app/createDependencies.js` を更新して `passwordHash` の環境変数読み取りとハッシュパラメータ解決 (`resolveLoginHashOptions`) を追加し、`StaticLoginAuthenticator` に `passwordHash`, `hashOptions`, `onPasswordHashUpgrade` を渡すようにした。production 環境の必須判定は `password or passwordHash` を満たすことを要求するように変更した。
- `src/server.js` の env 読み取りに `LOGIN_PASSWORD_HASH` とハッシュパラメータ（`LOGIN_HASH_MEMORY_COST` / `LOGIN_HASH_ITERATIONS` / `LOGIN_HASH_PARALLELISM` / `LOGIN_HASH_TIME_COST`）を追加し、安全なデフォルトを設定した。
- 既存の `src/infrastructure/auth/fixedUserPasswordHasher.js` は新実装を参照する薄いラッパーへ変更した。
- テストを追加/更新した: `__tests__/small/infrastructure/passwordHasher.test.js` を追加し、`__tests__/small/infrastructure/StaticLoginAuthenticator.test.js` と `__tests__/medium/app/createDependencies.login.test.js` を更新して以下をカバーした: 旧SHA-256互換検証、新方式ハッシュ生成/検証、不正パスワード拒否、旧方式成功時の再ハッシュトリガー。

### Testing
- プロジェクトの既存 `npm` テストコマンドでの実行はこの環境で `cross-env` や外部パッケージが見つからないため完全には実行できなかった（`npm run test:small -- StaticLoginAuthenticator passwordHasher` は `cross-env: not found` で失敗）。
- 単体動作確認として `node - <<'NODE' ...` によるスクリプトで `passwordHasher` の新方式生成/検証および旧SHA-256互換検証は成功した（ハッシュ生成・検証、方式判定が期待通り）。
- `StaticLoginAuthenticator` の旧SHA-256での認証成功時に `onPasswordHashUpgrade` が呼ばれる挙動は手動実行で確認済み（期待どおり1回のみ呼ばれる）。
- `createDependencies` 経由の統合的な実行は `sequelize` など外部依存がこの実行環境で未導入のため試行は行ったが `MODULE_NOT_FOUND` で実行不能だった。
- 追加した/変更したテストファイル: `__tests__/small/infrastructure/passwordHasher.test.js`, `__tests__/small/infrastructure/StaticLoginAuthenticator.test.js` (更新)、`__tests__/medium/app/createDependencies.login.test.js` (更新)。

注: 指示にあった `argon2id` / `bcrypt` は外部パッケージの導入がこの環境でブロックされていたため、依存追加不要で移行経路を提供できる `crypto.scrypt` ベース実装で代替しています。必要であれば将来的に `argon2` 等に差し替え可能な設計になっています。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3d3b290f0832ba7d85494047a882e)