### PR TITLE
test: ci-testのlargeテストを並列実行して所要時間を短縮する

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,8 +1,8 @@
 /** @type {import('@playwright/test').PlaywrightTestConfig} */
 module.exports = {
   testDir: './__tests__/large/e2e',
-  fullyParallel: false,
-  workers: 1,
+  fullyParallel: true,
+  workers: process.env.CI ? '50%' : undefined,
   timeout: 60_000,
   use: {
     headless: true,


### PR DESCRIPTION
## 概要
- `playwright.config.js` の large E2E 設定を見直し、CI での並列実行を有効化しました。
- `fullyParallel` を `true` に変更しました。
- `workers` を固定値 `1` から `process.env.CI ? '50%' : undefined` に変更しました。

## 変更理由 (Why)
- これまで large テストは常に単一ワーカーで逐次実行されており、テストケース増加に伴って CI の待ち時間が長くなっていました。
- ファイル単位の並列実行に切り替えることで、テスト内容は維持したまま総実行時間の短縮が期待できます。

## 影響範囲
- 影響ファイル: `playwright.config.js`
- 対象: large E2E テストの実行方式（CI 時）

## 補足
- この環境制約により実行検証は未実施です。CI 上で実測時間と安定性をご確認ください。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3d6f2b298832b87f94f08526f1c7a)