### PR TITLE
feat: ビューアーの動画判定をcontentType優先に切り替え、拡張子依存を緩和する

### DIFF
--- a/__tests__/large/e2e/viewer/viewer-navigation.large.test.js
+++ b/__tests__/large/e2e/viewer/viewer-navigation.large.test.js
@@ -10,6 +10,7 @@ const ContentId = require('../../../../src/domain/media/contentId');
 const Tag = require('../../../../src/domain/media/tag');
 const Category = require('../../../../src/domain/media/category');
 const Label = require('../../../../src/domain/media/label');
+const { toPublicContentPath } = require('../../../../src/controller/screen/publicContentPath');
 const { bootstrapE2eApp } = require('../helpers/bootstrapE2eApp');
 
 const createViewerSeedMedia = ({ mediaId, title, contentIds }) => new Media(
@@ -22,7 +23,7 @@ const createViewerSeedMedia = ({ mediaId, title, contentIds }) => new Media(
   [new Category('カテゴリ')],
 );
 
-const toExpectedPublicPath = contentId => `/contents/${contentId}`;
+const toExpectedPublicPath = contentId => toPublicContentPath(contentId);
 
 test.describe('large e2e: viewer ナビゲーション', () => {
   const seedMediaId = 'media-seed-viewer-navigation-1';

--- a/__tests__/large/e2e/viewer/viewer-navigation.large.test.js
+++ b/__tests__/large/e2e/viewer/viewer-navigation.large.test.js
@@ -32,6 +32,9 @@ test.describe('large e2e: viewer ナビゲーション', () => {
     'seed/viewer-navigation-content-2.jpg',
     'seed/viewer-navigation-content-3.jpg',
   ];
+  const seedVideoMediaId = 'media-seed-viewer-navigation-video-1';
+  const seedVideoTitle = 'ビューアー動画確認用タイトル';
+  const seedVideoContentId = '0123456789abcdef0123456789abcdef';
 
   let context;
 
@@ -46,13 +49,32 @@ test.describe('large e2e: viewer ナビゲーション', () => {
             title: seedTitle,
             contentIds: seedContentIds,
           }));
+          await app.locals.dependencies.mediaRepository.save(createViewerSeedMedia({
+            mediaId: seedVideoMediaId,
+            title: seedVideoTitle,
+            contentIds: [seedVideoContentId],
+          }));
         });
+
+        await app.locals.dependencies.sequelize.models.content.update(
+          { content_type: 'video/mp4' },
+          { where: { content_id: seedVideoContentId } }
+        );
 
         await fs.mkdir(path.join(tempContentDirectory, 'seed'), { recursive: true });
 
         await Promise.all(seedContentIds.map(contentId => {
           return fs.writeFile(path.join(tempContentDirectory, contentId), 'dummy', { encoding: 'utf8' });
         }));
+        const shardedSegments = [
+          seedVideoContentId.slice(0, 2),
+          seedVideoContentId.slice(2, 4),
+          seedVideoContentId.slice(4, 6),
+          seedVideoContentId.slice(6, 8),
+        ];
+        const videoDirectory = path.join(tempContentDirectory, ...shardedSegments);
+        await fs.mkdir(videoDirectory, { recursive: true });
+        await fs.writeFile(path.join(videoDirectory, seedVideoContentId), 'dummy-video', { encoding: 'utf8' });
       },
     });
   });
@@ -173,5 +195,21 @@ test.describe('large e2e: viewer ナビゲーション', () => {
       return elements.map(element => element.textContent.trim());
     });
     expect(footerTextsAtLastPage).toContain('次ページなし');
+  });
+
+  test('contentType=video が保存されたコンテンツは viewer で <video> として描画される', async () => {
+    const { baseUrl } = context;
+    await login({ page, baseUrl });
+
+    await page.goto(`${baseUrl}/screen/viewer/${seedVideoMediaId}/1`, { waitUntil: 'networkidle' });
+
+    await page.waitForSelector('.stage video');
+    expect(await page.$('.stage img')).toBeNull();
+    const videoState = await page.$eval('.stage video', element => ({
+      src: element.getAttribute('src'),
+      controls: element.hasAttribute('controls'),
+    }));
+    expect(videoState.src).toBe(toExpectedPublicPath(seedVideoContentId));
+    expect(videoState.controls).toBe(true);
   });
 });

--- a/__tests__/small/controller/screen/ScreenViewerGetController.test.js
+++ b/__tests__/small/controller/screen/ScreenViewerGetController.test.js
@@ -99,7 +99,7 @@ describe('ScreenViewerGetController', () => {
 
     expect(res.render).toHaveBeenCalledWith('screen/viewer', expect.objectContaining({
       content: {
-        id: '/contents/0123456789abcdef0123456789abcdef',
+        id: '/contents/01/23/45/67/0123456789abcdef0123456789abcdef',
         type: 'video',
       },
     }));

--- a/__tests__/small/controller/screen/ScreenViewerGetController.test.js
+++ b/__tests__/small/controller/screen/ScreenViewerGetController.test.js
@@ -83,6 +83,28 @@ describe('ScreenViewerGetController', () => {
     }));
   });
 
+  test('拡張子なしの32桁 contentId でも contentType が video なら type=video として描画する', async () => {
+    const getMediaContentWithNavigationService = {
+      execute: jest.fn().mockResolvedValue(new FoundResult({
+        contentId: '0123456789abcdef0123456789abcdef',
+        previousContentId: null,
+        nextContentId: null,
+        contentType: 'video',
+      })),
+    };
+    const controller = new ScreenViewerGetController({ getMediaContentWithNavigationService });
+    const res = createRes();
+
+    await controller.execute({ params: { mediaId: 'media-video', mediaPage: '1' } }, res);
+
+    expect(res.render).toHaveBeenCalledWith('screen/viewer', expect.objectContaining({
+      content: {
+        id: '/contents/0123456789abcdef0123456789abcdef',
+        type: 'video',
+      },
+    }));
+  });
+
   test.each([
     ['MediaNotFoundResult', new MediaNotFoundResult()],
     ['ContentNotFoundResult', new ContentNotFoundResult()],

--- a/src/application/media/query/GetMediaContentWithNavigationService.js
+++ b/src/application/media/query/GetMediaContentWithNavigationService.js
@@ -22,7 +22,7 @@ class Result {
 }
 
 class FoundResult extends Result {
-  constructor({ contentId, previousContentId, nextContentId }) {
+  constructor({ contentId, previousContentId, nextContentId, contentType = null }) {
     super();
 
     if (typeof contentId !== 'string' && contentId !== null) {
@@ -34,10 +34,14 @@ class FoundResult extends Result {
     if (typeof nextContentId !== 'string' && nextContentId !== null) {
       throw new Error();
     }
+    if (!(contentType === 'image' || contentType === 'video' || contentType === null)) {
+      throw new Error();
+    }
 
     this.contentId = contentId;
     this.previousContentId = previousContentId;
     this.nextContentId = nextContentId;
+    this.contentType = contentType;
   }
 }
 
@@ -70,6 +74,26 @@ class GetMediaContentWithNavigationService {
     }
 
     const mediaId = new MediaId(input.mediaId);
+    if (typeof this.#mediaRepository.findContentWithNavigationByMediaId !== 'function') {
+      return this.#executeWithLegacyPath({ input, mediaId });
+    }
+
+    const result = await this.#mediaRepository.findContentWithNavigationByMediaId({
+      mediaId,
+      contentPosition: input.contentPosition,
+    });
+
+    if (result === null) {
+      return new MediaNotFoundResult();
+    }
+    if (result.contentId === null) {
+      return new ContentNotFoundResult();
+    }
+
+    return new FoundResult(result);
+  }
+
+  async #executeWithLegacyPath({ input, mediaId }) {
     const media = await this.#mediaRepository.findByMediaId(mediaId);
 
     if (!media) {

--- a/src/controller/screen/ScreenViewerGetController.js
+++ b/src/controller/screen/ScreenViewerGetController.js
@@ -45,7 +45,7 @@ class ScreenViewerGetController {
         currentUserId: req.context?.userId || null,
         content: {
           id: toPublicContentPath(result.contentId),
-          type: this.#detectContentType(result.contentId),
+          type: result.contentType ?? this.#detectContentType(result.contentId),
         },
         previousPage: result.previousContentId === null ? null : {
           mediaId: req.params.mediaId,

--- a/src/infrastructure/SequelizeMediaRepository.js
+++ b/src/infrastructure/SequelizeMediaRepository.js
@@ -9,6 +9,22 @@ const Tag = require('../domain/media/tag');
 const Category = require('../domain/media/category');
 const Label = require('../domain/media/label');
 const normalizeTextInput = value => (typeof value === 'string' ? value.trim() : value);
+const VIDEO_MIME_TYPE_PREFIX = 'video/';
+
+const resolveContentTypeFromRow = (contentRow) => {
+  if (typeof contentRow?.content_type === 'string' && contentRow.content_type.startsWith(VIDEO_MIME_TYPE_PREFIX)) {
+    return 'video';
+  }
+  if (typeof contentRow?.content_type === 'string' && contentRow.content_type.startsWith('image/')) {
+    return 'image';
+  }
+
+  if (/\.(mp4|webm|ogg|mov|m4v)$/i.test(contentRow?.content_id ?? '')) {
+    return 'video';
+  }
+
+  return null;
+};
 
 function defineModels(sequelize) {
   const MediaModel = sequelize.define('media', {
@@ -22,6 +38,7 @@ function defineModels(sequelize) {
     content_id: { type: DataTypes.TEXT, primaryKey: true },
     media_id: { type: DataTypes.STRING, allowNull: false },
     position: { type: DataTypes.INTEGER, allowNull: false },
+    content_type: { type: DataTypes.TEXT, allowNull: true },
   }, { tableName: 'content', timestamps: false });
 
   const CategoryModel = sequelize.define('category', {
@@ -249,6 +266,41 @@ module.exports = class SequelizeMediaRepository extends IMediaRepository {
       priorityCategories,
       registeredAt,
     );
+  }
+
+  async findContentWithNavigationByMediaId({ mediaId, contentPosition }) {
+    if (!(mediaId instanceof MediaId)) {
+      throw new Error();
+    }
+    if (!Number.isInteger(contentPosition) || contentPosition <= 0) {
+      throw new Error();
+    }
+
+    const executionScope = this.#unitOfWorkContext.getCurrent();
+    const { MediaModel, ContentModel } = this.#models;
+
+    const mediaRow = await MediaModel.findByPk(mediaId.getId(), { transaction: executionScope });
+    if (!mediaRow) {
+      return null;
+    }
+
+    const rows = await ContentModel.findAll({
+      where: {
+        media_id: mediaId.getId(),
+        position: [contentPosition - 1, contentPosition, contentPosition + 1],
+      },
+      transaction: executionScope,
+    });
+
+    const rowMap = new Map(rows.map(row => [row.position, row]));
+    const current = rowMap.get(contentPosition) ?? null;
+
+    return {
+      contentId: current?.content_id ?? null,
+      previousContentId: rowMap.get(contentPosition - 1)?.content_id ?? null,
+      nextContentId: rowMap.get(contentPosition + 1)?.content_id ?? null,
+      contentType: resolveContentTypeFromRow(current),
+    };
   }
 
   async delete(media) {


### PR DESCRIPTION
### Motivation
- 拡張子を持たない32桁の `contentId` が増えると、拡張子ベースの判定では動画を誤って画像扱いしてしまう問題を解消するため。 
- DB やアップロード時に保持できる MIME 情報を利用して確実に `image` / `video` を判定できる経路を追加したい。 
- 既存データとの互換性を保つため、`contentType` がない場合は従来の拡張子フォールバックを維持する方針とした。 

### Description
- `GetMediaContentWithNavigationService` の `FoundResult` に `contentType` (`'image' | 'video' | null`) を追加し、リポジトリ側の新 API が存在する場合はそれを優先利用するようにした。 
- `SequelizeMediaRepository` に `content.content_type` カラム定義を追加し、`findContentWithNavigationByMediaId` を新設して現在/前/次の `contentId` と MIME 由来の `contentType` を返却するようにした。 
- `SequelizeMediaRepository` 側で MIME がなければ既存の拡張子判定にフォールバックする `resolveContentTypeFromRow` ロジックを追加した。 
- `ScreenViewerGetController` は `result.contentType` を優先してビューに渡し、未設定時のみ既存の `#detectContentType(contentId)` を用いるよう変更した。 
- 単体テスト (`__tests__/small/controller/screen/ScreenViewerGetController.test.js`) に拡張子なし32桁IDで `contentType: 'video'` を受け取った場合のケースを追加し、E2E (`__tests__/large/e2e/viewer/viewer-navigation.large.test.js`) にも `content_type='video/mp4'` を DB に設定した動画ケースを追加して `<video>` 描画を検証するシナリオを追加した。 

### Testing
- `node` で該当モジュールを読み込む簡易チェックを実行したが、`sequelize` が未インストールのため読み込みエラーとなった（モジュール未解決）。 
- `npm run test:small` / `npm run test:medium` を実行しようとしたが、実行環境に `cross-env` が無く失敗したためテストは実行できなかった。 
- `npx jest ...` による直接実行を試みたが、環境から npm registry へのアクセスが 403 を返し依存パッケージの入手に失敗したため実行できなかった。 
- テストスクリプトはリポジトリへ追加済みで、依存を揃えた CI/ローカル環境では `test:small` / `test:medium` / `test:large` により今回追加したケースが実行可能です。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4bac8e568832ba4b571a50c300498)