### PR TITLE
fix: Queue一覧の日付ソート意味をdate_asc/descで統一する

### DIFF
--- a/__tests__/small/applicationService/user/query/GetQueueService.test.js
+++ b/__tests__/small/applicationService/user/query/GetQueueService.test.js
@@ -34,13 +34,39 @@ describe('GetQueueService', () => {
     expect(result.start).toBe(1);
     expect(result.totalCount).toBe(2);
     expect(result.mediaOverviews).toEqual([
-      { mediaId: 'media-002', title: 'タイトルA', thumbnail: '/c2.jpg', tags: [], priorityCategories: [] },
       { mediaId: 'media-001', title: 'タイトルB', thumbnail: '/c1.jpg', tags: [], priorityCategories: [] },
+      { mediaId: 'media-002', title: 'タイトルA', thumbnail: '/c2.jpg', tags: [], priorityCategories: [] },
     ]);
     expect(result.currentPageMediaOverviews).toEqual([
-      { mediaId: 'media-002', title: 'タイトルA', thumbnail: '/c2.jpg', tags: [], priorityCategories: [], isFavorite: false, isQueued: true },
       { mediaId: 'media-001', title: 'タイトルB', thumbnail: '/c1.jpg', tags: [], priorityCategories: [], isFavorite: true, isQueued: true },
+      { mediaId: 'media-002', title: 'タイトルA', thumbnail: '/c2.jpg', tags: [], priorityCategories: [], isFavorite: false, isQueued: true },
     ]);
+  });
+
+
+  test('date_asc と date_desc は同一データで逆順になる', async () => {
+    const userRepository = new MockUserRepository();
+    const mediaQueryRepository = new MockMediaQueryRepository();
+    const user = new User(new UserId('user001'));
+    ['media-001', 'media-002', 'media-003'].forEach(mediaId => user.addQueue(new MediaId(mediaId)));
+
+    userRepository.findByUserId.mockResolvedValue(user);
+    mediaQueryRepository.findOverviewsByMediaIds.mockResolvedValue([
+      { mediaId: 'media-001', title: 'タイトルC', thumbnail: '/1.jpg', tags: [], priorityCategories: [] },
+      { mediaId: 'media-002', title: 'タイトルB', thumbnail: '/2.jpg', tags: [], priorityCategories: [] },
+      { mediaId: 'media-003', title: 'タイトルA', thumbnail: '/3.jpg', tags: [], priorityCategories: [] },
+    ]);
+
+    const service = new GetQueueService({ userRepository, mediaQueryRepository });
+    const dateDescResult = await service.execute(new Input({ userId: 'user001', sort: InputSortType.DATE_DESC, queuePage: 1 }));
+    const dateAscResult = await service.execute(new Input({ userId: 'user001', sort: InputSortType.DATE_ASC, queuePage: 1 }));
+
+    const dateDescIds = dateDescResult.currentPageMediaOverviews.map(media => media.mediaId);
+    const dateAscIds = dateAscResult.currentPageMediaOverviews.map(media => media.mediaId);
+
+    expect(dateDescIds).toEqual(['media-001', 'media-002', 'media-003']);
+    expect(dateAscIds).toEqual(['media-003', 'media-002', 'media-001']);
+    expect(dateAscIds).toEqual([...dateDescIds].reverse());
   });
 
   test('タイトル並び替えと開始位置を指定できる', async () => {

--- a/__tests__/small/controller/router/screen/setRouterScreenQueueGet.test.js
+++ b/__tests__/small/controller/router/screen/setRouterScreenQueueGet.test.js
@@ -78,6 +78,8 @@ describe('setRouterScreenQueueGet', () => {
     expect(bodyText).toContain('お気に入り解除');
     expect(bodyText).toContain('あとで見る解除');
     expect(bodyText).toContain('/screen/queue?queuePage=1&amp;sort=title_asc');
+    expect(bodyText).toContain('追加日時の新しい順');
+    expect(bodyText).toContain('追加日時の古い順');
     expect(getQueueService.execute).toHaveBeenCalledWith(expect.objectContaining({
       userId: 'user-001',
       sort: 'title_asc',

--- a/src/application/user/query/GetQueueService.js
+++ b/src/application/user/query/GetQueueService.js
@@ -98,10 +98,10 @@ const sortMediaOverviews = ({ sort, queueMediaIds, mediaOverviewMap, favoriteMed
     );
   };
 
-  if (sort === INPUT_SORT_TYPES.DATE_ASC) {
+  if (sort === INPUT_SORT_TYPES.DATE_DESC) {
     return [...queueMediaIds].map(toDisplayOverview);
   }
-  if (sort === INPUT_SORT_TYPES.DATE_DESC) {
+  if (sort === INPUT_SORT_TYPES.DATE_ASC) {
     return [...queueMediaIds].reverse().map(toDisplayOverview);
   }
 

--- a/src/controller/router/screen/setRouterScreenQueueGet.js
+++ b/src/controller/router/screen/setRouterScreenQueueGet.js
@@ -64,8 +64,8 @@ const setRouterScreenQueueGet = ({ router, authResolver, getQueueService }) => {
           totalCount: result.totalCount,
           pagination,
           sortOptions: [
-            { value: 'date_desc', label: '登録の新しい順' },
-            { value: 'date_asc', label: '登録の古い順' },
+            { value: 'date_desc', label: '追加日時の新しい順' },
+            { value: 'date_asc', label: '追加日時の古い順' },
             { value: 'title_asc', label: 'タイトル名の昇順' },
             { value: 'title_desc', label: 'タイトル名の降順' },
           ],


### PR DESCRIPTION
### Motivation
- `SequelizeUserRepository.findByUserId` の `queueItems` は追加日時降順で取得されるため、アプリケーション層での `date_asc`/`date_desc` の解釈を元順（`queueMediaIds`）基準に統一する必要があった。 

### Description
- `GetQueueService.sortMediaOverviews` を修正し、`DATE_DESC` が `queueMediaIds` の元順そのまま（追加日時の新しい順）を返し、`DATE_ASC` が元順を反転（追加日時の古い順）して返すようにした。 (`src/application/user/query/GetQueueService.js`) 
- キーワード表示を分かりやすくするために画面のソート文言を `登録の〜` から `追加日時の〜` に変更した。 (`src/controller/router/screen/setRouterScreenQueueGet.js`) 
- テストを修正・追加し、`DATE_DESC` の期待値を更新するとともに、同一データで `date_asc` と `date_desc` が相互に逆順になることを検証するテストを追加し、画面レンダリングテストで新しいソート文言の表示確認を追加した。 (`__tests__/small/applicationService/user/query/GetQueueService.test.js`, `__tests__/small/controller/router/screen/setRouterScreenQueueGet.test.js`) 

### Testing
- 単体テスト実行を試みたが、プロジェクト依存の問題により自動テストは完了できなかった（`cross-env` が見つからず `npm run test:small` は失敗した）。 実行コマンド: `npm run test:small -- __tests__/small/applicationService/user/query/GetQueueService.test.js __tests__/small/controller/router/screen/setRouterScreenQueueGet.test.js`（失敗）。
- 依存インストールを試行したが `npm install` 実行で依存解決エラー（`ENOTEMPTY`）が発生して失敗したため、ローカルでのフルテスト実行は未完了である（`npm install --no-audit --no-fund` にて失敗）。
- 代替で `npx jest` を使った実行も試みたが、npm レジストリのアクセス制限により `jest` の取得ができず失敗したため、CI/開発環境での実行を要請する（試行コマンド: `NODE_ENV=test LOG_OUTPUTS=memory npx --yes jest ...`）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3e080e2a4832b8eaddf49b42a61a6)