### PR TITLE
fix: ログイン試行のIP/Account二層レート制限を実装する

### DIFF
--- a/__tests__/medium/controller/router/user/setRouterApiLogin.test.js
+++ b/__tests__/medium/controller/router/user/setRouterApiLogin.test.js
@@ -98,6 +98,29 @@ describe('setRouterApiLogin (middle)', () => {
     expect(third.body).toEqual({ code: 1 });
   });
 
+
+  test('usernameを回転しても同一IPからの連続試行は制限される', async () => {
+    const app = createApp({ maxAttemptsPerWindow: 2, windowMs: 60_000 });
+
+    const first = await request(app)
+      .post('/api/login')
+      .type('form')
+      .send({ username: 'admin', password: 'wrong' });
+    const second = await request(app)
+      .post('/api/login')
+      .type('form')
+      .send({ username: 'guest', password: 'wrong' });
+    const third = await request(app)
+      .post('/api/login')
+      .type('form')
+      .send({ username: 'root', password: 'wrong' });
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(third.status).toBe(429);
+    expect(third.body).toEqual({ code: 1 });
+  });
+
   test('ロック期間経過後は再試行可能', async () => {
     const app = createApp({ maxAttemptsPerWindow: 100, windowMs: 60_000 });
 

--- a/__tests__/small/controller/api/LoginPostController.test.js
+++ b/__tests__/small/controller/api/LoginPostController.test.js
@@ -64,7 +64,8 @@ describe('LoginPostController', () => {
       session,
     });
     expect(loginAttemptStore.clearAuthenticationFailures).toHaveBeenCalledWith({ key: 'admin' });
-    expect(loginAttemptStore.clearRateLimit).toHaveBeenCalledWith({ scope: 'ip', key: 'ip:unknown|user:admin' });
+    expect(loginAttemptStore.clearRateLimit).toHaveBeenNthCalledWith(1, { scope: 'ip', key: 'unknown' });
+    expect(loginAttemptStore.clearRateLimit).toHaveBeenNthCalledWith(2, { scope: 'account', key: 'admin' });
     expect(res.cookie).toHaveBeenCalledWith('session_token', 'token-1', {
       httpOnly: true,
       path: '/',
@@ -171,7 +172,7 @@ describe('LoginPostController', () => {
     expect(loginAttemptStore.clearRateLimit).toHaveBeenCalledTimes(8);
   });
 
-  it('ログイン成功時は同一IPの別ユーザー分レート制限をクリアしない', async () => {
+  it('ログイン成功時は必要なIP/Accountキーのみレート制限をクリアする', async () => {
     const session = { regenerate: jest.fn() };
     const inMemoryStore = new InMemoryLoginAttemptStore();
     const inMemoryController = new LoginPostController({
@@ -179,8 +180,9 @@ describe('LoginPostController', () => {
       loginAttemptStore: inMemoryStore,
     });
     const nowMs = 1_000;
-    inMemoryStore.consumeRateLimit({ scope: 'ip', key: 'ip:127.0.0.1|user:admin', windowMs: 60_000, nowMs });
-    inMemoryStore.consumeRateLimit({ scope: 'ip', key: 'ip:127.0.0.1|user:guest', windowMs: 60_000, nowMs });
+    inMemoryStore.consumeRateLimit({ scope: 'ip', key: '127.0.0.1', windowMs: 60_000, nowMs });
+    inMemoryStore.consumeRateLimit({ scope: 'account', key: 'admin', windowMs: 60_000, nowMs });
+    inMemoryStore.consumeRateLimit({ scope: 'account', key: 'guest', windowMs: 60_000, nowMs });
 
     const req = {
       body: { username: 'admin', password: 'secret' },
@@ -195,19 +197,26 @@ describe('LoginPostController', () => {
     const res = createRes();
     await inMemoryController.execute(req, res);
 
-    const adminAfterSuccess = inMemoryStore.consumeRateLimit({
+    const ipAfterSuccess = inMemoryStore.consumeRateLimit({
       scope: 'ip',
-      key: 'ip:127.0.0.1|user:admin',
+      key: '127.0.0.1',
+      windowMs: 60_000,
+      nowMs: nowMs + 1,
+    });
+    const adminAfterSuccess = inMemoryStore.consumeRateLimit({
+      scope: 'account',
+      key: 'admin',
       windowMs: 60_000,
       nowMs: nowMs + 1,
     });
     const guestAfterSuccess = inMemoryStore.consumeRateLimit({
-      scope: 'ip',
-      key: 'ip:127.0.0.1|user:guest',
+      scope: 'account',
+      key: 'guest',
       windowMs: 60_000,
       nowMs: nowMs + 1,
     });
 
+    expect(ipAfterSuccess.count).toBe(1);
     expect(adminAfterSuccess.count).toBe(1);
     expect(guestAfterSuccess.count).toBe(2);
   });

--- a/__tests__/small/controller/api/LoginPostController.test.js
+++ b/__tests__/small/controller/api/LoginPostController.test.js
@@ -169,7 +169,7 @@ describe('LoginPostController', () => {
     }
 
     expect(loginAttemptStore.clearAuthenticationFailures).toHaveBeenCalledTimes(8);
-    expect(loginAttemptStore.clearRateLimit).toHaveBeenCalledTimes(8);
+    expect(loginAttemptStore.clearRateLimit).toHaveBeenCalledTimes(16);
   });
 
   it('ログイン成功時は必要なIP/Accountキーのみレート制限をクリアする', async () => {

--- a/__tests__/small/controller/middleware/LoginRateLimiter.test.js
+++ b/__tests__/small/controller/middleware/LoginRateLimiter.test.js
@@ -15,6 +15,7 @@ describe('LoginRateLimiter', () => {
     const loginAttemptStore = {
       consumeRateLimit: jest.fn()
         .mockReturnValueOnce({ count: 5, resetAtMs: Date.now() + 10_000 })
+        .mockReturnValueOnce({ count: 1, resetAtMs: Date.now() + 10_000 })
         .mockReturnValueOnce({ count: 6, resetAtMs: Date.now() + 10_000 }),
     };
     const middleware = new LoginRateLimiter({
@@ -34,7 +35,7 @@ describe('LoginRateLimiter', () => {
     expect(secondRes.json).toHaveBeenCalledWith({ code: 1 });
   });
 
-  test('同一IPでもユーザーが異なる試行は別キーとして扱う', async () => {
+  test('同一IPでusernameを回転してもIPスコープ制限を回避できない', async () => {
     const loginAttemptStore = new InMemoryLoginAttemptStore();
     const middleware = new LoginRateLimiter({
       loginAttemptStore,
@@ -50,14 +51,28 @@ describe('LoginRateLimiter', () => {
     const secondRes = createRes();
     const secondNext = jest.fn();
     await middleware.execute({ ip: '127.0.0.1', body: { username: 'bob' } }, secondRes, secondNext);
-    expect(secondNext).toHaveBeenCalledTimes(1);
-    expect(secondRes.status).not.toHaveBeenCalledWith(429);
+    expect(secondNext).not.toHaveBeenCalled();
+    expect(secondRes.status).toHaveBeenCalledWith(429);
+  });
 
-    const thirdRes = createRes();
-    const thirdNext = jest.fn();
-    await middleware.execute({ ip: '127.0.0.1', body: { username: 'alice' } }, thirdRes, thirdNext);
-    expect(thirdNext).not.toHaveBeenCalled();
-    expect(thirdRes.status).toHaveBeenCalledWith(429);
+  test('同一アカウントでIPを変えてもaccountスコープ制限を回避できない', async () => {
+    const loginAttemptStore = new InMemoryLoginAttemptStore();
+    const middleware = new LoginRateLimiter({
+      loginAttemptStore,
+      maxAttemptsPerWindow: 1,
+      windowMs: 60_000,
+    });
+
+    const firstRes = createRes();
+    const firstNext = jest.fn();
+    await middleware.execute({ ip: '127.0.0.1', body: { username: 'alice' } }, firstRes, firstNext);
+    expect(firstNext).toHaveBeenCalledTimes(1);
+
+    const secondRes = createRes();
+    const secondNext = jest.fn();
+    await middleware.execute({ ip: '127.0.0.2', body: { username: 'alice' } }, secondRes, secondNext);
+    expect(secondNext).not.toHaveBeenCalled();
+    expect(secondRes.status).toHaveBeenCalledWith(429);
   });
 
   test('認証成功が連続する想定では毎回nextへ進み429にならない', async () => {
@@ -107,7 +122,7 @@ describe('LoginRateLimiter', () => {
     expect(res.status).not.toHaveBeenCalled();
     expect(logger.warn).toHaveBeenCalledWith(
       'auth.login.failed',
-      expect.objectContaining({ reason: 'rate_limit_store_unavailable', store_failure_policy: 'fail_open' }),
+      expect.objectContaining({ reason: 'rate_limit_store_unavailable', store_failure_policy: 'fail_open', scope: 'ip' }),
     );
   });
 });

--- a/__tests__/small/infrastructure/InMemoryLoginAttemptStore.test.js
+++ b/__tests__/small/infrastructure/InMemoryLoginAttemptStore.test.js
@@ -48,4 +48,17 @@ describe('InMemoryLoginAttemptStore', () => {
 
     expect(afterClear.count).toBe(1);
   });
+
+  test('scopeごとに独立してレート制限カウンタを管理できる', () => {
+    const store = new InMemoryLoginAttemptStore();
+
+    const ip = store.consumeRateLimit({ scope: 'ip', key: '127.0.0.1', windowMs: 60_000, nowMs: 1_000 });
+    const account = store.consumeRateLimit({ scope: 'account', key: 'admin', windowMs: 60_000, nowMs: 1_000 });
+    const ipSecond = store.consumeRateLimit({ scope: 'ip', key: '127.0.0.1', windowMs: 60_000, nowMs: 2_000 });
+
+    expect(ip.count).toBe(1);
+    expect(account.count).toBe(1);
+    expect(ipSecond.count).toBe(2);
+  });
+
 });

--- a/__tests__/small/infrastructure/RedisLoginAttemptStore.test.js
+++ b/__tests__/small/infrastructure/RedisLoginAttemptStore.test.js
@@ -99,4 +99,19 @@ describe('RedisLoginAttemptStore', () => {
     expect(firstResult.count).toBe(1);
     expect(secondResult.count).toBe(2);
   });
+
+  test('scopeごとに独立したレート制限カウンタを共有できる', async () => {
+    const redis = createFakeRedis();
+    const first = new RedisLoginAttemptStore({ redis, keyPrefix: 'auth' });
+    const second = new RedisLoginAttemptStore({ redis, keyPrefix: 'auth' });
+
+    const ipFirst = await first.consumeRateLimit({ scope: 'ip', key: '127.0.0.1', windowMs: 60_000, nowMs: 100 });
+    const accountFirst = await second.consumeRateLimit({ scope: 'account', key: 'admin', windowMs: 60_000, nowMs: 101 });
+    const ipSecond = await second.consumeRateLimit({ scope: 'ip', key: '127.0.0.1', windowMs: 60_000, nowMs: 102 });
+
+    expect(ipFirst.count).toBe(1);
+    expect(accountFirst.count).toBe(1);
+    expect(ipSecond.count).toBe(2);
+  });
+
 });

--- a/src/controller/api/LoginPostController.js
+++ b/src/controller/api/LoginPostController.js
@@ -108,7 +108,11 @@ class LoginPostController {
       await this.#loginAttemptStore.clearAuthenticationFailures({ key: username });
       await this.#loginAttemptStore.clearRateLimit({
         scope: 'ip',
-        key: this.#buildRateLimitKey({ ipAddress, username }),
+        key: ipAddress,
+      });
+      await this.#loginAttemptStore.clearRateLimit({
+        scope: 'account',
+        key: username,
       });
     } catch (error) {
       logger?.warn('auth.login.store_cleanup_failed', {
@@ -176,11 +180,6 @@ class LoginPostController {
     return req.ip || req.connection?.remoteAddress || 'unknown';
   }
 
-  #buildRateLimitKey({ ipAddress, username }) {
-    const resolvedIpAddress = typeof ipAddress === 'string' && ipAddress.length > 0 ? ipAddress : 'unknown';
-    const resolvedUsername = typeof username === 'string' && username.length > 0 ? username : 'anonymous';
-    return `ip:${resolvedIpAddress}|user:${resolvedUsername}`;
-  }
 
   #fail(res) {
     return res.status(200).json({ code: 1 });

--- a/src/controller/middleware/LoginRateLimiter.js
+++ b/src/controller/middleware/LoginRateLimiter.js
@@ -21,45 +21,66 @@ class LoginRateLimiter {
     const requestId = req.context?.requestId;
     const ipAddress = this.#resolveIpAddress(req);
     const username = this.#resolveUsername(req);
-    const rateLimitKey = this.#buildRateLimitKey({ ipAddress, username });
     const storeFailurePolicy = this.#resolveStoreFailurePolicy(req);
 
-    let ipCounter;
-    try {
-      ipCounter = await this.#loginAttemptStore.consumeRateLimit({
-        scope: 'ip',
-        key: rateLimitKey,
-        windowMs: this.#windowMs,
-        nowMs,
-      });
-    } catch (error) {
-      logger?.warn('auth.login.failed', {
-        request_id: requestId,
-        reason: 'rate_limit_store_unavailable',
-        ip_address: ipAddress,
-        username,
-        store_failure_policy: storeFailurePolicy,
-        store_error_message: error?.message,
-      });
+    const targets = [
+      { scope: 'ip', key: ipAddress },
+      { scope: 'account', key: username },
+    ];
 
-      if (storeFailurePolicy === 'fail_open') {
-        return next();
+    for (const target of targets) {
+      let counter;
+      try {
+        counter = await this.#loginAttemptStore.consumeRateLimit({
+          scope: target.scope,
+          key: target.key,
+          windowMs: this.#windowMs,
+          nowMs,
+        });
+      } catch (error) {
+        logger?.warn('auth.login.failed', {
+          request_id: requestId,
+          reason: 'rate_limit_store_unavailable',
+          ip_address: ipAddress,
+          username,
+          scope: target.scope,
+          store_failure_policy: storeFailurePolicy,
+          store_error_message: error?.message,
+        });
+
+        if (storeFailurePolicy === 'fail_open') {
+          return next();
+        }
+
+        return res.status(503).json({ code: 1 });
       }
 
-      return res.status(503).json({ code: 1 });
-    }
-
-    if (ipCounter.count > this.#maxAttemptsPerWindow) {
-      logger?.warn('auth.login.failed', {
-        request_id: requestId,
-        reason: 'rate_limited',
-        ip_address: ipAddress,
-        username,
-      });
-      return res.status(429).json({ code: 1 });
+      if (counter.count > this.#maxAttemptsPerWindow) {
+        logger?.warn('auth.login.failed', {
+          request_id: requestId,
+          reason: 'rate_limited',
+          ip_address: ipAddress,
+          username,
+          scope: target.scope,
+          remaining: this.#resolveRemaining(counter),
+        });
+        return res.status(429).json({ code: 1 });
+      }
     }
 
     return next();
+  }
+
+  #resolveRemaining(counter) {
+    if (Number.isFinite(counter?.remaining)) {
+      return counter.remaining;
+    }
+
+    if (Number.isFinite(counter?.count)) {
+      return Math.max(this.#maxAttemptsPerWindow - counter.count, 0);
+    }
+
+    return undefined;
   }
 
   #resolveStoreFailurePolicy(req) {
@@ -78,10 +99,6 @@ class LoginRateLimiter {
 
   #resolveIpAddress(req) {
     return req.ip || req.connection?.remoteAddress || 'unknown';
-  }
-
-  #buildRateLimitKey({ ipAddress, username }) {
-    return `ip:${ipAddress}|user:${username}`;
   }
 }
 


### PR DESCRIPTION
### Motivation
- IP+username 結合キーのみでレート管理していたため、username 回転や IP 変更により制限を回避できる余地があり防御強度が不足していた。今回、IP とアカウントを独立したスコープで制限することでその抜けを防止する。

### Description
- `src/controller/middleware/LoginRateLimiter.js` を修正し、1リクエストで `consumeRateLimit` を `scope='ip' key=ipAddress` と `scope='account' key=username` の順に呼び出してそれぞれ消費するように変更し、いずれかが閾値超過なら `429` を返すようにした。ログの監査情報に `scope` と `remaining`（可能なら）を追加した。 
- `src/controller/api/LoginPostController.js` の成功時クリーンアップを見直し、旧来の結合キーを使わずに `clearRateLimit({ scope: 'ip', key: ipAddress })` と `clearRateLimit({ scope: 'account', key: username })` の必要なキーのみを解放するように変更し、不要なキーを巻き込まないようにした。合わせて結合キー生成メソッドを削除した。 
- ストア実装（`InMemoryLoginAttemptStore` / `RedisLoginAttemptStore`）は既存 API (`consumeRateLimit({ scope, key })`) でスコープ別管理が可能であったため本体変更は不要と判断し、再発防止のために両実装がスコープ単位で独立カウントを保持することを検証するテストを追加した。 
- 回帰テストを追加・更新し、以下をカバーするようにした：middleware の二層制限挙動、controller の成功時クリア挙動、username 回転で IP 制限を回避できない medium 統合テスト、InMemory/Redis の scope 独立カウント検証。変更ファイルの代表: `src/controller/middleware/LoginRateLimiter.js`, `src/controller/api/LoginPostController.js`, および複数の `__tests__/*`。

### Testing
- 変更に対してプロジェクトの Jest テスト群を個別に実行するコマンドを試行したが、環境から npm registry へアクセスした際に `403 Forbidden` が返り `jest` を取得できなかったため自動テストの実行は失敗した。 (実行例: `npx jest __tests__/small/controller/middleware/LoginRateLimiter.test.js --runInBand` が npm 403 で失敗)
- ローカルでの手動確認としてはユニットテストコードを追加・更新し整合性を確認済みで、CI/開発環境での実行が可能になれば追加したテスト群が動作する想定である。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d69154022c832b8e77169a14c6dc26)