### PR TITLE
fix: レート制限キーをIP+ユーザー単位に統一

### DIFF
--- a/__tests__/small/controller/api/LoginPostController.test.js
+++ b/__tests__/small/controller/api/LoginPostController.test.js
@@ -1,4 +1,5 @@
 const LoginPostController = require('../../../../src/controller/api/LoginPostController');
+const InMemoryLoginAttemptStore = require('../../../../src/infrastructure/InMemoryLoginAttemptStore');
 const {
   LoginSucceededResult,
   LoginFailedResult,
@@ -63,7 +64,7 @@ describe('LoginPostController', () => {
       session,
     });
     expect(loginAttemptStore.clearAuthenticationFailures).toHaveBeenCalledWith({ key: 'admin' });
-    expect(loginAttemptStore.clearRateLimit).toHaveBeenCalledWith({ scope: 'ip', key: 'unknown' });
+    expect(loginAttemptStore.clearRateLimit).toHaveBeenCalledWith({ scope: 'ip', key: 'ip:unknown|user:admin' });
     expect(res.cookie).toHaveBeenCalledWith('session_token', 'token-1', {
       httpOnly: true,
       path: '/',
@@ -168,5 +169,46 @@ describe('LoginPostController', () => {
 
     expect(loginAttemptStore.clearAuthenticationFailures).toHaveBeenCalledTimes(8);
     expect(loginAttemptStore.clearRateLimit).toHaveBeenCalledTimes(8);
+  });
+
+  it('ログイン成功時は同一IPの別ユーザー分レート制限をクリアしない', async () => {
+    const session = { regenerate: jest.fn() };
+    const inMemoryStore = new InMemoryLoginAttemptStore();
+    const inMemoryController = new LoginPostController({
+      loginService,
+      loginAttemptStore: inMemoryStore,
+    });
+    const nowMs = 1_000;
+    inMemoryStore.consumeRateLimit({ scope: 'ip', key: 'ip:127.0.0.1|user:admin', windowMs: 60_000, nowMs });
+    inMemoryStore.consumeRateLimit({ scope: 'ip', key: 'ip:127.0.0.1|user:guest', windowMs: 60_000, nowMs });
+
+    const req = {
+      body: { username: 'admin', password: 'secret' },
+      session,
+      ip: '127.0.0.1',
+      app: {
+        locals: {
+          env: {},
+        },
+      },
+    };
+    const res = createRes();
+    await inMemoryController.execute(req, res);
+
+    const adminAfterSuccess = inMemoryStore.consumeRateLimit({
+      scope: 'ip',
+      key: 'ip:127.0.0.1|user:admin',
+      windowMs: 60_000,
+      nowMs: nowMs + 1,
+    });
+    const guestAfterSuccess = inMemoryStore.consumeRateLimit({
+      scope: 'ip',
+      key: 'ip:127.0.0.1|user:guest',
+      windowMs: 60_000,
+      nowMs: nowMs + 1,
+    });
+
+    expect(adminAfterSuccess.count).toBe(1);
+    expect(guestAfterSuccess.count).toBe(2);
   });
 });

--- a/__tests__/small/controller/middleware/LoginRateLimiter.test.js
+++ b/__tests__/small/controller/middleware/LoginRateLimiter.test.js
@@ -1,4 +1,5 @@
 const LoginRateLimiter = require('../../../../src/controller/middleware/LoginRateLimiter');
+const InMemoryLoginAttemptStore = require('../../../../src/infrastructure/InMemoryLoginAttemptStore');
 
 describe('LoginRateLimiter', () => {
   const createRes = () => {
@@ -31,6 +32,32 @@ describe('LoginRateLimiter', () => {
     middleware.execute({ ip: '127.0.0.1', body: { username: 'admin' } }, secondRes, next);
     expect(secondRes.status).toHaveBeenCalledWith(429);
     expect(secondRes.json).toHaveBeenCalledWith({ code: 1 });
+  });
+
+  test('同一IPでもユーザーが異なる試行は別キーとして扱う', () => {
+    const loginAttemptStore = new InMemoryLoginAttemptStore();
+    const middleware = new LoginRateLimiter({
+      loginAttemptStore,
+      maxAttemptsPerWindow: 1,
+      windowMs: 60_000,
+    });
+
+    const firstRes = createRes();
+    const firstNext = jest.fn();
+    middleware.execute({ ip: '127.0.0.1', body: { username: 'alice' } }, firstRes, firstNext);
+    expect(firstNext).toHaveBeenCalledTimes(1);
+
+    const secondRes = createRes();
+    const secondNext = jest.fn();
+    middleware.execute({ ip: '127.0.0.1', body: { username: 'bob' } }, secondRes, secondNext);
+    expect(secondNext).toHaveBeenCalledTimes(1);
+    expect(secondRes.status).not.toHaveBeenCalledWith(429);
+
+    const thirdRes = createRes();
+    const thirdNext = jest.fn();
+    middleware.execute({ ip: '127.0.0.1', body: { username: 'alice' } }, thirdRes, thirdNext);
+    expect(thirdNext).not.toHaveBeenCalled();
+    expect(thirdRes.status).toHaveBeenCalledWith(429);
   });
 
   test('認証成功が連続する想定では毎回nextへ進み429にならない', () => {

--- a/src/controller/api/LoginPostController.js
+++ b/src/controller/api/LoginPostController.js
@@ -30,6 +30,7 @@ class LoginPostController {
       const username = req?.body?.username;
       const password = req?.body?.password;
       const session = req?.session;
+      const ipAddress = this.#resolveIpAddress(req);
 
       if (!this.#isValidCredential(username) || !this.#isValidCredential(password) || !session) {
         logger?.warn('auth.login.failed', {
@@ -60,7 +61,7 @@ class LoginPostController {
         this.#loginAttemptStore.clearAuthenticationFailures({ key: username });
         this.#loginAttemptStore.clearRateLimit({
           scope: 'ip',
-          key: this.#resolveIpAddress(req),
+          key: this.#buildRateLimitKey({ ipAddress, username }),
         });
         const cookiePolicy = this.#resolveSessionCookiePolicy(req);
         res.cookie('session_token', result.sessionToken, {
@@ -118,6 +119,12 @@ class LoginPostController {
 
   #resolveIpAddress(req) {
     return req.ip || req.connection?.remoteAddress || 'unknown';
+  }
+
+  #buildRateLimitKey({ ipAddress, username }) {
+    const resolvedIpAddress = typeof ipAddress === 'string' && ipAddress.length > 0 ? ipAddress : 'unknown';
+    const resolvedUsername = typeof username === 'string' && username.length > 0 ? username : 'anonymous';
+    return `ip:${resolvedIpAddress}|user:${resolvedUsername}`;
   }
 
   #fail(res) {

--- a/src/controller/middleware/LoginRateLimiter.js
+++ b/src/controller/middleware/LoginRateLimiter.js
@@ -20,10 +20,12 @@ class LoginRateLimiter {
     const logger = req.app?.locals?.dependencies?.logger;
     const requestId = req.context?.requestId;
     const ipAddress = this.#resolveIpAddress(req);
+    const username = this.#resolveUsername(req);
+    const rateLimitKey = this.#buildRateLimitKey({ ipAddress, username });
 
     const ipCounter = this.#loginAttemptStore.consumeRateLimit({
       scope: 'ip',
-      key: ipAddress,
+      key: rateLimitKey,
       windowMs: this.#windowMs,
       nowMs,
     });
@@ -33,7 +35,7 @@ class LoginRateLimiter {
         request_id: requestId,
         reason: 'rate_limited',
         ip_address: ipAddress,
-        username: this.#resolveUsername(req),
+        username,
       });
       return res.status(429).json({ code: 1 });
     }
@@ -52,6 +54,10 @@ class LoginRateLimiter {
 
   #resolveIpAddress(req) {
     return req.ip || req.connection?.remoteAddress || 'unknown';
+  }
+
+  #buildRateLimitKey({ ipAddress, username }) {
+    return `ip:${ipAddress}|user:${username}`;
   }
 }
 


### PR DESCRIPTION
### Motivation

- 同一IP環境でユーザーを切り替えた際、ログイン成功時のレート制限クリアがIP全体を対象にしてしまい別ユーザーの試行状態まで消えてしまう恐れがあったため、クリア対象を該当ユーザー分に局所化する必要がありました。

### Description

- `src/controller/middleware/LoginRateLimiter.js` にてレート制限のキーを単一の `ip` から複合キー `ip:${ip}|user:${username}` に変更し、`consumeRateLimit` 呼び出しに新キーを渡すようにしました。ログ出力でも解決した `username` を再利用します。
- `src/controller/api/LoginPostController.js` のログイン成功時 `clearRateLimit` を同一の複合キー形式で実行するようにし、`#buildRateLimitKey` ヘルパーを追加して `unknown` / `anonymous` のフォールバックを明示しました。
- ストア実装 `src/infrastructure/InMemoryLoginAttemptStore.js` は既存の `scope:key` 結合ロジックと整合しているため変更不要と判断しました。
- テストを追加・更新し、`__tests__/small/controller/middleware/LoginRateLimiter.test.js` に同一IPでユーザーが異なる場合に別キーでカウントされることを検証するケースを追加し、`__tests__/small/controller/api/LoginPostController.test.js` にログイン成功時に別ユーザー分のレート制限がクリアされないことを検証するケースを追加および既存期待値を新キー形式へ更新しました。

### Testing

- 依存解決のために `npm ci` を実行しインストールを試みましたが一部パッケージの警告が出ましたが完了しました。
- `npm run test:small -- <tests...>` を実行しようとしましたが、環境で `cross-env` が見つからず（`cross-env: not found`）テストスイートは実行できませんでした。変更に対するユニットテストは追加済みで、依存を揃えた環境では `jest` による小テスト群は通る想定です。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4bac90234832bb511c7b5f67caef8)