### PR TITLE
feat: ミドルウェア共通層でCSP nonce対応のセキュリティヘッダーを適用する

### DIFF
--- a/__tests__/small/app/setupMiddleware.test.js
+++ b/__tests__/small/app/setupMiddleware.test.js
@@ -172,4 +172,47 @@ describe('setupMiddleware (small)', () => {
 
     expect(app.locals.env).toBe(env);
   });
+
+  test('全レスポンス共通のセキュリティヘッダーと nonce を設定する', () => {
+    const { middleware } = createHarness({
+      env: {
+        devSessionToken: 'dev-token',
+        devSessionPaths: ['/screen/entry'],
+      },
+    });
+    const req = createReq({ headers: {}, path: '/screen/entry' });
+    const res = createRes();
+
+    middleware(req, res, jest.fn());
+
+    expect(typeof res.locals.cspNonce).toBe('string');
+    expect(res.locals.cspNonce.length).toBeGreaterThan(0);
+    expect(req.context.cspNonce).toBe(res.locals.cspNonce);
+    expect(res.setHeader).toHaveBeenCalledWith(
+      'Content-Security-Policy',
+      expect.stringContaining(`script-src 'self' 'nonce-${res.locals.cspNonce}'`),
+    );
+    expect(res.setHeader).toHaveBeenCalledWith('X-Content-Type-Options', 'nosniff');
+    expect(res.setHeader).toHaveBeenCalledWith('Referrer-Policy', 'strict-origin-when-cross-origin');
+    expect(res.setHeader).toHaveBeenCalledWith('X-Frame-Options', 'DENY');
+  });
+
+  test('Strict-Transport-Security は本番環境のみ設定する', () => {
+    const productionHarness = createHarness({ env: { nodeEnv: 'production' } });
+    const developmentHarness = createHarness({ env: { nodeEnv: 'development' } });
+    const productionRes = createRes();
+    const developmentRes = createRes();
+
+    productionHarness.middleware(createReq({ path: '/screen/login' }), productionRes, jest.fn());
+    developmentHarness.middleware(createReq({ path: '/screen/login' }), developmentRes, jest.fn());
+
+    expect(productionRes.setHeader).toHaveBeenCalledWith(
+      'Strict-Transport-Security',
+      'max-age=31536000; includeSubDomains',
+    );
+    expect(developmentRes.setHeader).not.toHaveBeenCalledWith(
+      'Strict-Transport-Security',
+      expect.anything(),
+    );
+  });
 });

--- a/__tests__/small/views/screen/edit.test.js
+++ b/__tests__/small/views/screen/edit.test.js
@@ -55,7 +55,7 @@ class ElementStub {
 }
 
 const extractInlineScript = html => {
-  const matches = [...html.matchAll(/<script>\s*([\s\S]*?)\s*<\/script>/g)];
+  const matches = [...html.matchAll(/<script(?:\s[^>]*)?>\s*([\s\S]*?)\s*<\/script>/g)];
   if (matches.length === 0) {
     throw new Error('inline script not found');
   }

--- a/__tests__/small/views/screen/xssRendering.test.js
+++ b/__tests__/small/views/screen/xssRendering.test.js
@@ -52,7 +52,7 @@ class ElementStub {
 }
 
 const extractInlineScript = html => {
-  const matches = [...html.matchAll(/<script>\s*([\s\S]*?)\s*<\/script>/g)];
+  const matches = [...html.matchAll(/<script(?:\s[^>]*)?>\s*([\s\S]*?)\s*<\/script>/g)];
   if (matches.length === 0) {
     throw new Error('inline script not found');
   }

--- a/src/app/setupMiddleware.js
+++ b/src/app/setupMiddleware.js
@@ -57,6 +57,39 @@ const resolveCsrfCookiePolicy = env => {
   };
 };
 
+const isProductionEnvironment = env => {
+  const nodeEnv = String(env.nodeEnv || process.env.NODE_ENV || '').toLowerCase();
+  return nodeEnv === 'production';
+};
+
+const createContentSecurityPolicy = ({ nonce }) => {
+  const directives = [
+    "default-src 'self'",
+    `script-src 'self' 'nonce-${nonce}'`,
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data:",
+    "font-src 'self'",
+    "connect-src 'self'",
+    "frame-ancestors 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "object-src 'none'",
+  ];
+
+  return directives.join('; ');
+};
+
+const applySecurityHeaders = ({ res, isProduction, cspValue }) => {
+  res.setHeader('Content-Security-Policy', cspValue);
+  res.setHeader('X-Content-Type-Options', 'nosniff');
+  res.setHeader('Referrer-Policy', 'strict-origin-when-cross-origin');
+  res.setHeader('X-Frame-Options', 'DENY');
+
+  if (isProduction) {
+    res.setHeader('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
+  }
+};
+
 const setupMiddleware = (app, { env = {}, dependencies: _dependencies } = {}) => {
   app.locals = app.locals ?? {};
   if (typeof app.locals.env === 'undefined') {
@@ -74,6 +107,19 @@ const setupMiddleware = (app, { env = {}, dependencies: _dependencies } = {}) =>
   app.use((req, res, next) => {
     req.context = req.context ?? {};
     attachSessionHelpers(req);
+
+    const securityNonce = crypto.randomBytes(16).toString('base64');
+    req.context.cspNonce = securityNonce;
+
+    res.locals = res.locals ?? {};
+    res.locals.cspNonce = securityNonce;
+
+    const cspValue = createContentSecurityPolicy({ nonce: securityNonce });
+    applySecurityHeaders({
+      res,
+      isProduction: isProductionEnvironment(env),
+      cspValue,
+    });
 
     const cookies = parseCookieHeader(req.header('cookie'));
     const legacySessionToken = req.header('x-session-token');
@@ -97,7 +143,6 @@ const setupMiddleware = (app, { env = {}, dependencies: _dependencies } = {}) =>
       });
     }
 
-    res.locals = res.locals ?? {};
     res.locals.csrfToken = req.session.csrf_token;
 
     const logger = req.app?.locals?.dependencies?.logger;

--- a/src/views/partials/topNavigator.ejs
+++ b/src/views/partials/topNavigator.ejs
@@ -71,10 +71,10 @@
     <button id="common-nav-logout" class="common-nav__logout" type="button">ログアウト</button>
   </div>
 </nav>
-<script nonce="<%= cspNonce %>">
+<script nonce="<%= typeof cspNonce === 'string' ? cspNonce : '' %>">
   window.__csrfToken = <%- JSON.stringify(typeof csrfToken === 'string' ? csrfToken : '') %>;
 </script>
-<script nonce="<%= cspNonce %>">
+<script nonce="<%= typeof cspNonce === 'string' ? cspNonce : '' %>">
   (() => {
     const logoutButton = document.getElementById('common-nav-logout');
     if (!logoutButton) return;

--- a/src/views/partials/topNavigator.ejs
+++ b/src/views/partials/topNavigator.ejs
@@ -71,10 +71,10 @@
     <button id="common-nav-logout" class="common-nav__logout" type="button">ログアウト</button>
   </div>
 </nav>
-<script>
+<script nonce="<%= cspNonce %>">
   window.__csrfToken = <%- JSON.stringify(typeof csrfToken === 'string' ? csrfToken : '') %>;
 </script>
-<script>
+<script nonce="<%= cspNonce %>">
   (() => {
     const logoutButton = document.getElementById('common-nav-logout');
     if (!logoutButton) return;

--- a/src/views/screen/detail.ejs
+++ b/src/views/screen/detail.ejs
@@ -151,7 +151,7 @@
       </div>
     </main>
 
-    <script>
+    <script nonce="<%= cspNonce %>">
       (() => {
         const mediaId = <%- JSON.stringify(mediaDetail.id) %>;
         const status = document.getElementById('request-status');

--- a/src/views/screen/detail.ejs
+++ b/src/views/screen/detail.ejs
@@ -151,7 +151,7 @@
       </div>
     </main>
 
-    <script nonce="<%= cspNonce %>">
+    <script nonce="<%= typeof cspNonce === 'string' ? cspNonce : '' %>">
       (() => {
         const mediaId = <%- JSON.stringify(mediaDetail.id) %>;
         const status = document.getElementById('request-status');

--- a/src/views/screen/edit.ejs
+++ b/src/views/screen/edit.ejs
@@ -121,7 +121,7 @@
       </div>
     </div>
 
-    <script>
+    <script nonce="<%= cspNonce %>">
       (() => {
         const mediaId = <%- JSON.stringify(mediaDetail.id) %>;
         const tagsByCategory = <%- JSON.stringify(tagsByCategory) %>;

--- a/src/views/screen/edit.ejs
+++ b/src/views/screen/edit.ejs
@@ -121,7 +121,7 @@
       </div>
     </div>
 
-    <script nonce="<%= cspNonce %>">
+    <script nonce="<%= typeof cspNonce === 'string' ? cspNonce : '' %>">
       (() => {
         const mediaId = <%- JSON.stringify(mediaDetail.id) %>;
         const tagsByCategory = <%- JSON.stringify(tagsByCategory) %>;

--- a/src/views/screen/entry.ejs
+++ b/src/views/screen/entry.ejs
@@ -124,7 +124,7 @@
       </div>
     </div>
 
-    <script>
+    <script nonce="<%= cspNonce %>">
       (() => {
         const tagsByCategory = <%- JSON.stringify(tagsByCategory) %>;
         const tagList = document.getElementById('tag-list');

--- a/src/views/screen/entry.ejs
+++ b/src/views/screen/entry.ejs
@@ -124,7 +124,7 @@
       </div>
     </div>
 
-    <script nonce="<%= cspNonce %>">
+    <script nonce="<%= typeof cspNonce === 'string' ? cspNonce : '' %>">
       (() => {
         const tagsByCategory = <%- JSON.stringify(tagsByCategory) %>;
         const tagList = document.getElementById('tag-list');

--- a/src/views/screen/favorite.ejs
+++ b/src/views/screen/favorite.ejs
@@ -52,7 +52,7 @@
             <form class="sort-form" method="get" action="/screen/favorite">
               <input type="hidden" name="page" value="1" />
               <label for="sort">並び順</label>
-              <select id="sort" name="sort" class="select-input" onchange="this.form.submit()">
+              <select id="sort" name="sort" class="select-input">
                 <% sortOptions.forEach((option) => { %>
                   <option value="<%= option.value %>" <%= currentConditions.sort === option.value ? 'selected' : '' %>><%= option.label %></option>
                 <% }) %>
@@ -114,8 +114,13 @@
       </div>
     </div>
 
-    <script>
+    <script nonce="<%= cspNonce %>">
       (() => {
+        const sortSelect = document.getElementById('sort');
+        if (sortSelect?.form) {
+          sortSelect.addEventListener('change', () => sortSelect.form.submit());
+        }
+
         const request = async ({ path, method, successMessage, statusElement, onSuccess }) => {
           statusElement.textContent = '通信中です...';
           try {

--- a/src/views/screen/favorite.ejs
+++ b/src/views/screen/favorite.ejs
@@ -114,7 +114,7 @@
       </div>
     </div>
 
-    <script nonce="<%= cspNonce %>">
+    <script nonce="<%= typeof cspNonce === 'string' ? cspNonce : '' %>">
       (() => {
         const sortSelect = document.getElementById('sort');
         if (sortSelect?.form) {

--- a/src/views/screen/login.ejs
+++ b/src/views/screen/login.ejs
@@ -102,7 +102,7 @@
         </noscript>
       </div>
     </div>
-    <script nonce="<%= cspNonce %>">
+    <script nonce="<%= typeof cspNonce === 'string' ? cspNonce : '' %>">
       (() => {
         const form = document.getElementById("loginForm");
         const message = document.getElementById("loginMessage");

--- a/src/views/screen/login.ejs
+++ b/src/views/screen/login.ejs
@@ -102,7 +102,7 @@
         </noscript>
       </div>
     </div>
-    <script>
+    <script nonce="<%= cspNonce %>">
       (() => {
         const form = document.getElementById("loginForm");
         const message = document.getElementById("loginMessage");

--- a/src/views/screen/queue.ejs
+++ b/src/views/screen/queue.ejs
@@ -111,7 +111,7 @@
       </div>
     </div>
 
-    <script nonce="<%= cspNonce %>">
+    <script nonce="<%= typeof cspNonce === 'string' ? cspNonce : '' %>">
       (() => {
         const sortSelect = document.getElementById('sort');
         if (sortSelect?.form) {

--- a/src/views/screen/queue.ejs
+++ b/src/views/screen/queue.ejs
@@ -48,7 +48,7 @@
             <form class="sort-form" method="get" action="/screen/queue">
               <input type="hidden" name="queuePage" value="1" />
               <label for="sort">並び順</label>
-              <select id="sort" name="sort" class="select-input" onchange="this.form.submit()">
+              <select id="sort" name="sort" class="select-input">
                 <% sortOptions.forEach((option) => { %>
                   <option value="<%= option.value %>" <%= currentConditions.sort === option.value ? 'selected' : '' %>><%= option.label %></option>
                 <% }) %>
@@ -111,8 +111,13 @@
       </div>
     </div>
 
-    <script>
+    <script nonce="<%= cspNonce %>">
       (() => {
+        const sortSelect = document.getElementById('sort');
+        if (sortSelect?.form) {
+          sortSelect.addEventListener('change', () => sortSelect.form.submit());
+        }
+
         const request = async ({ path, method, successMessage, failureMessage, statusElement }) => {
           statusElement.textContent = '通信中です...';
           try {

--- a/src/views/screen/search.ejs
+++ b/src/views/screen/search.ejs
@@ -126,7 +126,7 @@
       </div>
     </div>
 
-    <script nonce="<%= cspNonce %>">
+    <script nonce="<%= typeof cspNonce === 'string' ? cspNonce : '' %>">
       (() => {
         const tagsByCategory = <%- JSON.stringify(tagsByCategory) %>;
         const form = document.getElementById('search-form');

--- a/src/views/screen/search.ejs
+++ b/src/views/screen/search.ejs
@@ -126,7 +126,7 @@
       </div>
     </div>
 
-    <script>
+    <script nonce="<%= cspNonce %>">
       (() => {
         const tagsByCategory = <%- JSON.stringify(tagsByCategory) %>;
         const form = document.getElementById('search-form');

--- a/src/views/screen/summary.ejs
+++ b/src/views/screen/summary.ejs
@@ -155,7 +155,7 @@
         </nav>
       </div>
     </div>
-    <script nonce="<%= cspNonce %>">
+    <script nonce="<%= typeof cspNonce === 'string' ? cspNonce : '' %>">
       (() => {
         const sortSelect = document.getElementById('sort');
         if (sortSelect?.form) {

--- a/src/views/screen/summary.ejs
+++ b/src/views/screen/summary.ejs
@@ -86,7 +86,7 @@
                 <input type="hidden" name="tags" value="<%= `${tag.category}:${tag.label}` %>" />
               <% }) %>
               <label for="sort">並び順</label>
-              <select id="sort" name="sort" class="select-input" onchange="this.form.submit()">
+              <select id="sort" name="sort" class="select-input">
                 <% sortOptions.forEach((option) => { %>
                   <option value="<%= option.value %>" <%= currentConditions.sort === option.value ? 'selected' : '' %>><%= option.label %></option>
                 <% }) %>
@@ -155,5 +155,13 @@
         </nav>
       </div>
     </div>
+    <script nonce="<%= cspNonce %>">
+      (() => {
+        const sortSelect = document.getElementById('sort');
+        if (sortSelect?.form) {
+          sortSelect.addEventListener('change', () => sortSelect.form.submit());
+        }
+      })();
+    </script>
   </body>
 </html>


### PR DESCRIPTION
### Motivation
- 全ての画面/API応答で一貫したセキュリティヘッダーを付与することで、ルート追加や環境差分による保護漏れを防止するため。 
- 既存の多くのインラインスクリプトを維持しつつ `unsafe-inline` への依存を排し、CSP の効果を高めて XSS リスクを低減するため。 
- 本番環境では HSTS を有効化し、開発環境では HTTPS 非必須の互換性を保つため。 

### Description
- 共通ミドルウェア (`src/app/setupMiddleware.js`) に CSP nonce 生成を追加し、全レスポンスで以下のヘッダーを設定するように実装した（nonce は `req.context.cspNonce` / `res.locals.cspNonce` に公開）。
  - `Content-Security-Policy`（nonce方式で `script-src 'self' 'nonce-<nonce>'` を指定）
  - `X-Content-Type-Options: nosniff`
  - `Referrer-Policy: strict-origin-when-cross-origin`
  - `X-Frame-Options: DENY`（CSP の `frame-ancestors` も併記）
  - 本番環境のみ `Strict-Transport-Security: max-age=31536000; includeSubDomains`
- 既存のビュー（`src/views/.../*.ejs`）のインラインスクリプトに `nonce="<%= cspNonce %>"` を付与して CSP から除外するように変更した。
- インラインの `onchange="this.form.submit()"` を廃止し、`addEventListener` に置き換えて CSP に適合するように修正した（`summary`/`favorite`/`queue` 等）。
- 小テストを追加して nonce 生成・ヘッダー付与・HSTS の環境分岐を検証するケースを追加した（`__tests__/small/app/setupMiddleware.test.js` にテスト追加）。

### Testing
- 変更に対する小テストを追加した: `__tests__/small/app/setupMiddleware.test.js`（nonce の生成、`Content-Security-Policy` / `X-Content-Type-Options` / `Referrer-Policy` / `X-Frame-Options` の付与、HSTS の本番/開発分岐を検証）。
- CI / ローカルで `npm run test:small` を実行しようとしたが、実行環境に `cross-env` コマンドが見つからないため実行できなかった（環境側の依存実行バイナリが未配置のため）。
- `npm ci` / `npm install` を試行したが環境の制約や警告があり、テストスイートを正常に完走させられなかったため、テストは現在成功/失敗のどちらかを断定できない状態である。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d659df44c4832bbfd6bc24f17ca8bb)