### PR TITLE
開発用固定セッションを ENABLE_DEV_SESSION 明示時のみ有効化

### DIFF
--- a/__tests__/medium/app/commonNavigator.integration.test.js
+++ b/__tests__/medium/app/commonNavigator.integration.test.js
@@ -35,6 +35,7 @@ describe('medium: common navigator integration', () => {
     databaseStoragePath: ':memory:',
     contentRootDirectory: '/tmp/mangaviewer-medium-common-nav-contents',
     ...createLoginEnv(),
+    enableDevSession: 'true',
     devSessionToken: 'dev-token',
     devSessionUserId: userId,
     devSessionTtlMs: 60_000,

--- a/__tests__/medium/app/developmentSession.integration.test.js
+++ b/__tests__/medium/app/developmentSession.integration.test.js
@@ -139,6 +139,7 @@ describe('developmentSession wiring', () => {
 
     expect(listenMock).toHaveBeenCalledWith(3456, expect.any(Function));
     expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining('開発用固定セッションを有効化しました'));
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('開発用固定セッションは無効です: ENABLE_DEV_SESSION が未指定のため適用しません'));
     expect(errorSpy).not.toHaveBeenCalled();
     expect(exitSpy).not.toHaveBeenCalled();
   });

--- a/__tests__/medium/app/setupMiddleware.integration.test.js
+++ b/__tests__/medium/app/setupMiddleware.integration.test.js
@@ -18,6 +18,7 @@ const createApp = () => {
 
   setupMiddleware(app, {
     env: {
+      enableDevSession: 'true',
       devSessionToken: 'dev-token',
       devSessionUserId: 'admin-dev',
       devSessionTtlMs: 60_000,

--- a/__tests__/small/app/createApp.test.js
+++ b/__tests__/small/app/createApp.test.js
@@ -120,6 +120,7 @@ describe('createApp', () => {
       databaseStoragePath: databasePath,
       contentRootDirectory,
       ...createLoginEnv(),
+      enableDevSession: 'true',
       devSessionToken: 'dev-token',
       devSessionUserId: 'admin-dev',
       devSessionTtlMs: 60_000,

--- a/__tests__/small/app/developmentSession.test.js
+++ b/__tests__/small/app/developmentSession.test.js
@@ -6,6 +6,7 @@ const {
 describe('developmentSession', () => {
   test('固定セッション設定が揃っていると有効と判定する', () => {
     expect(hasDevelopmentSession({
+      enableDevSession: 'true',
       devSessionToken: 'dev-token',
       devSessionUserId: 'admin-dev',
       devSessionTtlMs: 60_000,
@@ -14,6 +15,7 @@ describe('developmentSession', () => {
 
   test('devSessionToken が欠落している場合は固定セッションを無効と判定する', () => {
     expect(hasDevelopmentSession({
+      enableDevSession: 'true',
       devSessionUserId: 'admin-dev',
       devSessionTtlMs: 60_000,
     })).toBe(false);
@@ -21,6 +23,7 @@ describe('developmentSession', () => {
 
   test('devSessionUserId が欠落している場合は固定セッションを無効と判定する', () => {
     expect(hasDevelopmentSession({
+      enableDevSession: 'true',
       devSessionToken: 'dev-token',
       devSessionTtlMs: 60_000,
     })).toBe(false);
@@ -32,6 +35,7 @@ describe('developmentSession', () => {
     ['非整数', 0.5],
   ])('devSessionTtlMs が %s の場合は固定セッションを無効と判定する', (_name, devSessionTtlMs) => {
     expect(hasDevelopmentSession({
+      enableDevSession: 'true',
       devSessionToken: 'dev-token',
       devSessionUserId: 'admin-dev',
       devSessionTtlMs,
@@ -40,6 +44,7 @@ describe('developmentSession', () => {
 
   test('対象パスのみ固定セッションを補完対象と判定する', () => {
     const env = {
+      enableDevSession: 'true',
       devSessionToken: 'dev-token',
       devSessionUserId: 'admin-dev',
       devSessionTtlMs: 60_000,
@@ -53,6 +58,7 @@ describe('developmentSession', () => {
 
   test('固定セッションが無効な場合は対象パスでも補完対象にしない', () => {
     const env = {
+      enableDevSession: 'true',
       devSessionToken: '',
       devSessionUserId: 'admin-dev',
       devSessionTtlMs: 60_000,
@@ -64,7 +70,21 @@ describe('developmentSession', () => {
 
   test('production 環境では固定セッション設定が揃っていても補完対象にしない', () => {
     const env = {
+      enableDevSession: 'true',
       nodeEnv: 'production',
+      devSessionToken: 'dev-token',
+      devSessionUserId: 'admin-dev',
+      devSessionTtlMs: 60_000,
+      devSessionPaths: ['/screen/entry'],
+    };
+
+    expect(hasDevelopmentSession(env)).toBe(false);
+    expect(shouldApplyDevelopmentSession({ env, requestPath: '/screen/entry' })).toBe(false);
+  });
+
+  test('明示フラグが true 以外の場合は固定セッションを有効化しない', () => {
+    const env = {
+      enableDevSession: '',
       devSessionToken: 'dev-token',
       devSessionUserId: 'admin-dev',
       devSessionTtlMs: 60_000,

--- a/__tests__/small/app/setupMiddleware.test.js
+++ b/__tests__/small/app/setupMiddleware.test.js
@@ -61,6 +61,7 @@ describe('setupMiddleware (small)', () => {
   ])('セッショントークン解決優先順位: $title', ({ headers, expected }) => {
     const { middleware } = createHarness({
       env: {
+        enableDevSession: 'true',
         devSessionToken: 'dev-token',
         devSessionUserId: 'admin-dev',
         devSessionTtlMs: 60_000,
@@ -80,6 +81,7 @@ describe('setupMiddleware (small)', () => {
   test('x-session-token はセッションへ反映せず監査ログのみ記録する', () => {
     const { middleware } = createHarness({
       env: {
+        enableDevSession: 'true',
         devSessionToken: 'dev-token',
         devSessionUserId: 'admin-dev',
         devSessionTtlMs: 60_000,
@@ -112,6 +114,7 @@ describe('setupMiddleware (small)', () => {
   test('Cookie 解析: Cookieヘッダの不正要素は無視し、session_token が無い場合は開発用固定セッションへフォールバックする', () => {
     const { middleware } = createHarness({
       env: {
+        enableDevSession: 'true',
         devSessionToken: 'dev-token',
         devSessionUserId: 'admin-dev',
         devSessionTtlMs: 60_000,

--- a/doc/1_requirements/architecture.md
+++ b/doc/1_requirements/architecture.md
@@ -9,6 +9,6 @@
 
 ## 開発支援機能
 - DevelopmentSession は、認証付き画面・API のローカル確認を容易にするための開発専用機能である。
-- `DEV_SESSION_TOKEN` / `DEV_SESSION_USER_ID` / `DEV_SESSION_TTL_MS` / `DEV_SESSION_PATHS` が揃った場合のみ有効化する。
+- `ENABLE_DEV_SESSION=true` が明示され、かつ `DEV_SESSION_TOKEN` / `DEV_SESSION_USER_ID` / `DEV_SESSION_TTL_MS` / `DEV_SESSION_PATHS` が揃った場合のみ有効化する。
 - 対象は `DEV_SESSION_PATHS` に列挙したパスに限定し、通常のヘッダ / Cookie によるセッション指定がある場合はそちらを優先する。
 - 本番環境や公開環境では利用しないことを前提とし、固定トークンを秘匿情報として扱う。

--- a/doc/4_application/app/server/readme.md
+++ b/doc/4_application/app/server/readme.md
@@ -19,6 +19,7 @@
 | `DEV_SESSION_USER_ID` | `devSessionUserId` | 空文字 | 開発用固定セッションの利用者ID |
 | `DEV_SESSION_TTL_MS` | `devSessionTtlMs` | `parseInt(..., 10) || 0` | 開発用固定セッションの TTL |
 | `DEV_SESSION_PATHS` | `devSessionPaths` | カンマ区切り分解後の配列 | 固定セッションを適用するパス一覧 |
+| `ENABLE_DEV_SESSION` | `enableDevSession` | 空文字 | 開発用固定セッションの明示有効化フラグ（`true` のみ有効） |
 | `FIXED_LOGIN_USERNAME` (`LOGIN_USERNAME` 互換) | `loginUsername` | 空文字 | 固定ログイン認証のユーザー名 |
 | `FIXED_LOGIN_PASSWORD` (`LOGIN_PASSWORD` 互換) | `loginPassword` | 空文字 | 固定ログイン認証のパスワード |
 | `FIXED_LOGIN_USER_ID` (`LOGIN_USER_ID` 互換) | `loginUserId` | 空文字 | ログイン成功時の利用者ID |
@@ -39,8 +40,9 @@
 4. 初期化失敗時は `console.error('アプリケーションの初期化に失敗しました', error)` を出力し、`process.exit(1)` で終了する。
 5. 初期化成功時のみ `app.listen(env.port, ...)` を実行する。
 6. listen 成功コールバックで `サーバーを起動しました: port=...` を出力する。
-7. `hasDevelopmentSession(env)` が `true` の場合は、固定セッション有効化ログも追加出力する。
-8. `server.on('error', ...)` で起動失敗を監視し、失敗時は `process.exit(1)` で終了する。
+7. `NODE_ENV !== production` かつ `ENABLE_DEV_SESSION` が未指定の場合は、固定セッションが無効である旨を起動ログへ出力する。
+8. `hasDevelopmentSession(env)` が `true` の場合は、固定セッション有効化ログも追加出力する。
+9. `server.on('error', ...)` で起動失敗を監視し、失敗時は `process.exit(1)` で終了する。
 
 ## `app.locals.ready` / `app.locals.close` の扱い
 - `server.js` が直接利用するのは `app.locals.ready` のみである。
@@ -50,6 +52,7 @@
 
 ## `DevelopmentSession` に関する起動責務
 - `hasDevelopmentSession(env)` を用いて、開発用固定セッション設定が有効かを起動時ログ判定に利用する。
+- 開発環境で `ENABLE_DEV_SESSION` が未指定の場合は無効として扱うため、起動時に誤設定検知ログを出力する。
 - セッションストアへの事前登録は `createDependencies`、リクエスト適用は `setupMiddleware` が担うため、`server.js` は環境変数解釈と起動ログ出力に責務を限定する。
 - 固定セッションの優先順位は `x-session-token` → `session_token` Cookie → 開発用固定セッションであり、その実行仕様自体は [setupMiddleware 設計書](/doc/5_api/controller/middleware/setupMiddleware/readme.md) を参照する。
 - 詳細は [DevelopmentSession 設計書](/doc/5_api/controller/middleware/DevelopmentSession/readme.md) を参照する。
@@ -59,3 +62,7 @@
 - [createDependencies 設計書](/doc/4_application/app/createDependencies/readme.md)
 - [setupMiddleware 設計書](/doc/5_api/controller/middleware/setupMiddleware/readme.md)
 - [DevelopmentSession 設計書](/doc/5_api/controller/middleware/DevelopmentSession/readme.md)
+
+## 運用メモ
+- 開発用固定セッションを使う場合は、`ENABLE_DEV_SESSION=true` を明示して起動する。
+- 本リポジトリでは `npm run dev:entry` が `ENABLE_DEV_SESSION=true` を付与した開発用起動コマンドになっている。

--- a/doc/5_api/controller/middleware/DevelopmentSession/readme.md
+++ b/doc/5_api/controller/middleware/DevelopmentSession/readme.md
@@ -17,6 +17,7 @@
 
 ### `hasDevelopmentSession(env)`
 以下をすべて満たす場合のみ `true` と判定する。
+- `enableDevSession` が文字列 `'true'`
 - `devSessionToken` が空文字ではない `string`
 - `devSessionUserId` が空文字ではない `string`
 - `devSessionTtlMs` が正の整数

--- a/doc/5_api/controller/middleware/setupMiddleware/readme.md
+++ b/doc/5_api/controller/middleware/setupMiddleware/readme.md
@@ -17,6 +17,7 @@
 | `devSessionPaths` | 固定セッション自動補完の対象パス一覧 |
 | `devSessionUserId` | `shouldApplyDevelopmentSession` の前提条件となる固定セッション設定の一部 |
 | `devSessionTtlMs` | `shouldApplyDevelopmentSession` の前提条件となる固定セッション設定の一部 |
+| `enableDevSession` | 開発用固定セッションの明示有効化フラグ。`'true'` のときのみ判定処理へ進む |
 
 ### `dependencies`
 - 現行実装では利用しないが、`createApp` からシグネチャを統一して受け取る。
@@ -44,7 +45,7 @@
 
 ### 優先順位詳細
 - `session_token` Cookie が非空文字列なら、その値を採用する。
-- Cookie が無い場合に限り、`shouldApplyDevelopmentSession({ env, requestPath: req.path })` を評価する。
+- Cookie が無い場合に限り、`enableDevSession === 'true'` のときだけ `shouldApplyDevelopmentSession({ env, requestPath: req.path })` を評価する。
 - `shouldApplyDevelopmentSession(...)` が `true` のときのみ `env.devSessionToken` を補完する。
 - したがって、開発用固定セッションは Cookie で明示指定された通常セッションを上書きしない。
 - 互換期間中は `x-session-token` を検知した場合のみ監査ログ (`auth.legacy_session_token_header.detected`) を出力する。ログには件数・送信元IP・User-Agentのみを含み、トークン値は記録しない。

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test:all:coverage": "cross-env NODE_ENV=test LOG_OUTPUTS=memory jest __tests__/ --coverage",
     "make-api": "node ./node_modules/aglio/bin/aglio.js -i ./doc/5_api/openapi/openapi.yaml -o ./doc/5_api/openapi/openapi.html",
     "watch-api": "node ./node_modules/aglio/bin/aglio.js -i ./doc/5_api/openapi/openapi.yaml -s",
-    "dev:entry": "cross-env FIXED_LOGIN_USER_ID=admin FIXED_LOGIN_USERNAME=admin FIXED_LOGIN_PASSWORD=admin DEV_SESSION_TOKEN=dev-token DEV_SESSION_USER_ID=admin-dev DEV_SESSION_TTL_MS=86400000 DEV_SESSION_PATHS=/screen/entry,/api/media nodemon ./src/server.js --watch ./src",
+    "dev:entry": "cross-env ENABLE_DEV_SESSION=true FIXED_LOGIN_USER_ID=admin FIXED_LOGIN_USERNAME=admin FIXED_LOGIN_PASSWORD=admin DEV_SESSION_TOKEN=dev-token DEV_SESSION_USER_ID=admin-dev DEV_SESSION_TTL_MS=86400000 DEV_SESSION_PATHS=/screen/entry,/api/media nodemon ./src/server.js --watch ./src",
     "seed:user": "node ./scripts/seed-fixed-user.js",
     "start:seeded": "npm run seed:user && npm run start"
   },

--- a/src/app/developmentSession.js
+++ b/src/app/developmentSession.js
@@ -1,6 +1,7 @@
 const isNonEmptyString = value => typeof value === 'string' && value.length > 0;
 
 const resolveNodeEnv = (env = {}) => String(env.nodeEnv || process.env.NODE_ENV || '').toLowerCase();
+const isDevelopmentSessionExplicitlyEnabled = (env = {}) => env.enableDevSession === 'true';
 
 const isDevelopmentSessionEnvironment = (env = {}) => {
   const nodeEnv = resolveNodeEnv(env);
@@ -15,11 +16,16 @@ const hasDevelopmentSessionConfiguration = (env = {}) => (
 );
 
 const hasDevelopmentSession = (env = {}) => (
-  isDevelopmentSessionEnvironment(env)
+  isDevelopmentSessionExplicitlyEnabled(env)
+  && isDevelopmentSessionEnvironment(env)
   && hasDevelopmentSessionConfiguration(env)
 );
 
 const resolveDevelopmentSessionApplication = ({ env = {}, requestPath = '' } = {}) => {
+  if (!isDevelopmentSessionExplicitlyEnabled(env)) {
+    return { enabled: false, reason: 'explicit_flag_disabled' };
+  }
+
   if (!isDevelopmentSessionEnvironment(env)) {
     return { enabled: false, reason: 'environment_not_allowed' };
   }
@@ -46,6 +52,7 @@ const shouldApplyDevelopmentSession = ({ env = {}, requestPath = '' } = {}) => {
 
 module.exports = {
   hasDevelopmentSession,
+  isDevelopmentSessionExplicitlyEnabled,
   resolveDevelopmentSessionApplication,
   shouldApplyDevelopmentSession,
 };

--- a/src/app/setupMiddleware.js
+++ b/src/app/setupMiddleware.js
@@ -3,6 +3,7 @@ const crypto = require('crypto');
 const express = require('express');
 
 const {
+  isDevelopmentSessionExplicitlyEnabled,
   shouldApplyDevelopmentSession,
   resolveDevelopmentSessionApplication,
 } = require('./developmentSession');
@@ -142,7 +143,10 @@ const setupMiddleware = (app, { env = {}, dependencies: _dependencies } = {}) =>
         path: req.path,
       });
 
-      if (shouldApplyDevelopmentSession({ env, requestPath: req.path })) {
+      if (
+        isDevelopmentSessionExplicitlyEnabled(env)
+        && shouldApplyDevelopmentSession({ env, requestPath: req.path })
+      ) {
         req.session.session_token = env.devSessionToken;
       }
 

--- a/src/server.js
+++ b/src/server.js
@@ -15,6 +15,7 @@ const parseSessionPaths = value => (value || '')
   .filter(entry => entry.length > 0);
 
 const isConfigured = value => String(value || '').trim().length > 0;
+const isNonProduction = nodeEnv => String(nodeEnv || '').toLowerCase() !== 'production';
 
 const assertDevelopmentSessionConfigurationAllowed = (env, source = {}) => {
   const isProduction = String(env.nodeEnv || '').toLowerCase() === 'production';
@@ -56,6 +57,7 @@ const createEnv = source => ({
   devSessionUserId: source.DEV_SESSION_USER_ID || '',
   devSessionTtlMs: Number.parseInt(source.DEV_SESSION_TTL_MS, 10) || 0,
   devSessionPaths: parseSessionPaths(source.DEV_SESSION_PATHS),
+  enableDevSession: source.ENABLE_DEV_SESSION || '',
   loginUsername: source.FIXED_LOGIN_USERNAME || source.LOGIN_USERNAME || '',
   loginPassword: source.FIXED_LOGIN_PASSWORD || source.LOGIN_PASSWORD || '',
   loginPasswordHash: source.FIXED_LOGIN_PASSWORD_HASH || source.LOGIN_PASSWORD_HASH || '',
@@ -112,6 +114,10 @@ const startServer = async () => {
 
   const server = app.listen(env.port, () => {
     console.log(`サーバーを起動しました: port=${env.port}`);
+
+    if (isNonProduction(env.nodeEnv) && !isConfigured(process.env.ENABLE_DEV_SESSION)) {
+      console.log('開発用固定セッションは無効です: ENABLE_DEV_SESSION が未指定のため適用しません');
+    }
 
     if (hasDevelopmentSession(env)) {
       console.log([


### PR DESCRIPTION
### Motivation
- 開発用固定セッションが `DEV_SESSION_*` のみで自動有効化されると、誤設定時に認証バイパスになるリスクがあるため明示フラグを必須化するため。 
- 起動時に `ENABLE_DEV_SESSION` 未指定をログ出力して早期に誤設定を検知できるようにするため。 

### Description
- `src/app/developmentSession.js` に `isDevelopmentSessionExplicitlyEnabled` を追加し、`hasDevelopmentSession` と `resolveDevelopmentSessionApplication` に `enableDevSession === 'true'` チェックを導入した。 
- `src/app/setupMiddleware.js` は固定セッションを適用する前に明示フラグを確認するよう変更し、フラグ通過時のみ `shouldApplyDevelopmentSession` による補完を行うようにした。 
- `src/server.js` の `createEnv` に `enableDevSession` を追加し、`NODE_ENV !== production` かつ `ENABLE_DEV_SESSION` 未指定時に起動ログで無効を通知するメッセージを追加した。 
- 開発用起動スクリプト `package.json` の `dev:entry` に `ENABLE_DEV_SESSION=true` を付与し、設計ドキュメント（`doc/...`）とテスト（`__tests__/...`）を明示フラグ前提に更新した。 

### Testing
- 既存の unit / integration テスト群を該当箇所（`__tests__/small` / `__tests__/medium`）へ合わせて更新し、明示フラグ有効ケースを追加または修正した。 
- ローカルで `npm run test:small -- developmentSession setupMiddleware createApp` を実行しようとしたが、環境に `cross-env` が見つからないため実行できず（`sh: 1: cross-env: not found`）。 
- `npm ci` を試行したが実行環境で依存導入が完了せず中断したため、自動テストのフル実行は行えていない（環境依存のため再現環境での実行を推奨する）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6dcb430cc832b90f13ed78b321acd)