### PR TITLE
公開コンテンツパスの許可形式限定と画面フォールバック追加

### DIFF
--- a/__tests__/large/e2e/auth/auth-guard-uncovered-routes.large.test.js
+++ b/__tests__/large/e2e/auth/auth-guard-uncovered-routes.large.test.js
@@ -28,11 +28,13 @@ const expectUnauthorizedJsonResponse = async response => {
   expect(response.status()).toBe(401);
 };
 
-const toExpectedPublicPath = contentId => `/contents/${contentId}`;
+const toExpectedPublicPath = contentId => {
+  return `/contents/${contentId.slice(0, 2)}/${contentId.slice(2, 4)}/${contentId.slice(4, 6)}/${contentId.slice(6, 8)}/${contentId}`;
+};
 
 test.describe('large e2e: 認可境界（未カバー導線）', () => {
   const detailMediaId = 'auth-uncovered-media-1';
-  const contentIdForViewer = 'seed/auth-uncovered-content-1.jpg';
+  const contentIdForViewer = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
   const contentIdForPost = '11111111111111111111111111111111';
 
   let appContext;
@@ -50,8 +52,15 @@ test.describe('large e2e: 認可境界（未カバー導線）', () => {
           }));
         });
 
-        await fs.mkdir(path.join(tempContentDirectory, 'seed'), { recursive: true });
-        await fs.writeFile(path.join(tempContentDirectory, contentIdForViewer), 'dummy', { encoding: 'utf8' });
+        const viewerDirectory = path.join(
+          tempContentDirectory,
+          contentIdForViewer.slice(0, 2),
+          contentIdForViewer.slice(2, 4),
+          contentIdForViewer.slice(4, 6),
+          contentIdForViewer.slice(6, 8),
+        );
+        await fs.mkdir(viewerDirectory, { recursive: true });
+        await fs.writeFile(path.join(viewerDirectory, contentIdForViewer), 'dummy', { encoding: 'utf8' });
 
         const postContentDirectory = path.join(tempContentDirectory, '11', '11', '11', '11');
         await fs.mkdir(postContentDirectory, { recursive: true });

--- a/__tests__/large/e2e/edit/edit-update-media.large.test.js
+++ b/__tests__/large/e2e/edit/edit-update-media.large.test.js
@@ -134,7 +134,7 @@ test.describe('large e2e: edit 画面での既存メディア更新', () => {
     });
     expect(initialMediaTexts).toHaveLength(seedContentIds.length);
     initialMediaTexts.forEach(text => {
-      expect(text).toMatch(/^contentId: /);
+      expect(text).toMatch(/^(既存)?contentId: /);
     });
 
     await page.click('#title', { clickCount: 3 });

--- a/__tests__/large/e2e/viewer/viewer-navigation.large.test.js
+++ b/__tests__/large/e2e/viewer/viewer-navigation.large.test.js
@@ -29,9 +29,9 @@ test.describe('large e2e: viewer ナビゲーション', () => {
   const seedMediaId = 'media-seed-viewer-navigation-1';
   const seedTitle = 'ビューアー遷移確認用タイトル';
   const seedContentIds = [
-    'seed/viewer-navigation-content-1.jpg',
-    'seed/viewer-navigation-content-2.jpg',
-    'seed/viewer-navigation-content-3.jpg',
+    '11111111111111111111111111111111',
+    '22222222222222222222222222222222',
+    '33333333333333333333333333333333',
   ];
   const seedVideoMediaId = 'media-seed-viewer-navigation-video-1';
   const seedVideoTitle = 'ビューアー動画確認用タイトル';
@@ -62,10 +62,16 @@ test.describe('large e2e: viewer ナビゲーション', () => {
           { where: { content_id: seedVideoContentId } }
         );
 
-        await fs.mkdir(path.join(tempContentDirectory, 'seed'), { recursive: true });
-
         await Promise.all(seedContentIds.map(contentId => {
-          return fs.writeFile(path.join(tempContentDirectory, contentId), 'dummy', { encoding: 'utf8' });
+          const imageDirectory = path.join(
+            tempContentDirectory,
+            contentId.slice(0, 2),
+            contentId.slice(2, 4),
+            contentId.slice(4, 6),
+            contentId.slice(6, 8),
+          );
+          return fs.mkdir(imageDirectory, { recursive: true })
+            .then(() => fs.writeFile(path.join(imageDirectory, contentId), 'dummy', { encoding: 'utf8' }));
         }));
         const shardedSegments = [
           seedVideoContentId.slice(0, 2),

--- a/__tests__/medium/controller/router/screen/setRouterScreenDetailGet.test.js
+++ b/__tests__/medium/controller/router/screen/setRouterScreenDetailGet.test.js
@@ -113,7 +113,6 @@ describe('setRouterScreenDetailGet (middle)', () => {
     expect(response.bodyText).toContain('カテゴリー一覧');
     expect(response.bodyText).toContain('/screen/summary?summaryPage=1&sort=date_asc&tags=%E4%BD%9C%E8%80%85%3A%E5%B1%B1%E7%94%B0%20%E5%A4%AA%E9%83%8E');
     expect(response.bodyText).toContain('/screen/viewer/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/1');
-    expect(response.bodyText).toContain('src="/contents/content-001"');
     expect(response.bodyText).toContain('サムネイル未設定');
   });
 });

--- a/__tests__/medium/controller/router/screen/setRouterScreenEditGet.test.js
+++ b/__tests__/medium/controller/router/screen/setRouterScreenEditGet.test.js
@@ -112,6 +112,6 @@ describe('setRouterScreenEditGet (middle)', () => {
     expect(response.bodyText).toContain('<title>メディア編集 の編集</title>');
     expect(response.bodyText).toContain(path.join('src', 'views', 'screen', 'edit.ejs'));
     expect(response.bodyText).toContain('media-001');
-    expect(response.bodyText).toContain('/contents/content-1');
+    expect(response.bodyText).toContain('media-001:');
   });
 });

--- a/__tests__/medium/controller/router/screen/setRouterScreenFavoriteGet.test.js
+++ b/__tests__/medium/controller/router/screen/setRouterScreenFavoriteGet.test.js
@@ -148,7 +148,7 @@ describe('setRouterScreenFavoriteGet (middle)', () => {
     expect(response.bodyText).toContain(path.join('src', 'views', 'screen', 'favorite.ejs'));
     expect(response.bodyText).toContain('sort=date_asc');
     expect(response.bodyText).toContain('page=1');
-    expect(response.bodyText).toContain('thumbnail=/contents/content-');
+    expect(response.bodyText).toContain('thumbnail=');
   });
 
   test('sort を変更すると指定順で描画される', async () => {

--- a/__tests__/medium/controller/router/screen/setRouterScreenQueueGet.test.js
+++ b/__tests__/medium/controller/router/screen/setRouterScreenQueueGet.test.js
@@ -105,7 +105,7 @@ describe('setRouterScreenQueueGet (middle)', () => {
     expect(response.headers.get('content-type')).toContain('text/html');
     expect(response.bodyText).toContain('<title>あとで見る一覧</title>');
     expect(response.bodyText).toContain(path.join('src', 'views', 'screen', 'queue.ejs'));
-    expect(response.bodyText).toContain(':title_desc:2:41:1,2,3:/contents/content-001:false:true:');
+    expect(response.bodyText).toContain(':title_desc:2:41:1,2,3::false:true:');
     expect(response.bodyText).toContain('summary=/screen/summary?summaryPage=1&sort=date_asc&tags=');
     expect(response.bodyText).toContain('page=/screen/queue?queuePage=1&sort=title_desc');
     expect(response.bodyText).toContain('favoriteLabel=お気に入り追加');

--- a/__tests__/medium/controller/router/screen/setRouterScreenSummaryGet.test.js
+++ b/__tests__/medium/controller/router/screen/setRouterScreenSummaryGet.test.js
@@ -92,7 +92,7 @@ describe('setRouterScreenSummaryGet (middle)', () => {
     expect(response.bodyText).toContain(path.join('src', 'views', 'screen', 'summary.ejs'));
     expect(response.bodyText).toContain(':太郎:作者:山田:11:5:');
     expect(response.bodyText).toContain('太郎の冒険');
-    expect(response.bodyText).toContain('/contents/content-001');
+    expect(response.bodyText).toContain('太郎の冒険::1');
     expect(response.bodyText).toContain(':1</body>');
     expect(searchMediaService.execute).toHaveBeenCalledWith(expect.objectContaining({
       title: '太郎',

--- a/__tests__/medium/controller/screen/screenControllers.test.js
+++ b/__tests__/medium/controller/screen/screenControllers.test.js
@@ -51,7 +51,7 @@ describe('medium: ScreenDetailGetController', () => {
         pageTitle: '作品タイトル の詳細',
         mediaDetail: {
           ...mediaDetail,
-          contents: [{ id: 'content-001', thumbnail: '/contents/content-001', position: 1 }],
+          contents: [{ id: 'content-001', thumbnail: '', position: 1 }],
         },
         currentPath: '/screen/detail',
         currentUserId: null,
@@ -106,18 +106,21 @@ describe('medium: ScreenViewerGetController', () => {
         currentUserId: null,
         content: {
           id: '/contents/page-2.jpg',
+          hasRenderableContent: true,
           type: 'image',
         },
         previousPage: {
           mediaId: 'media-001',
           mediaPage: 1,
           contentId: '/contents/page-1.jpg',
+          hasRenderableContent: true,
           href: '/screen/viewer/media-001/1',
         },
         nextPage: {
           mediaId: 'media-001',
           mediaPage: 3,
           contentId: '/contents/page-3.jpg',
+          hasRenderableContent: true,
           href: '/screen/viewer/media-001/3',
         },
       },
@@ -147,6 +150,7 @@ describe('medium: ScreenViewerGetController', () => {
         mediaPage: 10,
         content: {
           id: '/contents/page-10.mp4',
+          hasRenderableContent: true,
           type: 'video',
         },
         previousPage: null,

--- a/__tests__/small/controller/router/screen/setRouterScreenViewerGet.test.js
+++ b/__tests__/small/controller/router/screen/setRouterScreenViewerGet.test.js
@@ -55,7 +55,7 @@ describe('setRouterScreenViewerGet', () => {
     expect(res.render).toHaveBeenCalledWith('screen/viewer', expect.objectContaining({
       mediaId: 'media-1',
       mediaPage: 2,
-      content: { id: '/contents/page-2.jpg', type: 'image' },
+      content: expect.objectContaining({ id: '/contents/page-2.jpg', type: 'image' }),
       previousPage: expect.objectContaining({ href: '/screen/viewer/media-1/1' }),
       nextPage: expect.objectContaining({ href: '/screen/viewer/media-1/3' }),
     }));

--- a/__tests__/small/controller/screen/ScreenDetailGetController.test.js
+++ b/__tests__/small/controller/screen/ScreenDetailGetController.test.js
@@ -36,7 +36,7 @@ describe('ScreenDetailGetController', () => {
       pageTitle: '作品タイトル の詳細',
       mediaDetail: {
         ...mediaDetail,
-        contents: [{ id: 'content-1', thumbnail: '/contents/content-1', position: 1 }],
+        contents: [{ id: 'content-1', thumbnail: '', position: 1 }],
       },
       currentPath: '/screen/detail',
       currentUserId: 'admin',

--- a/__tests__/small/controller/screen/ScreenViewerGetController.test.js
+++ b/__tests__/small/controller/screen/ScreenViewerGetController.test.js
@@ -43,18 +43,21 @@ describe('ScreenViewerGetController', () => {
       currentUserId: 'admin',
       content: {
         id: '/contents/page-2.jpg',
+        hasRenderableContent: true,
         type: 'image',
       },
       previousPage: {
         mediaId: 'media-1',
         mediaPage: 1,
         contentId: '/contents/page-1.jpg',
+        hasRenderableContent: true,
         href: '/screen/viewer/media-1/1',
       },
       nextPage: {
         mediaId: 'media-1',
         mediaPage: 3,
         contentId: '/contents/page-3.jpg',
+        hasRenderableContent: true,
         href: '/screen/viewer/media-1/3',
       },
     });
@@ -76,6 +79,7 @@ describe('ScreenViewerGetController', () => {
     expect(res.render).toHaveBeenCalledWith('screen/viewer', expect.objectContaining({
       content: {
         id: '/contents/page-10.mp4',
+        hasRenderableContent: true,
         type: 'video',
       },
       previousPage: null,
@@ -100,6 +104,7 @@ describe('ScreenViewerGetController', () => {
     expect(res.render).toHaveBeenCalledWith('screen/viewer', expect.objectContaining({
       content: {
         id: '/contents/01/23/45/67/0123456789abcdef0123456789abcdef',
+        hasRenderableContent: true,
         type: 'video',
       },
     }));

--- a/__tests__/small/controller/screen/publicContentPath.test.js
+++ b/__tests__/small/controller/screen/publicContentPath.test.js
@@ -15,7 +15,18 @@ describe('toPublicContentPath', () => {
     expect(toPublicContentPath('/contents/a/b/c.jpg')).toBe('/contents/a/b/c.jpg');
   });
 
-  test('相対パスは /contents を先頭に付与する', () => {
-    expect(toPublicContentPath('seed/page-1.jpg')).toBe('/contents/seed/page-1.jpg');
+  test('http/https/protocol-relative URLは拒否する', () => {
+    expect(toPublicContentPath('http://example.com/a.jpg')).toBe('');
+    expect(toPublicContentPath('https://example.com/a.jpg')).toBe('');
+    expect(toPublicContentPath('//example.com/a.jpg')).toBe('');
+  });
+
+  test('data URLは拒否する', () => {
+    expect(toPublicContentPath('data:image/png;base64,AAAA')).toBe('');
+  });
+
+  test('/contents 以外の絶対パスと相対パスは拒否する', () => {
+    expect(toPublicContentPath('/tmp/a.jpg')).toBe('');
+    expect(toPublicContentPath('seed/page-1.jpg')).toBe('');
   });
 });

--- a/src/controller/screen/ScreenViewerGetController.js
+++ b/src/controller/screen/ScreenViewerGetController.js
@@ -37,6 +37,10 @@ class ScreenViewerGetController {
         throw new Error('unexpected result');
       }
 
+      const contentPath = toPublicContentPath(result.contentId);
+      const previousContentPath = result.previousContentId === null ? null : toPublicContentPath(result.previousContentId);
+      const nextContentPath = result.nextContentId === null ? null : toPublicContentPath(result.nextContentId);
+
       return res.status(200).render('screen/viewer', {
         pageTitle: `ビューアー ${req.params.mediaId} - ${mediaPage}ページ`,
         mediaId: req.params.mediaId,
@@ -44,19 +48,22 @@ class ScreenViewerGetController {
         currentPath: '/screen/viewer',
         currentUserId: req.context?.userId || null,
         content: {
-          id: toPublicContentPath(result.contentId),
+          id: contentPath,
+          hasRenderableContent: contentPath.length > 0,
           type: result.contentType ?? this.#detectContentType(result.contentId),
         },
         previousPage: result.previousContentId === null ? null : {
           mediaId: req.params.mediaId,
           mediaPage: mediaPage - 1,
-          contentId: toPublicContentPath(result.previousContentId),
+          contentId: previousContentPath,
+          hasRenderableContent: previousContentPath.length > 0,
           href: `/screen/viewer/${req.params.mediaId}/${mediaPage - 1}`,
         },
         nextPage: result.nextContentId === null ? null : {
           mediaId: req.params.mediaId,
           mediaPage: mediaPage + 1,
-          contentId: toPublicContentPath(result.nextContentId),
+          contentId: nextContentPath,
+          hasRenderableContent: nextContentPath.length > 0,
           href: `/screen/viewer/${req.params.mediaId}/${mediaPage + 1}`,
         },
       });

--- a/src/controller/screen/publicContentPath.js
+++ b/src/controller/screen/publicContentPath.js
@@ -18,8 +18,8 @@ const toPublicContentPath = contentId => {
     return '';
   }
 
-  if (/^(https?:)?\/\//.test(normalized) || normalized.startsWith('data:')) {
-    return normalized;
+  if (/^(https?:)?\/\//i.test(normalized) || /^data:/i.test(normalized)) {
+    return '';
   }
 
   if (normalized.startsWith('/contents/')) {
@@ -27,7 +27,7 @@ const toPublicContentPath = contentId => {
   }
 
   if (normalized.startsWith('/')) {
-    return normalized;
+    return '';
   }
 
   if ((/^[0-9a-f]{32}$/i).test(normalized)) {
@@ -35,13 +35,18 @@ const toPublicContentPath = contentId => {
     return `/contents/${buildShardedPath(canonicalContentId)}`;
   }
 
-  return `/contents/${normalized.replace(/^\/+/, '')}`;
+  return '';
 };
 
-const mapMediaOverviewThumbnailToPublicPath = mediaOverview => ({
-  ...mediaOverview,
-  thumbnail: toPublicContentPath(mediaOverview.thumbnail),
-});
+const mapMediaOverviewThumbnailToPublicPath = mediaOverview => {
+  const thumbnail = toPublicContentPath(mediaOverview.thumbnail);
+
+  return {
+    ...mediaOverview,
+    thumbnail,
+    hasThumbnail: thumbnail.length > 0,
+  };
+};
 
 module.exports = {
   toPublicContentPath,

--- a/src/views/screen/favorite.ejs
+++ b/src/views/screen/favorite.ejs
@@ -70,7 +70,7 @@
                 <article class="media-card" data-media-id="<%= media.mediaId %>" data-favorite-delete-path="/api/favorite/<%= media.mediaId %>" data-queue-put-path="/api/queue/<%= media.mediaId %>">
                   <div class="media-body">
                     <a class="thumbnail" href="/screen/detail/<%= media.mediaId %>">
-                      <% if (media.thumbnail) { %>
+                      <% if (media.hasThumbnail) { %>
                         <img src="<%= media.thumbnail %>" alt="<%= media.title %> のサムネイル" />
                       <% } else { %>
                         <span>NO IMAGE</span>

--- a/src/views/screen/queue.ejs
+++ b/src/views/screen/queue.ejs
@@ -65,7 +65,7 @@
                 <article class="media-card" data-media-id="<%= media.mediaId %>" data-favorite-put-path="/api/favorite/<%= media.mediaId %>" data-favorite-delete-path="/api/favorite/<%= media.mediaId %>" data-queue-put-path="/api/queue/<%= media.mediaId %>" data-queue-delete-path="/api/queue/<%= media.mediaId %>" data-is-favorite="<%= media.isFavorite %>" data-is-queued="<%= media.isQueued %>">
                   <div class="media-body">
                     <a class="thumbnail" href="/screen/detail/<%= media.mediaId %>">
-                      <% if (media.thumbnail) { %>
+                      <% if (media.hasThumbnail) { %>
                         <img src="<%= media.thumbnail %>" alt="<%= media.title %> のサムネイル" />
                       <% } else { %>
                         <span>NO IMAGE</span>

--- a/src/views/screen/summary.ejs
+++ b/src/views/screen/summary.ejs
@@ -103,7 +103,7 @@
                 <article class="media-card">
                   <div class="media-body">
                     <a class="thumbnail" href="/screen/detail/<%= media.mediaId %>">
-                      <% if (media.thumbnail) { %>
+                      <% if (media.hasThumbnail) { %>
                         <img src="<%= media.thumbnail %>" alt="<%= media.title %> のサムネイル" />
                       <% } else { %>
                         <span>NO IMAGE</span>

--- a/src/views/screen/viewer.ejs
+++ b/src/views/screen/viewer.ejs
@@ -30,6 +30,7 @@
         border-radius: 18px; padding: 16px; overflow: hidden;
       }
       .stage img, .stage video { width: 100%; max-height: calc(100vh - 220px); object-fit: contain; border-radius: 12px; background: #000; }
+      .stage-placeholder { text-align: center; color: #cbd5e1; }
       .footer-nav { display:flex; justify-content:space-between; gap:12px; flex-wrap:wrap; }
       .footer-nav a, .footer-nav span {
         display:inline-flex; align-items:center; justify-content:center; min-width: 128px; min-height: 44px; padding: 10px 16px;
@@ -61,7 +62,9 @@
         </header>
 
         <article class="stage">
-          <% if (content.type === 'video') { %>
+          <% if (!content.hasRenderableContent) { %>
+            <div class="stage-placeholder">表示可能なコンテンツがありません。</div>
+          <% } else if (content.type === 'video') { %>
             <video src="<%= content.id %>" controls playsinline>
               動画を再生できません。
             </video>


### PR DESCRIPTION
### Motivation
- 外部ホストやdata URLをそのまま描画可能な公開パスとして許容すると、アプリ管理外リソース参照や意図しない描画リスクがあるため許可境界を厳密化するため。 
- 公開パスを拒否した際にUIが壊れないよう、ビューアーと一覧でフォールバック表示を入れてユーザ体験の退行を防ぐため。 

### Description
- `toPublicContentPath` を修正し、`http://`/`https://`/`//`/`data:` を拒否して空文字を返すよう変更し、許可形式を `32hex`（シャーディング変換）と `/contents/...` のみに限定した。 
- `/...` などのその他の絶対パスや相対パスは許可せず空文字を返す実装に統一した。 
- `mapMediaOverviewThumbnailToPublicPath` を更新して `thumbnail` に加え `hasThumbnail` を返すようにし、一覧テンプレートで `hasThumbnail` に基づくフォールバック表示を行うようにした。 
- `ScreenViewerGetController` 側で `toPublicContentPath` を先に解決して `content.hasRenderableContent` としてテンプレートへ渡し、描画不可時に `viewer.ejs` で「表示可能なコンテンツがありません。」を表示するフォールバックを追加した。 
- 関連の小テスト `__tests__/small/controller/screen/publicContentPath.test.js` とコントローラ側の期待値を更新して、外部URLや `data:` の拒否と `/contents` / `32hex` の挙動を検証するようにした。 

### Testing
- `npm run test:small` を実行しようとしたが `cross-env: not found` により小テストスイートはこの環境では実行できず失敗した。 
- `npm install` は環境上の `node_modules` 競合（`ENOTEMPTY` 等）により継続実行が困難であり完全な自動テスト実行ができなかった。 
- 代替として `node` を使い `toPublicContentPath` の主要ケース（`http://`, `https://`, `//`, `data:`, `/contents/...`, `32hex`, その他パス）を手動実行で確認し期待通りの出力を確認した。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5222d5f54832bad03bd77e918d138)