### PR TITLE
fix: ログイン成功連続時に429へ到達しないよう制限責務を分離する

### DIFF
--- a/__tests__/large/e2e/auth/login-to-summary.large.test.js
+++ b/__tests__/large/e2e/auth/login-to-summary.large.test.js
@@ -57,4 +57,20 @@ test.describe('large e2e: ログイン画面からサマリー画面まで遷移
     expect(page.url()).toBe(`${baseUrl}/screen/summary`);
     await expect(page.locator('body')).toContainText(seedTitle);
   });
+
+  test('認証成功だけを連続して実行しても /api/login が 429 を返さない', async () => {
+    const { baseUrl } = appContext;
+
+    for (let i = 0; i < 8; i += 1) {
+      const response = await page.request.post(`${baseUrl}/api/login`, {
+        form: {
+          username: 'admin',
+          password: 'admin',
+        },
+      });
+
+      expect(response.status()).toBe(200);
+      await expect(response.json()).resolves.toEqual({ code: 0 });
+    }
+  });
 });

--- a/__tests__/medium/controller/api/apiControllers.test.js
+++ b/__tests__/medium/controller/api/apiControllers.test.js
@@ -14,6 +14,7 @@ const createLoginAttemptStore = () => ({
   getTemporaryLockState: jest.fn(() => ({ isLocked: false, failureCount: 0, lockUntilMs: 0 })),
   recordAuthenticationFailure: jest.fn(() => ({ failureCount: 1, lockUntilMs: 0, isLocked: false })),
   clearAuthenticationFailures: jest.fn(),
+  clearRateLimit: jest.fn(),
 });
 
 const createApp = ({ loginService, logoutService, registerMediaService, updateMediaService, deleteMediaService }) => {

--- a/__tests__/small/controller/api/LoginPostController.test.js
+++ b/__tests__/small/controller/api/LoginPostController.test.js
@@ -44,6 +44,7 @@ describe('LoginPostController', () => {
       getTemporaryLockState: jest.fn().mockReturnValue({ isLocked: false, failureCount: 0, lockUntilMs: 0 }),
       recordAuthenticationFailure: jest.fn().mockReturnValue({ failureCount: 1, lockUntilMs: 0, isLocked: false }),
       clearAuthenticationFailures: jest.fn(),
+      clearRateLimit: jest.fn(),
     };
     controller = new LoginPostController({ loginService, loginAttemptStore });
   });
@@ -62,6 +63,7 @@ describe('LoginPostController', () => {
       session,
     });
     expect(loginAttemptStore.clearAuthenticationFailures).toHaveBeenCalledWith({ key: 'admin' });
+    expect(loginAttemptStore.clearRateLimit).toHaveBeenCalledWith({ scope: 'ip', key: 'unknown' });
     expect(res.cookie).toHaveBeenCalledWith('session_token', 'token-1', {
       httpOnly: true,
       path: '/',
@@ -83,6 +85,7 @@ describe('LoginPostController', () => {
 
     expect(loginAttemptStore.recordAuthenticationFailure).toHaveBeenCalledWith({ key: 'admin' });
     expect(loginAttemptStore.clearAuthenticationFailures).not.toHaveBeenCalled();
+    expect(loginAttemptStore.clearRateLimit).not.toHaveBeenCalled();
     expect(res.cookie).not.toHaveBeenCalled();
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith({ code: 1 });
@@ -150,5 +153,20 @@ describe('LoginPostController', () => {
       sameSite: 'strict',
       maxAge: 120_000,
     });
+  });
+
+  it('認証成功が連続しても429にはならず毎回code=0を返す', async () => {
+    for (let i = 0; i < 8; i += 1) {
+      const { res } = await execute({
+        body: { username: 'admin', password: 'secret' },
+        session: { regenerate: jest.fn() },
+      });
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({ code: 0 });
+    }
+
+    expect(loginAttemptStore.clearAuthenticationFailures).toHaveBeenCalledTimes(8);
+    expect(loginAttemptStore.clearRateLimit).toHaveBeenCalledTimes(8);
   });
 });

--- a/__tests__/small/controller/middleware/LoginRateLimiter.test.js
+++ b/__tests__/small/controller/middleware/LoginRateLimiter.test.js
@@ -1,0 +1,54 @@
+const LoginRateLimiter = require('../../../../src/controller/middleware/LoginRateLimiter');
+
+describe('LoginRateLimiter', () => {
+  const createRes = () => {
+    const res = {
+      status: jest.fn(),
+      json: jest.fn(),
+    };
+    res.status.mockReturnValue(res);
+    return res;
+  };
+
+  test('同一IPで上限超過時は429を返す', () => {
+    const loginAttemptStore = {
+      consumeRateLimit: jest.fn()
+        .mockReturnValueOnce({ count: 5, resetAtMs: Date.now() + 10_000 })
+        .mockReturnValueOnce({ count: 6, resetAtMs: Date.now() + 10_000 }),
+    };
+    const middleware = new LoginRateLimiter({
+      loginAttemptStore,
+      maxAttemptsPerWindow: 5,
+      windowMs: 60_000,
+    });
+    const next = jest.fn();
+
+    const firstRes = createRes();
+    middleware.execute({ ip: '127.0.0.1', body: { username: 'admin' } }, firstRes, next);
+    expect(next).toHaveBeenCalledTimes(1);
+
+    const secondRes = createRes();
+    middleware.execute({ ip: '127.0.0.1', body: { username: 'admin' } }, secondRes, next);
+    expect(secondRes.status).toHaveBeenCalledWith(429);
+    expect(secondRes.json).toHaveBeenCalledWith({ code: 1 });
+  });
+
+  test('認証成功が連続する想定では毎回nextへ進み429にならない', () => {
+    const loginAttemptStore = {
+      consumeRateLimit: jest.fn().mockReturnValue({ count: 1, resetAtMs: Date.now() + 60_000 }),
+    };
+    const middleware = new LoginRateLimiter({
+      loginAttemptStore,
+      maxAttemptsPerWindow: 5,
+      windowMs: 60_000,
+    });
+
+    for (let i = 0; i < 8; i += 1) {
+      const res = createRes();
+      const next = jest.fn();
+      middleware.execute({ ip: '127.0.0.1', body: { username: 'admin' } }, res, next);
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(res.status).not.toHaveBeenCalledWith(429);
+    }
+  });
+});

--- a/__tests__/small/controller/router/user/setRouterApiLogin.test.js
+++ b/__tests__/small/controller/router/user/setRouterApiLogin.test.js
@@ -18,6 +18,7 @@ describe('setRouterApiLogin', () => {
     getTemporaryLockState: jest.fn().mockReturnValue({ isLocked: false, failureCount: 0, lockUntilMs: 0 }),
     recordAuthenticationFailure: jest.fn(),
     clearAuthenticationFailures: jest.fn(),
+    clearRateLimit: jest.fn(),
   });
 
   it('POST /api/login にRateLimiterとログインコントローラーを登録できる', async () => {

--- a/__tests__/small/infrastructure/InMemoryLoginAttemptStore.test.js
+++ b/__tests__/small/infrastructure/InMemoryLoginAttemptStore.test.js
@@ -38,4 +38,14 @@ describe('InMemoryLoginAttemptStore', () => {
       lockUntilMs: 0,
     });
   });
+
+  test('IPレート制限カウンタをクリアできる', () => {
+    const store = new InMemoryLoginAttemptStore();
+
+    store.consumeRateLimit({ scope: 'ip', key: '127.0.0.1', windowMs: 60_000, nowMs: 1_000 });
+    store.clearRateLimit({ scope: 'ip', key: '127.0.0.1' });
+    const afterClear = store.consumeRateLimit({ scope: 'ip', key: '127.0.0.1', windowMs: 60_000, nowMs: 2_000 });
+
+    expect(afterClear.count).toBe(1);
+  });
 });

--- a/src/controller/api/LoginPostController.js
+++ b/src/controller/api/LoginPostController.js
@@ -15,6 +15,9 @@ class LoginPostController {
     if (!loginAttemptStore || typeof loginAttemptStore.recordAuthenticationFailure !== 'function') {
       throw new Error('loginAttemptStore.recordAuthenticationFailure must be a function');
     }
+    if (typeof loginAttemptStore.clearRateLimit !== 'function') {
+      throw new Error('loginAttemptStore.clearRateLimit must be a function');
+    }
 
     this.#loginService = loginService;
     this.#loginAttemptStore = loginAttemptStore;
@@ -55,6 +58,10 @@ class LoginPostController {
 
       if (result instanceof LoginSucceededResult) {
         this.#loginAttemptStore.clearAuthenticationFailures({ key: username });
+        this.#loginAttemptStore.clearRateLimit({
+          scope: 'ip',
+          key: this.#resolveIpAddress(req),
+        });
         const cookiePolicy = this.#resolveSessionCookiePolicy(req);
         res.cookie('session_token', result.sessionToken, {
           httpOnly: true,
@@ -107,6 +114,10 @@ class LoginPostController {
       sameSite: isProduction ? 'strict' : 'lax',
       maxAge: sessionTtlMs,
     };
+  }
+
+  #resolveIpAddress(req) {
+    return req.ip || req.connection?.remoteAddress || 'unknown';
   }
 
   #fail(res) {

--- a/src/controller/middleware/LoginRateLimiter.js
+++ b/src/controller/middleware/LoginRateLimiter.js
@@ -19,7 +19,6 @@ class LoginRateLimiter {
     const nowMs = Date.now();
     const logger = req.app?.locals?.dependencies?.logger;
     const requestId = req.context?.requestId;
-    const username = this.#resolveUsername(req);
     const ipAddress = this.#resolveIpAddress(req);
 
     const ipCounter = this.#loginAttemptStore.consumeRateLimit({
@@ -28,19 +27,13 @@ class LoginRateLimiter {
       windowMs: this.#windowMs,
       nowMs,
     });
-    const usernameCounter = this.#loginAttemptStore.consumeRateLimit({
-      scope: 'username',
-      key: username,
-      windowMs: this.#windowMs,
-      nowMs,
-    });
 
-    if (ipCounter.count > this.#maxAttemptsPerWindow || usernameCounter.count > this.#maxAttemptsPerWindow) {
+    if (ipCounter.count > this.#maxAttemptsPerWindow) {
       logger?.warn('auth.login.failed', {
         request_id: requestId,
         reason: 'rate_limited',
         ip_address: ipAddress,
-        username,
+        username: this.#resolveUsername(req),
       });
       return res.status(429).json({ code: 1 });
     }

--- a/src/infrastructure/InMemoryLoginAttemptStore.js
+++ b/src/infrastructure/InMemoryLoginAttemptStore.js
@@ -33,6 +33,11 @@ class InMemoryLoginAttemptStore extends LoginAttemptStore {
     };
   }
 
+  clearRateLimit({ scope, key } = {}) {
+    const bucketKey = `${scope || 'unknown'}:${key || 'anonymous'}`;
+    this.#rateLimitBuckets.delete(bucketKey);
+  }
+
   getTemporaryLockState({ key, nowMs = Date.now() } = {}) {
     const state = this.#failureStates.get(key);
     if (!state) {

--- a/src/infrastructure/LoginAttemptStore.js
+++ b/src/infrastructure/LoginAttemptStore.js
@@ -3,6 +3,10 @@ class LoginAttemptStore {
     throw new Error('consumeRateLimit must be implemented');
   }
 
+  clearRateLimit() {
+    throw new Error('clearRateLimit must be implemented');
+  }
+
   getTemporaryLockState() {
     throw new Error('getTemporaryLockState must be implemented');
   }


### PR DESCRIPTION
### Motivation
- ミドルウェアが username 単位までカウントしていたため、認証成功のみを連続すると不必要に 429 に到達し得る問題を解消するため。 
- レート制限は粗い IP 単位に限定し、ユーザー単位の失敗ロックは認証失敗時にコントローラー側で扱う責務分離を行うため。 
- 成功時に失敗状態とレート状態を明示的にクリアして、正常なログインが 429 に巻き込まれないことを保証するため。 

### Description
- `LoginRateLimiter` を修正し username カウンタを廃止して IP 単位のカウントのみで 429 判定を行うようにした（`src/controller/middleware/LoginRateLimiter.js`）。
- `LoginPostController` に `clearRateLimit` 依存を追加し、ログイン成功時に `clearAuthenticationFailures` と合わせて IP レートカウンタをクリアする処理を追加した（`src/controller/api/LoginPostController.js`）。
- 抽象 `LoginAttemptStore` と実装 `InMemoryLoginAttemptStore` に `clearRateLimit` を追加して IP レートカウンタを削除できるようにした（`src/infrastructure/LoginAttemptStore.js`, `src/infrastructure/InMemoryLoginAttemptStore.js`）。
- テストを追加・更新して回帰を防止し、small レベルのミドルウェアテスト新規作成、LoginPostController のテスト強化、InMemory ストアのレートクリア確認および large E2E に成功連続時に 429 を返さないケースを追加した（各 __tests__ を更新）。

### Testing
- `node --check` による構文チェック（`src` と追加/更新したテストファイル群）を実行し問題は検出されませんでした。 
- `npm run test:small` 実行は `cross-env: not found` により実行できませんでしたので Jest による単体テストは未実行です。 
- 依存インストール（`npm install`）はレジストリへのアクセスで `403 Forbidden` が返り完了できなかったため、CI 上での E2E 実行も行えていません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d48c69df50832b883b98cf56ebca50)