### PR TITLE
fix: メディア一覧の日付ソートを実在カラム(created_at)基準に修正

### DIFF
--- a/__tests__/large/e2e/edit/edit-update-media.large.test.js
+++ b/__tests__/large/e2e/edit/edit-update-media.large.test.js
@@ -30,12 +30,13 @@ const login = async ({ page, baseUrl }) => {
     return response.url() === `${baseUrl}/api/login` && response.request().method() === 'POST';
   });
 
+  const summaryPagePromise = page.waitForURL(`${baseUrl}/screen/summary`, { waitUntil: 'networkidle' });
   await page.click('button[type="submit"]');
 
   const loginResponse = await loginResponsePromise;
   expect(loginResponse.status()).toBe(200);
 
-  await page.waitForNavigation({ waitUntil: 'networkidle' });
+  await summaryPagePromise;
   expect(page.url()).toBe(`${baseUrl}/screen/summary`);
 };
 

--- a/src/infrastructure/SequelizeMediaQueryRepository.js
+++ b/src/infrastructure/SequelizeMediaQueryRepository.js
@@ -29,9 +29,9 @@ const extractMediaIdValue = mediaId => {
 const buildSortOrder = (sortType) => {
   switch (sortType) {
     case SortType.DATE_ASC:
-      return [['createdAtProxy', 'ASC'], ['media_id', 'ASC']];
+      return [['created_at', 'ASC'], ['media_id', 'ASC']];
     case SortType.DATE_DESC:
-      return [['createdAtProxy', 'DESC'], ['media_id', 'ASC']];
+      return [['created_at', 'DESC'], ['media_id', 'ASC']];
     case SortType.TITLE_ASC:
       return [['title', 'ASC'], ['media_id', 'ASC']];
     case SortType.TITLE_DESC:
@@ -235,10 +235,7 @@ module.exports = class SequelizeMediaQueryRepository extends IMediaQueryReposito
     const order = buildSortOrder(condition.sortType);
     const query = {
       where: { media_id: mediaIds },
-      attributes: [
-        'media_id',
-        [this.sequelize.literal('rowid'), 'createdAtProxy'],
-      ],
+      attributes: ['media_id'],
       offset: condition.start - 1,
       limit: condition.size,
     };


### PR DESCRIPTION
### Motivation
- `SequelizeMediaQueryRepository` が `sequelize.literal('rowid')` のような方言依存の疑似列に依存しており、SQLite 以外（PostgreSQL 等）で互換性がない懸念があったため。 
- `SearchMediaService` 経由で指定される `date_asc` / `date_desc` の意味を保ちながら、移植性と安定した並び順を確保する必要があったため。

### Description
- `buildSortOrder` の `SortType.DATE_ASC` / `SortType.DATE_DESC` を `['created_at', ...]`（`media.created_at` 実在カラム）を参照する複合ソート（`created_at` + `media_id`）に変更しました。 
- `#paginateMediaIds` の `attributes` から `sequelize.literal('rowid')`（および仮想フィールド `createdAtProxy` の生成）を削除し、取得カラムを `media_id` のみに整理しました。 
- 方言依存の疑似列への依存を排し、`SearchMediaService` の `date_asc` / `date_desc` との対応関係は維持されることを確認しました。

### Testing
- 変更箇所と関連参照の確認に `rg -n "rowid|created_at|DATE_ASC|DATE_DESC|date_asc|date_desc"` を実行して差分とルーティング側マッピングを確認しました（成功）。 
- 単体テスト実行を `npm run test:small -- __tests__/small/infrastructure/SequelizeMediaQueryRepository.test.js` で試みましたが、この環境では `cross-env` が見つからず実行できませんでした（失敗）。 
- 直接 `NODE_ENV=test ... ./node_modules/.bin/jest` を実行してみましたが、`jest` 実行ファイルが存在しないためテストを実行できませんでした（失敗）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3de4e0154832b942d597892c1a8a0)