### PR TITLE
fix: ログインAPIにCSRF検証を適用しクライアント送信と仕様を整合する

### DIFF
--- a/__tests__/large/e2e/auth/login-to-summary.large.test.js
+++ b/__tests__/large/e2e/auth/login-to-summary.large.test.js
@@ -60,12 +60,21 @@ test.describe('large e2e: ログイン画面からサマリー画面まで遷移
 
   test('認証成功だけを連続して実行しても /api/login が 429 を返さない', async () => {
     const { baseUrl } = appContext;
+    await page.request.get(`${baseUrl}/screen/login`);
+    const cookies = await page.context().cookies(baseUrl);
+    const csrfToken = cookies.find(cookie => cookie.name === 'csrf_token')?.value || '';
+
+    expect(csrfToken).not.toBe('');
 
     for (let i = 0; i < 8; i += 1) {
       const response = await page.request.post(`${baseUrl}/api/login`, {
         form: {
           username: 'admin',
           password: 'admin',
+        },
+        headers: {
+          origin: baseUrl,
+          'x-csrf-token': csrfToken,
         },
       });
 

--- a/__tests__/medium/app/setupRoutes.notFound.test.js
+++ b/__tests__/medium/app/setupRoutes.notFound.test.js
@@ -11,6 +11,14 @@ const createLoginEnv = () => ({
   loginUserId: 'test-user-id',
 });
 
+const extractCsrfToken = cookies => {
+  const cookie = (cookies || []).find(entry => entry.startsWith('csrf_token='));
+  if (!cookie) {
+    return '';
+  }
+  return cookie.split(';')[0].split('=')[1] || '';
+};
+
 const createTempPath = (prefix, leaf) => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
   return {
@@ -73,9 +81,18 @@ describe('setupRoutes not found handler (middle)', () => {
 
   test('既存の api ルートは個別レスポンスを返し、未定義の api ルートだけが共通 404 JSON を返す', async () => {
     await createReadyApp();
+    const bootstrapResponse = await request(app)
+      .get('/screen/login')
+      .set('origin', 'http://127.0.0.1')
+      .set('host', '127.0.0.1');
+    const csrfToken = extractCsrfToken(bootstrapResponse.headers['set-cookie']);
 
     const existingResponse = await request(app)
       .post('/api/login')
+      .set('origin', 'http://127.0.0.1')
+      .set('host', '127.0.0.1')
+      .set('x-csrf-token', csrfToken)
+      .set('Cookie', bootstrapResponse.headers['set-cookie'])
       .type('form')
       .send({ username: 'invalid', password: 'invalid' });
     expect(existingResponse.status).toBe(200);

--- a/__tests__/medium/controller/router/media/cookieAuthMediaPost.integration.test.js
+++ b/__tests__/medium/controller/router/media/cookieAuthMediaPost.integration.test.js
@@ -32,6 +32,18 @@ class FixedMediaIdValueGenerator {
 }
 
 describe('Cookie認証での /api/media 回帰テスト (medium)', () => {
+  const createCsrfReadyAgent = async app => {
+    const agent = request.agent(app);
+    const bootstrapResponse = await agent
+      .get('/screen/login')
+      .set('origin', 'http://127.0.0.1')
+      .set('host', '127.0.0.1');
+    return {
+      agent,
+      csrfToken: extractCsrfToken(bootstrapResponse.headers['set-cookie']),
+    };
+  };
+
   const createJpegBuffer = () => Buffer.from([
     0xff, 0xd8, 0xff, 0xdb,
     0x00, 0x43, 0x00, 0x08,
@@ -104,9 +116,13 @@ describe('Cookie認証での /api/media 回帰テスト (medium)', () => {
 
   test('ログイン後は Cookie + CSRF ヘッダで /api/media に成功する', async () => {
     const { app, authResolver } = createApp();
+    const { agent, csrfToken } = await createCsrfReadyAgent(app);
 
-    const loginResponse = await request(app)
+    const loginResponse = await agent
       .post('/api/login')
+      .set('origin', 'http://127.0.0.1')
+      .set('host', '127.0.0.1')
+      .set('x-csrf-token', csrfToken)
       .type('form')
       .send({ username: 'admin', password: 'secret' });
 

--- a/__tests__/medium/controller/router/media/cookieAuthMediaPost.integration.test.js
+++ b/__tests__/medium/controller/router/media/cookieAuthMediaPost.integration.test.js
@@ -132,12 +132,11 @@ describe('Cookie認証での /api/media 回帰テスト (medium)', () => {
 
     const validJpegHeader = Buffer.from([0xff, 0xd8, 0xff, 0xdb]);
 
-    const response = await request(app)
+    const response = await agent
       .post('/api/media')
       .set('origin', 'http://127.0.0.1')
       .set('host', '127.0.0.1')
-      .set('x-csrf-token', extractCsrfToken(loginResponse.headers['set-cookie']))
-      .set('Cookie', loginResponse.headers['set-cookie'])
+      .set('x-csrf-token', csrfToken)
       .field('title', 'cookie-auth-title')
       .field('tags[0][category]', '作者')
       .field('tags[0][label]', '山田')

--- a/__tests__/medium/controller/router/user/setRouterApiLogin.test.js
+++ b/__tests__/medium/controller/router/user/setRouterApiLogin.test.js
@@ -11,6 +11,26 @@ const StaticLoginAuthenticator = require('../../../../../src/infrastructure/Stat
 const { LoginService } = require('../../../../../src/application/user/command/LoginService');
 const setupMiddleware = require('../../../../../src/app/setupMiddleware');
 
+const extractCsrfToken = cookies => {
+  const cookie = (cookies || []).find(entry => entry.startsWith('csrf_token='));
+  if (!cookie) {
+    return '';
+  }
+  return cookie.split(';')[0].split('=')[1] || '';
+};
+
+const createCsrfReadyAgent = async app => {
+  const agent = request.agent(app);
+  const bootstrapResponse = await agent
+    .get('/screen/login')
+    .set('origin', 'http://127.0.0.1')
+    .set('host', '127.0.0.1');
+  return {
+    agent,
+    csrfToken: extractCsrfToken(bootstrapResponse.headers['set-cookie']),
+  };
+};
+
 describe('setRouterApiLogin (middle)', () => {
   const createApp = ({
     maxAttemptsPerWindow = 5,
@@ -56,9 +76,13 @@ describe('setRouterApiLogin (middle)', () => {
 
   test('閾値以内は通常通りログインできる', async () => {
     const app = createApp({ maxAttemptsPerWindow: 5 });
+    const { agent, csrfToken } = await createCsrfReadyAgent(app);
 
-    const loginResponse = await request(app)
+    const loginResponse = await agent
       .post('/api/login')
+      .set('origin', 'http://127.0.0.1')
+      .set('host', '127.0.0.1')
+      .set('x-csrf-token', csrfToken)
       .type('form')
       .send({ username: 'admin', password: 'secret' });
 
@@ -78,17 +102,27 @@ describe('setRouterApiLogin (middle)', () => {
 
   test('閾値超過でRateLimiterにより拒否される', async () => {
     const app = createApp({ maxAttemptsPerWindow: 2, windowMs: 60_000 });
+    const { agent, csrfToken } = await createCsrfReadyAgent(app);
 
-    const first = await request(app)
+    const first = await agent
       .post('/api/login')
+      .set('origin', 'http://127.0.0.1')
+      .set('host', '127.0.0.1')
+      .set('x-csrf-token', csrfToken)
       .type('form')
       .send({ username: 'admin', password: 'wrong' });
-    const second = await request(app)
+    const second = await agent
       .post('/api/login')
+      .set('origin', 'http://127.0.0.1')
+      .set('host', '127.0.0.1')
+      .set('x-csrf-token', csrfToken)
       .type('form')
       .send({ username: 'admin', password: 'wrong' });
-    const third = await request(app)
+    const third = await agent
       .post('/api/login')
+      .set('origin', 'http://127.0.0.1')
+      .set('host', '127.0.0.1')
+      .set('x-csrf-token', csrfToken)
       .type('form')
       .send({ username: 'admin', password: 'wrong' });
 
@@ -101,17 +135,27 @@ describe('setRouterApiLogin (middle)', () => {
 
   test('usernameを回転しても同一IPからの連続試行は制限される', async () => {
     const app = createApp({ maxAttemptsPerWindow: 2, windowMs: 60_000 });
+    const { agent, csrfToken } = await createCsrfReadyAgent(app);
 
-    const first = await request(app)
+    const first = await agent
       .post('/api/login')
+      .set('origin', 'http://127.0.0.1')
+      .set('host', '127.0.0.1')
+      .set('x-csrf-token', csrfToken)
       .type('form')
       .send({ username: 'admin', password: 'wrong' });
-    const second = await request(app)
+    const second = await agent
       .post('/api/login')
+      .set('origin', 'http://127.0.0.1')
+      .set('host', '127.0.0.1')
+      .set('x-csrf-token', csrfToken)
       .type('form')
       .send({ username: 'guest', password: 'wrong' });
-    const third = await request(app)
+    const third = await agent
       .post('/api/login')
+      .set('origin', 'http://127.0.0.1')
+      .set('host', '127.0.0.1')
+      .set('x-csrf-token', csrfToken)
       .type('form')
       .send({ username: 'root', password: 'wrong' });
 
@@ -123,17 +167,24 @@ describe('setRouterApiLogin (middle)', () => {
 
   test('ロック期間経過後は再試行可能', async () => {
     const app = createApp({ maxAttemptsPerWindow: 100, windowMs: 60_000 });
+    const { agent, csrfToken } = await createCsrfReadyAgent(app);
 
       for (let i = 0; i < 3; i += 1) {
-        const response = await request(app)
+        const response = await agent
           .post('/api/login')
+          .set('origin', 'http://127.0.0.1')
+          .set('host', '127.0.0.1')
+          .set('x-csrf-token', csrfToken)
           .type('form')
           .send({ username: 'admin', password: 'wrong' });
         expect(response.status).toBe(200);
       }
 
-      const lockedResponse = await request(app)
+      const lockedResponse = await agent
         .post('/api/login')
+        .set('origin', 'http://127.0.0.1')
+        .set('host', '127.0.0.1')
+        .set('x-csrf-token', csrfToken)
         .type('form')
         .send({ username: 'admin', password: 'secret' });
 
@@ -142,8 +193,11 @@ describe('setRouterApiLogin (middle)', () => {
 
     await new Promise(resolve => setTimeout(resolve, 1_100));
 
-      const retryResponse = await request(app)
+      const retryResponse = await agent
         .post('/api/login')
+        .set('origin', 'http://127.0.0.1')
+        .set('host', '127.0.0.1')
+        .set('x-csrf-token', csrfToken)
         .type('form')
         .send({ username: 'admin', password: 'secret' });
 
@@ -153,17 +207,24 @@ describe('setRouterApiLogin (middle)', () => {
 
   test('成功時に失敗カウンタがリセットされる', async () => {
     const app = createApp({ maxAttemptsPerWindow: 100, windowMs: 60_000 });
+    const { agent, csrfToken } = await createCsrfReadyAgent(app);
 
       for (let i = 0; i < 2; i += 1) {
-        const response = await request(app)
+        const response = await agent
           .post('/api/login')
+          .set('origin', 'http://127.0.0.1')
+          .set('host', '127.0.0.1')
+          .set('x-csrf-token', csrfToken)
           .type('form')
           .send({ username: 'admin', password: 'wrong' });
         expect(response.status).toBe(200);
       }
 
-      const success = await request(app)
+      const success = await agent
         .post('/api/login')
+        .set('origin', 'http://127.0.0.1')
+        .set('host', '127.0.0.1')
+        .set('x-csrf-token', csrfToken)
         .type('form')
         .send({ username: 'admin', password: 'secret' });
 
@@ -171,15 +232,21 @@ describe('setRouterApiLogin (middle)', () => {
       expect(success.body).toEqual({ code: 0 });
 
       for (let i = 0; i < 2; i += 1) {
-        const response = await request(app)
+        const response = await agent
           .post('/api/login')
+          .set('origin', 'http://127.0.0.1')
+          .set('host', '127.0.0.1')
+          .set('x-csrf-token', csrfToken)
           .type('form')
           .send({ username: 'admin', password: 'wrong' });
         expect(response.status).toBe(200);
       }
 
-      const shouldNotLockYet = await request(app)
+      const shouldNotLockYet = await agent
         .post('/api/login')
+        .set('origin', 'http://127.0.0.1')
+        .set('host', '127.0.0.1')
+        .set('x-csrf-token', csrfToken)
         .type('form')
         .send({ username: 'admin', password: 'secret' });
 

--- a/__tests__/medium/controller/router/user/setRouterApiLogout.test.js
+++ b/__tests__/medium/controller/router/user/setRouterApiLogout.test.js
@@ -23,6 +23,18 @@ const extractCsrfToken = cookies => {
 };
 
 describe('setRouterApiLogout (middle)', () => {
+  const createCsrfReadyAgent = async app => {
+    const agent = request.agent(app);
+    const bootstrapResponse = await agent
+      .get('/screen/login')
+      .set('origin', 'http://127.0.0.1')
+      .set('host', '127.0.0.1');
+    return {
+      agent,
+      csrfToken: extractCsrfToken(bootstrapResponse.headers['set-cookie']),
+    };
+  };
+
   const createApp = ({ sessionTerminator } = {}) => {
     const app = express();
     const router = express.Router();
@@ -68,9 +80,13 @@ describe('setRouterApiLogout (middle)', () => {
 
   test('認証済みなら POST /api/logout でcode=0を返し、後続リクエストは401になる', async () => {
     const app = createApp();
+    const { agent, csrfToken } = await createCsrfReadyAgent(app);
 
-    const loginResponse = await request(app)
+    const loginResponse = await agent
       .post('/api/login')
+      .set('origin', 'http://127.0.0.1')
+      .set('host', '127.0.0.1')
+      .set('x-csrf-token', csrfToken)
       .type('form')
       .send({ username: 'admin', password: 'secret' });
 
@@ -112,9 +128,13 @@ describe('setRouterApiLogout (middle)', () => {
       execute: jest.fn().mockResolvedValue(false),
     };
     const app = createApp({ sessionTerminator });
+    const { agent, csrfToken } = await createCsrfReadyAgent(app);
 
-    const loginResponse = await request(app)
+    const loginResponse = await agent
       .post('/api/login')
+      .set('origin', 'http://127.0.0.1')
+      .set('host', '127.0.0.1')
+      .set('x-csrf-token', csrfToken)
       .type('form')
       .send({ username: 'admin', password: 'secret' });
 

--- a/__tests__/medium/controller/router/user/setRouterApiLogout.test.js
+++ b/__tests__/medium/controller/router/user/setRouterApiLogout.test.js
@@ -90,12 +90,11 @@ describe('setRouterApiLogout (middle)', () => {
       .type('form')
       .send({ username: 'admin', password: 'secret' });
 
-    const logoutResponse = await request(app)
+    const logoutResponse = await agent
       .post('/api/logout')
       .set('origin', 'http://127.0.0.1')
       .set('host', '127.0.0.1')
-      .set('x-csrf-token', extractCsrfToken(loginResponse.headers['set-cookie']))
-      .set('Cookie', loginResponse.headers['set-cookie']);
+      .set('x-csrf-token', csrfToken);
 
     expect(logoutResponse.status).toBe(200);
     expect(logoutResponse.body).toEqual({ code: 0 });
@@ -138,12 +137,11 @@ describe('setRouterApiLogout (middle)', () => {
       .type('form')
       .send({ username: 'admin', password: 'secret' });
 
-    const logoutResponse = await request(app)
+    const logoutResponse = await agent
       .post('/api/logout')
       .set('origin', 'http://127.0.0.1')
       .set('host', '127.0.0.1')
-      .set('x-csrf-token', extractCsrfToken(loginResponse.headers['set-cookie']))
-      .set('Cookie', loginResponse.headers['set-cookie']);
+      .set('x-csrf-token', csrfToken);
 
     expect(logoutResponse.status).toBe(200);
     expect(logoutResponse.body).toEqual({ code: 1 });

--- a/__tests__/small/controller/router/user/setRouterApiLogin.test.js
+++ b/__tests__/small/controller/router/user/setRouterApiLogin.test.js
@@ -31,20 +31,36 @@ describe('setRouterApiLogin', () => {
     setRouterApiLogin({ router, loginService, loginAttemptStore });
 
     expect(router.post).toHaveBeenCalledTimes(1);
-    const [path, rateLimiter, handler] = router.post.mock.calls[0];
+    const [path, rateLimiter, csrf, handler] = router.post.mock.calls[0];
     expect(path).toBe('/api/login');
     expect(typeof rateLimiter).toBe('function');
+    expect(typeof csrf).toBe('function');
     expect(typeof handler).toBe('function');
 
     const req = {
       ip: '127.0.0.1',
+      method: 'POST',
+      path: '/api/login',
       body: { username: 'admin', password: 'secret' },
-      session: { regenerate: jest.fn() },
+      session: { regenerate: jest.fn(), csrf_token: 'csrf-token' },
+      get: jest.fn((name) => {
+        const headers = {
+          'x-csrf-token': 'csrf-token',
+          origin: 'http://localhost',
+          host: 'localhost',
+        };
+        return headers[String(name).toLowerCase()] ?? headers[name];
+      }),
+      protocol: 'http',
+      app: { locals: { dependencies: { logger: { warn: jest.fn() } } } },
+      context: {},
     };
     const res = createRes();
 
     await rateLimiter(req, res, async () => {
-      await handler(req, res);
+      await csrf(req, res, async () => {
+        await handler(req, res);
+      });
     });
 
     expect(loginService.execute).toHaveBeenCalledTimes(1);

--- a/__tests__/small/controller/router/user/setRouterApiLogin.test.js
+++ b/__tests__/small/controller/router/user/setRouterApiLogin.test.js
@@ -52,7 +52,13 @@ describe('setRouterApiLogin', () => {
         return headers[String(name).toLowerCase()] ?? headers[name];
       }),
       protocol: 'http',
-      app: { locals: { dependencies: { logger: { warn: jest.fn() } } } },
+      app: {
+        locals: {
+          dependencies: {
+            logger: { warn: jest.fn(), info: jest.fn(), error: jest.fn() },
+          },
+        },
+      },
       context: {},
     };
     const res = createRes();

--- a/doc/5_api/openapi/paths/api/login.yaml
+++ b/doc/5_api/openapi/paths/api/login.yaml
@@ -1,7 +1,14 @@
 # /api/login
 post:
   summary: ログイン処理
-  description: ログイン成功時に session_token Cookie を発行する。
+  description: ログイン成功時に session_token Cookie を発行する。CSRFトークン検証に成功した場合のみ処理される。
+  parameters:
+    - name: X-CSRF-Token
+      in: header
+      required: true
+      schema:
+        type: string
+      description: セッションに紐づくCSRFトークン
   requestBody:
     required: true
     content:

--- a/src/controller/middleware/CsrfProtectionMiddleware.js
+++ b/src/controller/middleware/CsrfProtectionMiddleware.js
@@ -2,11 +2,11 @@ class CsrfProtectionMiddleware {
   #options;
 
   constructor({
-    excludedPaths = ['/api/login'],
+    excludedPaths = [],
     allowedOrigin,
   } = {}) {
     this.#options = {
-      excludedPaths: new Set(Array.isArray(excludedPaths) ? excludedPaths : ['/api/login']),
+      excludedPaths: new Set(Array.isArray(excludedPaths) ? excludedPaths : []),
       allowedOrigin,
     };
   }

--- a/src/controller/router/user/setRouterApiLogin.js
+++ b/src/controller/router/user/setRouterApiLogin.js
@@ -1,5 +1,6 @@
 const LoginPostController = require('../../api/LoginPostController');
 const LoginRateLimiter = require('../../middleware/LoginRateLimiter');
+const CsrfProtectionMiddleware = require('../../middleware/CsrfProtectionMiddleware');
 
 const setRouterApiLogin = ({
   router,
@@ -13,9 +14,10 @@ const setRouterApiLogin = ({
     maxAttemptsPerWindow,
     windowMs,
   });
+  const csrf = new CsrfProtectionMiddleware();
   const controller = new LoginPostController({ loginService, loginAttemptStore });
 
-  router.post('/api/login', rateLimiter.execute.bind(rateLimiter), controller.execute.bind(controller));
+  router.post('/api/login', rateLimiter.execute.bind(rateLimiter), csrf.execute.bind(csrf), controller.execute.bind(controller));
 };
 
 module.exports = setRouterApiLogin;

--- a/src/views/screen/login.ejs
+++ b/src/views/screen/login.ejs
@@ -103,6 +103,8 @@
       </div>
     </div>
     <script nonce="<%= typeof cspNonce === 'string' ? cspNonce : '' %>">
+      window.__csrfToken = <%- JSON.stringify(typeof csrfToken === 'string' ? csrfToken : '') %>;
+
       (() => {
         const form = document.getElementById("loginForm");
         const message = document.getElementById("loginMessage");
@@ -125,7 +127,8 @@
             const response = await fetch("/api/login", {
               method: "POST",
               headers: {
-                "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8"
+                "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
+                "X-CSRF-Token": window.__csrfToken || ""
               },
               body: body.toString()
             });


### PR DESCRIPTION
### Motivation
- ログインAPIがCSRF検証の除外対象になっている状態を解消し、他の更新系APIと同等の防御水準に揃えるため。 
- クライアント実装とAPI仕様の整合をとり、実装・運用・テスト時の認識齟齬を防ぐため。 

### Description
- `src/controller/middleware/CsrfProtectionMiddleware.js` の既定 `excludedPaths` を `['/api/login']` から空配列に変更し、デフォルトで `/api/login` を検証対象にしました。 
- `src/controller/router/user/setRouterApiLogin.js` に `CsrfProtectionMiddleware` を追加し、`LoginRateLimiter` の後に `csrf.execute` を通すようにしました（`router.post('/api/login', rateLimiter, csrf, controller)`）。 
- `src/views/screen/login.ejs` の送信処理で `window.__csrfToken` をセットし、`fetch('/api/login')` のヘッダに必ず `X-CSRF-Token` を付与するように変更しました。 
- OpenAPI ドキュメント `doc/5_api/openapi/paths/api/login.yaml` に `X-CSRF-Token` ヘッダを必須パラメータとして追記し、CSRF検証が前提である旨を説明に追加しました。 

### Testing
- `node --check src/controller/middleware/CsrfProtectionMiddleware.js` と `node --check src/controller/router/user/setRouterApiLogin.js` を実行して構文チェックは成功しました。 
- `npm run test:small -- --runInBand` を試行しましたが、環境に `cross-env` が存在しないため `sh: 1: cross-env: not found` で自動テストは実行できませんでした。 
- 変更後の静的構文チェックは通過していますが、統合／E2E テストは環境依存のため未実行です。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6ec169184832bbc649f63c5d8f7b3)