### PR TITLE
fix: 公開コンテンツパスをアプリ管理下のみに制限する

### DIFF
--- a/__tests__/medium/controller/router/screen/setRouterScreenDetailGet.test.js
+++ b/__tests__/medium/controller/router/screen/setRouterScreenDetailGet.test.js
@@ -63,7 +63,7 @@ describe('setRouterScreenDetailGet (middle)', () => {
       await mediaRepository.save(new Media(
         new MediaId('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
         new MediaTitle('作品A'),
-        [new ContentId('content-001'), new ContentId('')],
+        [new ContentId('11111111111111111111111111111111'), new ContentId('')],
         [new Tag(new Category('作者'), new Label('山田 太郎'))],
         [new Category('作者')],
       ));
@@ -113,7 +113,7 @@ describe('setRouterScreenDetailGet (middle)', () => {
     expect(response.bodyText).toContain('カテゴリー一覧');
     expect(response.bodyText).toContain('/screen/summary?summaryPage=1&sort=date_asc&tags=%E4%BD%9C%E8%80%85%3A%E5%B1%B1%E7%94%B0%20%E5%A4%AA%E9%83%8E');
     expect(response.bodyText).toContain('/screen/viewer/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/1');
-    expect(response.bodyText).toContain('src="/contents/content-001"');
+    expect(response.bodyText).toContain('src="/contents/11/11/11/11/11111111111111111111111111111111"');
     expect(response.bodyText).toContain('サムネイル未設定');
   });
 });

--- a/__tests__/medium/controller/router/screen/setRouterScreenEditGet.test.js
+++ b/__tests__/medium/controller/router/screen/setRouterScreenEditGet.test.js
@@ -82,7 +82,7 @@ describe('setRouterScreenEditGet (middle)', () => {
           mediaDetail: {
             id: 'media-001',
             title: 'メディア編集',
-            contents: [{ id: 'content-1' }],
+            contents: [{ id: '/contents/content-1' }],
             tags: [{ category: '作者', label: '山田' }],
             priorityCategories: ['作者'],
           },

--- a/__tests__/medium/controller/router/screen/setRouterScreenFavoriteGet.test.js
+++ b/__tests__/medium/controller/router/screen/setRouterScreenFavoriteGet.test.js
@@ -78,21 +78,21 @@ describe('setRouterScreenFavoriteGet (middle)', () => {
       await mediaRepository.save(new Media(
         new MediaId('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
         new MediaTitle('あいうえお'),
-        [new ContentId('content-001')],
+        [new ContentId('11111111111111111111111111111111')],
         [new Tag(new Category('作者'), new Label('山田'))],
         [new Category('作者')],
       ));
       await mediaRepository.save(new Media(
         new MediaId('bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'),
         new MediaTitle('かきくけこ'),
-        [new ContentId('content-002')],
+        [new ContentId('22222222222222222222222222222222')],
         [new Tag(new Category('作者'), new Label('佐藤'))],
         [new Category('作者')],
       ));
       await mediaRepository.save(new Media(
         new MediaId('cccccccccccccccccccccccccccccccc'),
         new MediaTitle('さしすせそ'),
-        [new ContentId('content-003')],
+        [new ContentId('33333333333333333333333333333333')],
         [new Tag(new Category('ジャンル'), new Label('冒険'))],
         [new Category('ジャンル')],
       ));
@@ -148,7 +148,7 @@ describe('setRouterScreenFavoriteGet (middle)', () => {
     expect(response.bodyText).toContain(path.join('src', 'views', 'screen', 'favorite.ejs'));
     expect(response.bodyText).toContain('sort=date_asc');
     expect(response.bodyText).toContain('page=1');
-    expect(response.bodyText).toContain('thumbnail=/contents/content-');
+    expect(response.bodyText).toContain('thumbnail=/contents/');
   });
 
   test('sort を変更すると指定順で描画される', async () => {
@@ -172,7 +172,7 @@ describe('setRouterScreenFavoriteGet (middle)', () => {
           await mediaRepository.save(new Media(
             new MediaId(mediaId),
             new MediaTitle(`追加作品${suffix}`),
-            [new ContentId(`content-${suffix}`)],
+            [new ContentId('44444444444444444444444444444444')],
             [new Tag(new Category('作者'), new Label(`作家${suffix}`))],
             [new Category('作者')],
           ));

--- a/__tests__/medium/controller/router/screen/setRouterScreenQueueGet.test.js
+++ b/__tests__/medium/controller/router/screen/setRouterScreenQueueGet.test.js
@@ -50,7 +50,7 @@ describe('setRouterScreenQueueGet (middle)', () => {
         mediaOverviews: [{
           mediaId: 'media-001',
           title: 'タイトル1',
-          thumbnail: 'content-001',
+          thumbnail: '/contents/content-001',
           tags: [{ category: '作者', label: '山田' }],
           priorityCategories: [],
           isFavorite: false,

--- a/__tests__/medium/controller/router/screen/setRouterScreenSummaryGet.test.js
+++ b/__tests__/medium/controller/router/screen/setRouterScreenSummaryGet.test.js
@@ -46,7 +46,7 @@ describe('setRouterScreenSummaryGet (middle)', () => {
         mediaOverviews: [{
           mediaId: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
           title: '太郎の冒険',
-          thumbnail: 'content-001',
+          thumbnail: '/contents/content-001',
           tags: [{ category: '作者', label: '山田' }],
           priorityCategories: ['作者'],
         }],

--- a/__tests__/medium/controller/screen/screenControllers.test.js
+++ b/__tests__/medium/controller/screen/screenControllers.test.js
@@ -24,11 +24,12 @@ const createAppWithRenderCapture = (mountRoute) => {
 
 describe('medium: ScreenDetailGetController', () => {
   test('medium: 正常系 - ルーティング由来の req.params.mediaId を使って詳細画面を描画する', async () => {
+    const contentId = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
     const mediaDetail = {
       id: 'media-001',
       title: '作品タイトル',
       registeredAt: '2026-03-20 12:34 UTC',
-      contents: [{ id: 'content-001', thumbnail: 'content-001', position: 1 }],
+      contents: [{ id: 'content-001', thumbnail: contentId, position: 1 }],
       tags: [{ category: '作者', label: '山田' }],
       categories: ['作者'],
       priorityCategories: ['作者'],
@@ -51,7 +52,7 @@ describe('medium: ScreenDetailGetController', () => {
         pageTitle: '作品タイトル の詳細',
         mediaDetail: {
           ...mediaDetail,
-          contents: [{ id: 'content-001', thumbnail: '/contents/content-001', position: 1 }],
+          contents: [{ id: 'content-001', thumbnail: '/contents/aa/aa/aa/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', position: 1 }],
         },
         currentPath: '/screen/detail',
         currentUserId: null,
@@ -107,6 +108,7 @@ describe('medium: ScreenViewerGetController', () => {
         content: {
           id: '/contents/page-2.jpg',
           type: 'image',
+          hasSource: true,
         },
         previousPage: {
           mediaId: 'media-001',
@@ -148,6 +150,7 @@ describe('medium: ScreenViewerGetController', () => {
         content: {
           id: '/contents/page-10.mp4',
           type: 'video',
+          hasSource: true,
         },
         previousPage: null,
         nextPage: null,

--- a/__tests__/small/controller/router/screen/setRouterScreenSummaryGet.test.js
+++ b/__tests__/small/controller/router/screen/setRouterScreenSummaryGet.test.js
@@ -99,4 +99,32 @@ describe('setRouterScreenSummaryGet', () => {
       size: 10,
     }));
   });
+
+  test('危険なサムネイルURLは無効化して NO IMAGE を表示する', async () => {
+    const { app } = createApp({
+      output: new Output({
+        mediaOverviews: [{
+          mediaId: 'media-001',
+          title: 'タイトル1',
+          thumbnail: 'https://example.com/evil.jpg',
+          tags: [],
+          priorityCategories: [],
+        }],
+        totalCount: 1,
+      }),
+    });
+
+    const server = app.listen(0);
+    await new Promise(resolve => server.once('listening', resolve));
+    const { port } = server.address();
+    const response = await fetch(`http://127.0.0.1:${port}/screen/summary`, {
+      headers: { cookie: 'session_token=valid-token' },
+    });
+    const bodyText = await response.text();
+    await new Promise(resolve => server.close(resolve));
+
+    expect(response.status).toBe(200);
+    expect(bodyText).toContain('NO IMAGE');
+    expect(bodyText).not.toContain('https://example.com/evil.jpg');
+  });
 });

--- a/__tests__/small/controller/router/screen/setRouterScreenViewerGet.test.js
+++ b/__tests__/small/controller/router/screen/setRouterScreenViewerGet.test.js
@@ -55,7 +55,7 @@ describe('setRouterScreenViewerGet', () => {
     expect(res.render).toHaveBeenCalledWith('screen/viewer', expect.objectContaining({
       mediaId: 'media-1',
       mediaPage: 2,
-      content: { id: '/contents/page-2.jpg', type: 'image' },
+      content: { id: '/contents/page-2.jpg', type: 'image', hasSource: true },
       previousPage: expect.objectContaining({ href: '/screen/viewer/media-1/1' }),
       nextPage: expect.objectContaining({ href: '/screen/viewer/media-1/3' }),
     }));

--- a/__tests__/small/controller/screen/ScreenDetailGetController.test.js
+++ b/__tests__/small/controller/screen/ScreenDetailGetController.test.js
@@ -12,11 +12,12 @@ describe('ScreenDetailGetController', () => {
   };
 
   test('mediaId を service に渡して詳細画面を描画する', async () => {
+    const contentId = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
     const mediaDetail = {
       id: 'media-1',
       title: '作品タイトル',
       registeredAt: '2026-03-20 12:34 UTC',
-      contents: [{ id: 'content-1', thumbnail: 'content-1', position: 1 }],
+      contents: [{ id: 'content-1', thumbnail: contentId, position: 1 }],
       tags: [{ category: '作者', label: '山田' }],
       categories: ['作者'],
       priorityCategories: ['作者'],
@@ -36,7 +37,7 @@ describe('ScreenDetailGetController', () => {
       pageTitle: '作品タイトル の詳細',
       mediaDetail: {
         ...mediaDetail,
-        contents: [{ id: 'content-1', thumbnail: '/contents/content-1', position: 1 }],
+        contents: [{ id: 'content-1', thumbnail: '/contents/aa/aa/aa/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', position: 1 }],
       },
       currentPath: '/screen/detail',
       currentUserId: 'admin',

--- a/__tests__/small/controller/screen/ScreenViewerGetController.test.js
+++ b/__tests__/small/controller/screen/ScreenViewerGetController.test.js
@@ -44,6 +44,7 @@ describe('ScreenViewerGetController', () => {
       content: {
         id: '/contents/page-2.jpg',
         type: 'image',
+        hasSource: true,
       },
       previousPage: {
         mediaId: 'media-1',
@@ -77,9 +78,32 @@ describe('ScreenViewerGetController', () => {
       content: {
         id: '/contents/page-10.mp4',
         type: 'video',
+        hasSource: true,
       },
       previousPage: null,
       nextPage: null,
+    }));
+  });
+
+  test('contentId が外部URLの場合は空のソースとして描画モデルを返す', async () => {
+    const getMediaContentWithNavigationService = {
+      execute: jest.fn().mockResolvedValue(new FoundResult({
+        contentId: 'https://example.com/page-1.jpg',
+        previousContentId: null,
+        nextContentId: null,
+      })),
+    };
+    const controller = new ScreenViewerGetController({ getMediaContentWithNavigationService });
+    const res = createRes();
+
+    await controller.execute({ params: { mediaId: 'media-1', mediaPage: '1' } }, res);
+
+    expect(res.render).toHaveBeenCalledWith('screen/viewer', expect.objectContaining({
+      content: {
+        id: '',
+        type: 'image',
+        hasSource: false,
+      },
     }));
   });
 

--- a/__tests__/small/controller/screen/publicContentPath.test.js
+++ b/__tests__/small/controller/screen/publicContentPath.test.js
@@ -15,7 +15,20 @@ describe('toPublicContentPath', () => {
     expect(toPublicContentPath('/contents/a/b/c.jpg')).toBe('/contents/a/b/c.jpg');
   });
 
-  test('相対パスは /contents を先頭に付与する', () => {
-    expect(toPublicContentPath('seed/page-1.jpg')).toBe('/contents/seed/page-1.jpg');
+  test.each([
+    'http://example.com/evil.jpg',
+    'https://example.com/evil.jpg',
+    '//example.com/evil.jpg',
+    'data:image/png;base64,xxxx',
+  ])('外部URLまたは data URL (%s) は拒否して空文字を返す', (value) => {
+    expect(toPublicContentPath(value)).toBe('');
+  });
+
+  test.each([
+    '/etc/passwd',
+    '/image/cover.jpg',
+    'seed/page-1.jpg',
+  ])('許可形式以外 (%s) は空文字を返す', (value) => {
+    expect(toPublicContentPath(value)).toBe('');
   });
 });

--- a/src/controller/router/screen/setRouterScreenFavoriteGet.js
+++ b/src/controller/router/screen/setRouterScreenFavoriteGet.js
@@ -46,7 +46,12 @@ const setRouterScreenFavoriteGet = ({ router, authResolver, getFavoriteSummaries
           page,
           pageSize: PAGE_SIZE,
         });
-        const mediaOverviews = result.mediaOverviews.map(mapMediaOverviewThumbnailToPublicPath);
+        const mediaOverviews = result.mediaOverviews
+          .map(mapMediaOverviewThumbnailToPublicPath)
+          .map(media => ({
+            ...media,
+            thumbnailFallbackLabel: 'NO IMAGE',
+          }));
 
         res.status(200).render('screen/favorite', {
           pageTitle: 'お気に入り一覧',

--- a/src/controller/router/screen/setRouterScreenQueueGet.js
+++ b/src/controller/router/screen/setRouterScreenQueueGet.js
@@ -50,7 +50,11 @@ const setRouterScreenQueueGet = ({ router, authResolver, getQueueService }) => {
           pageSize: DEFAULT_PAGE_SIZE,
         });
         const mediaOverviews = (result.currentPageMediaOverviews ?? result.mediaOverviews)
-          .map(mapMediaOverviewThumbnailToPublicPath);
+          .map(mapMediaOverviewThumbnailToPublicPath)
+          .map(media => ({
+            ...media,
+            thumbnailFallbackLabel: 'NO IMAGE',
+          }));
 
         res.status(200).render('screen/queue', {
           pageTitle: 'あとで見る一覧',

--- a/src/controller/router/screen/setRouterScreenSummaryGet.js
+++ b/src/controller/router/screen/setRouterScreenSummaryGet.js
@@ -124,7 +124,12 @@ const setRouterScreenSummaryGet = ({ router, authResolver, searchMediaService })
           summaryPage: range.summaryPage,
           pageSize: range.size,
         });
-        const mediaOverviews = result.mediaOverviews.map(mapMediaOverviewThumbnailToPublicPath);
+        const mediaOverviews = result.mediaOverviews
+          .map(mapMediaOverviewThumbnailToPublicPath)
+          .map(media => ({
+            ...media,
+            thumbnailFallbackLabel: 'NO IMAGE',
+          }));
 
         res.status(200).render('screen/summary', {
           pageTitle: 'メディア一覧',

--- a/src/controller/screen/ScreenViewerGetController.js
+++ b/src/controller/screen/ScreenViewerGetController.js
@@ -37,6 +37,9 @@ class ScreenViewerGetController {
         throw new Error('unexpected result');
       }
 
+      const contentPublicPath = toPublicContentPath(result.contentId);
+      const contentType = this.#detectContentType(result.contentId);
+
       return res.status(200).render('screen/viewer', {
         pageTitle: `ビューアー ${req.params.mediaId} - ${mediaPage}ページ`,
         mediaId: req.params.mediaId,
@@ -44,8 +47,9 @@ class ScreenViewerGetController {
         currentPath: '/screen/viewer',
         currentUserId: req.context?.userId || null,
         content: {
-          id: toPublicContentPath(result.contentId),
-          type: this.#detectContentType(result.contentId),
+          id: contentPublicPath,
+          type: contentType,
+          hasSource: contentPublicPath.length > 0,
         },
         previousPage: result.previousContentId === null ? null : {
           mediaId: req.params.mediaId,

--- a/src/controller/screen/publicContentPath.js
+++ b/src/controller/screen/publicContentPath.js
@@ -18,8 +18,8 @@ const toPublicContentPath = contentId => {
     return '';
   }
 
-  if (/^(https?:)?\/\//.test(normalized) || normalized.startsWith('data:')) {
-    return normalized;
+  if (/^(https?:)?\/\//i.test(normalized) || /^data:/i.test(normalized)) {
+    return '';
   }
 
   if (normalized.startsWith('/contents/')) {
@@ -27,7 +27,7 @@ const toPublicContentPath = contentId => {
   }
 
   if (normalized.startsWith('/')) {
-    return normalized;
+    return '';
   }
 
   if ((/^[0-9a-f]{32}$/i).test(normalized)) {
@@ -35,7 +35,7 @@ const toPublicContentPath = contentId => {
     return `/contents/${buildShardedPath(canonicalContentId)}`;
   }
 
-  return `/contents/${normalized.replace(/^\/+/, '')}`;
+  return '';
 };
 
 const mapMediaOverviewThumbnailToPublicPath = mediaOverview => ({

--- a/src/views/screen/favorite.ejs
+++ b/src/views/screen/favorite.ejs
@@ -73,7 +73,7 @@
                       <% if (media.thumbnail) { %>
                         <img src="<%= media.thumbnail %>" alt="<%= media.title %> のサムネイル" />
                       <% } else { %>
-                        <span>NO IMAGE</span>
+                        <span><%= media.thumbnailFallbackLabel %></span>
                       <% } %>
                     </a>
                     <div class="meta">

--- a/src/views/screen/queue.ejs
+++ b/src/views/screen/queue.ejs
@@ -68,7 +68,7 @@
                       <% if (media.thumbnail) { %>
                         <img src="<%= media.thumbnail %>" alt="<%= media.title %> のサムネイル" />
                       <% } else { %>
-                        <span>NO IMAGE</span>
+                        <span><%= media.thumbnailFallbackLabel %></span>
                       <% } %>
                     </a>
                     <div class="meta">

--- a/src/views/screen/summary.ejs
+++ b/src/views/screen/summary.ejs
@@ -106,7 +106,7 @@
                       <% if (media.thumbnail) { %>
                         <img src="<%= media.thumbnail %>" alt="<%= media.title %> のサムネイル" />
                       <% } else { %>
-                        <span>NO IMAGE</span>
+                        <span><%= media.thumbnailFallbackLabel %></span>
                       <% } %>
                     </a>
                     <div class="meta">

--- a/src/views/screen/viewer.ejs
+++ b/src/views/screen/viewer.ejs
@@ -61,7 +61,9 @@
         </header>
 
         <article class="stage">
-          <% if (content.type === 'video') { %>
+          <% if (!content.hasSource) { %>
+            <p>コンテンツを表示できません。</p>
+          <% } else if (content.type === 'video') { %>
             <video src="<%= content.id %>" controls playsinline>
               動画を再生できません。
             </video>


### PR DESCRIPTION
### Motivation
- 外部ホストや `data:` スキームをそのままビューへ渡すとアプリ外のリソース読み込みを引き起こすため、公開パスをアプリ管理下のコンテンツのみに限定する必要がありました。

### Description
- `toPublicContentPath` を更新し、`http://`/`https://`/`//`/`data:` を拒否して空文字を返すようにし、許可形式を `/contents/...` と `32hex`（シャーディング変換）に限定しました（`src/controller/screen/publicContentPath.js`）。
- ビューアコントローラで `contentPublicPath` と `contentType` を事前に算出し、`hasSource` フラグを描画モデルに追加して無効パス時のフォールバックを可能にしました（`src/controller/screen/ScreenViewerGetController.js`）。
- ビュー側で `!content.hasSource` の場合に「コンテンツを表示できません。」を表示するフォールバックを追加しました（`src/views/screen/viewer.ejs`）。
- 一覧系（summary/queue/favorite）では `mapMediaOverviewThumbnailToPublicPath` の結果に `thumbnailFallbackLabel: 'NO IMAGE'` を付与し、テンプレートで空サムネイル時にそのラベルを表示するよう修正しました（`src/controller/router/screen/*` と `src/views/screen/*.ejs`）。
- テストを追加/修正して外部URL・`data:` の拒否、許可形式の維持、一覧のフォールバック表示を検証するケースを追加しました（`__tests__/small/controller/screen/publicContentPath.test.js`、`ScreenViewerGetController.test.js`、`setRouterScreenSummaryGet.test.js`）。

### Testing
- `npm run test:small` はローカル環境で `cross-env` が見つからず実行できませんでした（失敗）。
- `npx jest` による直接実行は環境の npm レジストリアクセス制限で失敗しました（失敗）。
- 影響範囲の smoke チェックとして `node -e "require('./src/controller/screen/publicContentPath'); require('./src/controller/screen/ScreenViewerGetController'); require('./src/controller/router/screen/setRouterScreenSummaryGet');"` によるモジュール読み込みは成功しました（成功）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4baca3aa4832b94a072f236e37abc)