### PR TITLE
fix: 本番環境で開発用固定セッションを無効化し監査ログと起動ガードを追加

### DIFF
--- a/__tests__/medium/app/developmentSession.integration.test.js
+++ b/__tests__/medium/app/developmentSession.integration.test.js
@@ -80,6 +80,33 @@ describe('developmentSession wiring', () => {
     });
   });
 
+  test('setupMiddleware は production 環境では固定セッション設定が揃っていても req.session.session_token を補完しない', async () => {
+    const app = express();
+    setupMiddleware(app, {
+      env: {
+        nodeEnv: 'production',
+        devSessionToken: 'dev-token',
+        devSessionUserId: 'admin-dev',
+        devSessionTtlMs: 60_000,
+        devSessionPaths: ['/screen/entry'],
+      },
+      dependencies: {},
+    });
+
+    app.get('/screen/entry', (req, res) => {
+      res.status(200).json({
+        sessionToken: req.session.session_token ?? null,
+      });
+    });
+
+    const response = await request(app).get('/screen/entry');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      sessionToken: null,
+    });
+  });
+
   test('server.js 相当の初期化では固定セッション設定が無効な場合に有効化ログを出力しない', async () => {
     const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
@@ -222,6 +249,48 @@ describe('developmentSession wiring', () => {
     expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining('サーバーを起動しました'));
     expect(errorSpy).toHaveBeenCalledWith(
       expect.stringContaining('サーバーの起動を中止しました: 本番環境で insecure login(ALLOW_INSECURE_DEFAULT_LOGIN=true) は禁止されています'),
+      expect.any(Error),
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  test('server.js 相当の初期化では production かつ DEV_SESSION_* 指定時に起動を中止する', async () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {});
+    const listenMock = jest.fn((port, callback) => {
+      callback();
+      return { on: jest.fn() };
+    });
+
+    process.env.NODE_ENV = 'production';
+    process.env.PORT = '3460';
+    process.env.FIXED_LOGIN_USERNAME = 'admin-user';
+    process.env.FIXED_LOGIN_PASSWORD = 'admin-password';
+    process.env.FIXED_LOGIN_USER_ID = 'admin-user-id';
+    process.env.LOGIN_USERNAME = 'admin-user';
+    process.env.LOGIN_PASSWORD = 'admin-password';
+    process.env.LOGIN_USER_ID = 'admin-user-id';
+    process.env.ALLOW_INSECURE_DEFAULT_LOGIN = '';
+    process.env.DEV_SESSION_TOKEN = 'dev-token';
+    process.env.DEV_SESSION_USER_ID = '';
+    process.env.DEV_SESSION_TTL_MS = '';
+    process.env.DEV_SESSION_PATHS = '';
+
+    jest.doMock('../../../src/app', () => jest.fn(() => ({
+      locals: {
+        ready: Promise.resolve(),
+      },
+      listen: listenMock,
+    })));
+
+    require('../../../src/server');
+    await Promise.resolve();
+
+    expect(listenMock).not.toHaveBeenCalled();
+    expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining('サーバーを起動しました'));
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('サーバーの起動を中止しました: 本番環境で DEV_SESSION_* の設定は禁止されています'),
       expect.any(Error),
     );
     expect(exitSpy).toHaveBeenCalledWith(1);

--- a/__tests__/small/app/developmentSession.test.js
+++ b/__tests__/small/app/developmentSession.test.js
@@ -61,4 +61,17 @@ describe('developmentSession', () => {
 
     expect(shouldApplyDevelopmentSession({ env, requestPath: '/screen/entry' })).toBe(false);
   });
+
+  test('production 環境では固定セッション設定が揃っていても補完対象にしない', () => {
+    const env = {
+      nodeEnv: 'production',
+      devSessionToken: 'dev-token',
+      devSessionUserId: 'admin-dev',
+      devSessionTtlMs: 60_000,
+      devSessionPaths: ['/screen/entry'],
+    };
+
+    expect(hasDevelopmentSession(env)).toBe(false);
+    expect(shouldApplyDevelopmentSession({ env, requestPath: '/screen/entry' })).toBe(false);
+  });
 });

--- a/src/app/developmentSession.js
+++ b/src/app/developmentSession.js
@@ -1,22 +1,51 @@
 const isNonEmptyString = value => typeof value === 'string' && value.length > 0;
 
-const hasDevelopmentSession = (env = {}) => (
+const resolveNodeEnv = (env = {}) => String(env.nodeEnv || process.env.NODE_ENV || '').toLowerCase();
+
+const isDevelopmentSessionEnvironment = (env = {}) => {
+  const nodeEnv = resolveNodeEnv(env);
+  return nodeEnv === 'development' || nodeEnv === 'test';
+};
+
+const hasDevelopmentSessionConfiguration = (env = {}) => (
   isNonEmptyString(env.devSessionToken)
   && isNonEmptyString(env.devSessionUserId)
   && Number.isInteger(env.devSessionTtlMs)
   && env.devSessionTtlMs > 0
 );
 
-const shouldApplyDevelopmentSession = ({ env = {}, requestPath = '' } = {}) => {
-  if (!hasDevelopmentSession(env)) {
-    return false;
+const hasDevelopmentSession = (env = {}) => (
+  isDevelopmentSessionEnvironment(env)
+  && hasDevelopmentSessionConfiguration(env)
+);
+
+const resolveDevelopmentSessionApplication = ({ env = {}, requestPath = '' } = {}) => {
+  if (!isDevelopmentSessionEnvironment(env)) {
+    return { enabled: false, reason: 'environment_not_allowed' };
   }
 
-  return Array.isArray(env.devSessionPaths)
-    && env.devSessionPaths.includes(requestPath);
+  if (!hasDevelopmentSessionConfiguration(env)) {
+    return { enabled: false, reason: 'configuration_incomplete' };
+  }
+
+  if (!Array.isArray(env.devSessionPaths)) {
+    return { enabled: false, reason: 'paths_not_configured' };
+  }
+
+  if (!env.devSessionPaths.includes(requestPath)) {
+    return { enabled: false, reason: 'path_not_targeted' };
+  }
+
+  return { enabled: true, reason: 'enabled' };
+};
+
+const shouldApplyDevelopmentSession = ({ env = {}, requestPath = '' } = {}) => {
+  const decision = resolveDevelopmentSessionApplication({ env, requestPath });
+  return decision.enabled;
 };
 
 module.exports = {
   hasDevelopmentSession,
+  resolveDevelopmentSessionApplication,
   shouldApplyDevelopmentSession,
 };

--- a/src/app/setupMiddleware.js
+++ b/src/app/setupMiddleware.js
@@ -2,7 +2,10 @@ const path = require('path');
 const crypto = require('crypto');
 const express = require('express');
 
-const { shouldApplyDevelopmentSession } = require('./developmentSession');
+const {
+  shouldApplyDevelopmentSession,
+  resolveDevelopmentSessionApplication,
+} = require('./developmentSession');
 
 const parseCookieHeader = cookieHeader => {
   if (typeof cookieHeader !== 'string' || cookieHeader.length === 0) {
@@ -124,10 +127,31 @@ const setupMiddleware = (app, { env = {}, dependencies: _dependencies } = {}) =>
     const cookies = parseCookieHeader(req.header('cookie'));
     const legacySessionToken = req.header('x-session-token');
 
+    const logger = req.app?.locals?.dependencies?.logger;
+
     if (typeof cookies.session_token === 'string' && cookies.session_token.length > 0) {
       req.session.session_token = cookies.session_token;
-    } else if (shouldApplyDevelopmentSession({ env, requestPath: req.path })) {
-      req.session.session_token = env.devSessionToken;
+    } else {
+      const developmentSessionDecision = resolveDevelopmentSessionApplication({
+        env,
+        requestPath: req.path,
+      });
+      logger?.info('auth.development_session.audit.before_apply', {
+        enabled: developmentSessionDecision.enabled,
+        reason: developmentSessionDecision.reason,
+        path: req.path,
+      });
+
+      if (shouldApplyDevelopmentSession({ env, requestPath: req.path })) {
+        req.session.session_token = env.devSessionToken;
+      }
+
+      logger?.info('auth.development_session.audit.after_apply', {
+        enabled: typeof req.session.session_token === 'string'
+          && req.session.session_token === env.devSessionToken,
+        reason: developmentSessionDecision.reason,
+        path: req.path,
+      });
     }
 
     if (typeof cookies.csrf_token === 'string' && cookies.csrf_token.length > 0) {
@@ -144,8 +168,6 @@ const setupMiddleware = (app, { env = {}, dependencies: _dependencies } = {}) =>
     }
 
     res.locals.csrfToken = req.session.csrf_token;
-
-    const logger = req.app?.locals?.dependencies?.logger;
 
     if (typeof legacySessionToken === 'string' && legacySessionToken.length > 0) {
       logger?.warn('auth.legacy_session_token_header.detected', {

--- a/src/server.js
+++ b/src/server.js
@@ -4,7 +4,6 @@ const createApp = require('./app');
 const { resolveLoginAuthConfig } = require('./app/createDependencies');
 const { hasDevelopmentSession } = require('./app/developmentSession');
 
-
 const parsePositiveInt = (value, fallback) => {
   const parsed = Number.parseInt(value, 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
@@ -14,6 +13,30 @@ const parseSessionPaths = value => (value || '')
   .split(',')
   .map(entry => entry.trim())
   .filter(entry => entry.length > 0);
+
+const isConfigured = value => String(value || '').trim().length > 0;
+
+const assertDevelopmentSessionConfigurationAllowed = (env, source = {}) => {
+  const isProduction = String(env.nodeEnv || '').toLowerCase() === 'production';
+  if (!isProduction) {
+    return;
+  }
+
+  const hasConfiguredDevSession = [
+    source.DEV_SESSION_TOKEN,
+    source.DEV_SESSION_USER_ID,
+    source.DEV_SESSION_TTL_MS,
+    source.DEV_SESSION_PATHS,
+  ].some(isConfigured);
+
+  if (!hasConfiguredDevSession) {
+    return;
+  }
+
+  const error = new Error('本番環境では DEV_SESSION_* の設定を許可できません');
+  error.code = 'DEV_SESSION_DISALLOWED_IN_PRODUCTION';
+  throw error;
+};
 
 const createEnv = source => ({
   nodeEnv: source.NODE_ENV || 'development',
@@ -59,8 +82,14 @@ const createEnv = source => ({
 const startServer = async () => {
   const env = createEnv(process.env);
   try {
+    assertDevelopmentSessionConfigurationAllowed(env, process.env);
     resolveLoginAuthConfig(env);
   } catch (error) {
+    if (error?.code === 'DEV_SESSION_DISALLOWED_IN_PRODUCTION') {
+      console.error('サーバーの起動を中止しました: 本番環境で DEV_SESSION_* の設定は禁止されています', error);
+      process.exit(1);
+      return;
+    }
     if (error?.code === 'INSECURE_DEFAULT_LOGIN_DISALLOWED_IN_PRODUCTION') {
       console.error('サーバーの起動を中止しました: 本番環境で insecure login(ALLOW_INSECURE_DEFAULT_LOGIN=true) は禁止されています', error);
       process.exit(1);
@@ -102,6 +131,7 @@ const startServer = async () => {
 startServer();
 
 module.exports = {
+  assertDevelopmentSessionConfigurationAllowed,
   createEnv,
   startServer,
 };


### PR DESCRIPTION
### Motivation
- 開発用の固定セッションが本番で有効化されると認証バイパスに繋がるため、本番環境では常に無効化する防御を導入する目的です。 
- 誤設定を早期に検知するために起動時ガードとリクエスト単位での監査ログを追加します。 
- 将来の回帰を防ぐためにユニット / 統合テストに「production では無効」ケースを追加します。 

### Description
- `src/app/developmentSession.js` に環境判定を導入し、`development` / `test` 以外（例: `production`）では固定セッションを無効化するロジックを追加し、`resolveDevelopmentSessionApplication` を導入して適用可否と理由を返すようにしました。 
- `src/app/setupMiddleware.js` の固定セッション適用処理前後で `auth.development_session.audit.before_apply` / `auth.development_session.audit.after_apply` の監査ログを出力するようにしました（`resolveDevelopmentSessionApplication` を使用）。 
- `src/server.js` に `assertDevelopmentSessionConfigurationAllowed` を追加し、本番環境で `DEV_SESSION_*` 系の環境変数がセットされている場合は起動を中止して明示的なエラーを出すガードを実装しました。 
- テストを追加・更新して `__tests__/small/app/developmentSession.test.js` と `__tests__/medium/app/developmentSession.integration.test.js` に production 無効ケースを追加しました。 

### Testing
- 構文チェックとして `node --check` を用いて `src/app/developmentSession.js`、`src/app/setupMiddleware.js`、`src/server.js`、および変更したテストファイルの構文を検証し成功しました。 
- 自動化テスト実行として `npm run test:small` を試行しましたが、環境に `cross-env` が未導入で実行できなかったため、テストスイートは実行できませんでした。 
- 開発依存のインストール (`npm install --include=dev`) を試みましたが環境上の問題により完了できなかったため、今回は構文チェックのみを実施しています。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d691543744832bb011c3449fd22d32)