### PR TITLE
fix: ログアウト時にsession_token Cookieを必ず失効させる

### DIFF
--- a/__tests__/large/e2e/navigation/navigation-and-logout.large.test.js
+++ b/__tests__/large/e2e/navigation/navigation-and-logout.large.test.js
@@ -175,6 +175,10 @@ test.describe('large e2e: サマリー・詳細遷移とログアウト後導線
 
     const logoutResponse = await logoutResponsePromise;
     expect(logoutResponse.status()).toBe(200);
+    const clearCookieHeader = await logoutResponse.headerValue('set-cookie');
+    expect(clearCookieHeader).toEqual(expect.stringContaining('session_token=;'));
+    expect(clearCookieHeader).toEqual(expect.stringContaining('Path=/'));
+    expect(clearCookieHeader).toEqual(expect.stringContaining('SameSite=Lax'));
     await page.waitForURL(`${baseUrl}/screen/login`, { waitUntil: 'networkidle' });
 
     const protectedResponse = await page.goto(`${baseUrl}/screen/summary`, { waitUntil: 'networkidle' });

--- a/__tests__/medium/controller/api/apiControllers.test.js
+++ b/__tests__/medium/controller/api/apiControllers.test.js
@@ -75,10 +75,16 @@ describe('API controllers (middle)', () => {
       .send({ username: 'admin', password: 'wrong' })
       .expect(200, { code: 1 });
 
-    await request(app)
+    const logoutResponse = await request(app)
       .post('/logout')
       .send({})
       .expect(200, { code: 1 });
+
+    expect(logoutResponse.headers['set-cookie']).toEqual(expect.arrayContaining([
+      expect.stringMatching(/session_token=;/),
+      expect.stringMatching(/Path=\//),
+      expect.stringMatching(/SameSite=Lax/),
+    ]));
   });
 
   test('normal: MediaPost / MediaPatch / MediaDelete が HTTP レベルで成功レスポンスを返す', async () => {

--- a/__tests__/medium/controller/router/user/setRouterApiLogout.test.js
+++ b/__tests__/medium/controller/router/user/setRouterApiLogout.test.js
@@ -72,6 +72,11 @@ describe('setRouterApiLogout (middle)', () => {
 
     expect(logoutResponse.status).toBe(200);
     expect(logoutResponse.body).toEqual({ code: 0 });
+    expect(logoutResponse.headers['set-cookie']).toEqual(expect.arrayContaining([
+      expect.stringMatching(/session_token=;/),
+      expect.stringMatching(/Path=\//),
+      expect.stringMatching(/SameSite=Lax/),
+    ]));
 
     const protectedResponse = await request(app)
       .get('/api/protected')
@@ -108,5 +113,10 @@ describe('setRouterApiLogout (middle)', () => {
 
     expect(logoutResponse.status).toBe(200);
     expect(logoutResponse.body).toEqual({ code: 1 });
+    expect(logoutResponse.headers['set-cookie']).toEqual(expect.arrayContaining([
+      expect.stringMatching(/session_token=;/),
+      expect.stringMatching(/Path=\//),
+      expect.stringMatching(/SameSite=Lax/),
+    ]));
   });
 });

--- a/__tests__/small/controller/api/LogoutPostController.test.js
+++ b/__tests__/small/controller/api/LogoutPostController.test.js
@@ -12,6 +12,7 @@ describe('LogoutPostController', () => {
     const res = {
       status: jest.fn(),
       json: jest.fn(),
+      clearCookie: jest.fn(),
     };
     res.status.mockReturnValue(res);
     return res;
@@ -39,6 +40,11 @@ describe('LogoutPostController', () => {
 
     expect(logoutService.execute).toHaveBeenCalledTimes(1);
     expect(logoutService.execute.mock.calls[0][0]).toMatchObject({ session });
+    expect(res.clearCookie).toHaveBeenCalledWith('session_token', expect.objectContaining({
+      path: '/',
+      sameSite: 'lax',
+      secure: false,
+    }));
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith({ code: 0 });
   });
@@ -48,6 +54,11 @@ describe('LogoutPostController', () => {
 
     const { res } = await execute({ session: { session_token: 'token-1' } });
 
+    expect(res.clearCookie).toHaveBeenCalledWith('session_token', expect.objectContaining({
+      path: '/',
+      sameSite: 'lax',
+      secure: false,
+    }));
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith({ code: 1 });
   });
@@ -56,6 +67,11 @@ describe('LogoutPostController', () => {
     const { res } = await execute({ session: undefined });
 
     expect(logoutService.execute).not.toHaveBeenCalled();
+    expect(res.clearCookie).toHaveBeenCalledWith('session_token', expect.objectContaining({
+      path: '/',
+      sameSite: 'lax',
+      secure: false,
+    }));
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith({ code: 1 });
   });
@@ -65,7 +81,28 @@ describe('LogoutPostController', () => {
 
     const { res } = await execute({ session: { session_token: 'token-1' } });
 
+    expect(res.clearCookie).toHaveBeenCalledWith('session_token', expect.objectContaining({
+      path: '/',
+      sameSite: 'lax',
+      secure: false,
+    }));
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith({ code: 1 });
+  });
+
+  it('production環境ではclearCookieにsameSite=strict, secure=trueを指定する', async () => {
+    const req = {
+      session: { session_token: 'token-1' },
+      app: { locals: { env: { nodeEnv: 'production' } } },
+    };
+    const res = createRes();
+
+    await controller.execute(req, res);
+
+    expect(res.clearCookie).toHaveBeenCalledWith('session_token', expect.objectContaining({
+      path: '/',
+      sameSite: 'strict',
+      secure: true,
+    }));
   });
 });

--- a/__tests__/small/controller/router/user/setRouterApiLogout.test.js
+++ b/__tests__/small/controller/router/user/setRouterApiLogout.test.js
@@ -5,6 +5,7 @@ describe('setRouterApiLogout', () => {
     const res = {
       status: jest.fn(),
       json: jest.fn(),
+      clearCookie: jest.fn(),
     };
     res.status.mockReturnValue(res);
     return res;
@@ -35,6 +36,11 @@ describe('setRouterApiLogout', () => {
 
     await handler(req, res);
     expect(logoutService.execute).toHaveBeenCalledTimes(1);
+    expect(res.clearCookie).toHaveBeenCalledWith('session_token', expect.objectContaining({
+      path: '/',
+      sameSite: 'lax',
+      secure: false,
+    }));
     expect(res.status).toHaveBeenCalledWith(200);
   });
 

--- a/src/controller/api/LogoutPostController.js
+++ b/src/controller/api/LogoutPostController.js
@@ -46,7 +46,7 @@ class LogoutPostController {
 
   #clearSessionCookie(req, res) {
     const cookiePolicy = this.#resolveSessionCookiePolicy(req);
-    res.clearCookie('session_token', {
+    res?.clearCookie?.('session_token', {
       httpOnly: true,
       path: '/',
       secure: cookiePolicy.secure,

--- a/src/controller/api/LogoutPostController.js
+++ b/src/controller/api/LogoutPostController.js
@@ -19,6 +19,7 @@ class LogoutPostController {
     try {
       const session = req?.session;
       if (!session) {
+        this.#clearSessionCookie(req, res);
         logger?.warn('auth.logout.failed', {
           request_id: requestId,
           reason: 'missing_session',
@@ -27,11 +28,13 @@ class LogoutPostController {
       }
 
       const result = await this.#logoutService.execute(new LogoutQuery({ session }));
+      this.#clearSessionCookie(req, res);
       logger?.info('auth.logout', {
         request_id: requestId,
       });
       return res.status(200).json({ code: result.code });
     } catch (error) {
+      this.#clearSessionCookie(req, res);
       logger?.error('auth.logout.error', {
         request_id: requestId,
         message: error?.message,
@@ -39,6 +42,27 @@ class LogoutPostController {
       });
       return this.#fail(res);
     }
+  }
+
+  #clearSessionCookie(req, res) {
+    const cookiePolicy = this.#resolveSessionCookiePolicy(req);
+    res.clearCookie('session_token', {
+      httpOnly: true,
+      path: '/',
+      secure: cookiePolicy.secure,
+      sameSite: cookiePolicy.sameSite,
+    });
+  }
+
+  #resolveSessionCookiePolicy(req) {
+    const env = req?.app?.locals?.env ?? {};
+    const nodeEnv = String(env.nodeEnv || process.env.NODE_ENV || '').toLowerCase();
+    const isProduction = nodeEnv === 'production';
+
+    return {
+      secure: isProduction,
+      sameSite: isProduction ? 'strict' : 'lax',
+    };
   }
 
   #fail(res) {


### PR DESCRIPTION
### Motivation
- ログアウト処理後にクライアント側の `session_token` Cookie が残ると UI と認証状態が不整合になるため、到達したログアウトハンドラでは確実に Cookie を失効させる方針とした。 
- `LoginPostController` のクッキーポリシー (`path`, `sameSite`, `secure`) と整合させて挙動を統一する必要があった。 
- 失効ヘッダの回帰を防ぐため、小中大それぞれのテスト層で `Set-Cookie` / `clearCookie` の検証を追加した。 

### Description
- `LogoutPostController.execute` の全分岐（成功・失敗・例外・session 未設定）で `res.clearCookie('session_token', ...)` を呼ぶようにした。 
- `#clearSessionCookie` と `#resolveSessionCookiePolicy` を追加し、`path: '/'`, `sameSite` と `secure` を `LoginPostController.#resolveSessionCookiePolicy` と同等のロジックで決定するよう実装した。 
- テストを追加/更新して `session_token` 失効ヘッダを検証するようにした（`__tests__/small/controller/api/LogoutPostController.test.js`, `__tests__/medium/controller/api/apiControllers.test.js`, `__tests__/medium/controller/router/user/setRouterApiLogout.test.js`, `__tests__/large/e2e/navigation/navigation-and-logout.large.test.js`）。 

### Testing
- `npm run test:small -- LogoutPostController.test.js` を実行しようとしたが、環境で `cross-env` が見つからずテスト実行できなかった（失敗）。 
- `npm install --include=dev` を試行したが依存解決中にエラーが発生し（`ENOTEMPTY` 等）、テスト実行に至らなかった（失敗）。 
- テストコードは各レイヤで追加済みだが、リモート実行環境の依存問題のため自動テストは今回の実行では成功していない。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3e46120f0832b87085ad3a2bc7333)