### PR TITLE
fix: /contents 静的配信にセキュリティヘッダと拡張子制限を適用

### DIFF
--- a/__tests__/small/app/setupMiddleware.test.js
+++ b/__tests__/small/app/setupMiddleware.test.js
@@ -218,4 +218,38 @@ describe('setupMiddleware (small)', () => {
       expect.anything(),
     );
   });
+
+  test('/contents 配信では静的配信専用ヘッダーを付与し、許可拡張子のみ配信する', () => {
+    const app = {
+      locals: {},
+      set: jest.fn(),
+      use: jest.fn(),
+    };
+
+    setupMiddleware(app, {
+      env: {
+        contentRootDirectory: '/tmp/contents',
+      },
+      dependencies: {},
+    });
+
+    const contentsUseCall = app.use.mock.calls.find(call => call[0] === '/contents');
+    expect(contentsUseCall).toBeDefined();
+    expect(contentsUseCall).toHaveLength(3);
+
+    const [, validateContentStaticPath, staticMiddleware] = contentsUseCall;
+    expect(typeof validateContentStaticPath).toBe('function');
+    expect(typeof staticMiddleware).toBe('function');
+
+    const next = jest.fn();
+    const invalidRes = { status: jest.fn().mockReturnThis(), end: jest.fn() };
+    validateContentStaticPath({ path: '/payload.html' }, invalidRes, next);
+    expect(invalidRes.status).toHaveBeenCalledWith(404);
+    expect(invalidRes.end).toHaveBeenCalledTimes(1);
+    expect(next).not.toHaveBeenCalled();
+
+    const validNext = jest.fn();
+    validateContentStaticPath({ path: '/movie.webm' }, { status: jest.fn(), end: jest.fn() }, validNext);
+    expect(validNext).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/app/setupMiddleware.js
+++ b/src/app/setupMiddleware.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const crypto = require('crypto');
 const express = require('express');
+const { ALLOWED_CONTENT_EXTENSIONS } = require('../shared/contentMimeTypes');
 
 const {
   isDevelopmentSessionExplicitlyEnabled,
@@ -94,6 +95,22 @@ const applySecurityHeaders = ({ res, isProduction, cspValue }) => {
   }
 };
 
+const validateContentStaticPath = (req, res, next) => {
+  const extension = path.extname(req.path || '').toLowerCase();
+  if (ALLOWED_CONTENT_EXTENSIONS.has(extension)) {
+    next();
+    return;
+  }
+
+  res.status(404).end();
+};
+
+const applyContentStaticHeaders = res => {
+  res.setHeader('X-Content-Type-Options', 'nosniff');
+  res.setHeader('X-Frame-Options', 'DENY');
+  res.setHeader('Referrer-Policy', 'strict-origin-when-cross-origin');
+};
+
 const setupMiddleware = (app, { env = {}, dependencies: _dependencies } = {}) => {
   app.locals = app.locals ?? {};
   if (typeof app.locals.env === 'undefined') {
@@ -103,7 +120,13 @@ const setupMiddleware = (app, { env = {}, dependencies: _dependencies } = {}) =>
   app.set('views', path.join(__dirname, '..', 'views'));
   app.set('view engine', 'ejs');
   if (typeof env.contentRootDirectory === 'string' && env.contentRootDirectory.length > 0) {
-    app.use('/contents', express.static(env.contentRootDirectory));
+    app.use(
+      '/contents',
+      validateContentStaticPath,
+      express.static(env.contentRootDirectory, {
+        setHeaders: applyContentStaticHeaders,
+      }),
+    );
   }
   app.use(express.json());
   app.use(express.urlencoded({ extended: true }));

--- a/src/infrastructure/MulterDiskStorageContentUploadAdapter.js
+++ b/src/infrastructure/MulterDiskStorageContentUploadAdapter.js
@@ -5,25 +5,13 @@ const path = require('path');
 const multer = require('multer');
 
 const IContentUploadAdapter = require('../controller/middleware/adapter/IContentUploadAdapter');
+const { ALLOWED_CONTENT_MIME_TYPES } = require('../shared/contentMimeTypes');
 
 const MAX_FILES = 100;
 const MAX_FIELDS = 500;
 const MAX_PARTS = 600;
 const MAX_FILE_SIZE = 50 * 1024 * 1024;
 const FILE_FIELD_PATTERN = /^contents\[(\d+)\]\[file\]$/;
-const IMAGE_MIME_TYPES = new Set([
-  'image/jpeg',
-  'image/png',
-  'image/gif',
-  'image/webp',
-]);
-const VIDEO_MIME_TYPES = new Set([
-  'video/mp4',
-  'video/webm',
-  'video/quicktime',
-]);
-const ALLOWED_MIME_TYPES = new Set([...IMAGE_MIME_TYPES, ...VIDEO_MIME_TYPES]);
-
 const SIGNATURE_VALIDATORS = {
   'image/jpeg': header => header.length >= 3
     && header[0] === 0xff
@@ -124,7 +112,7 @@ module.exports = class MulterDiskStorageContentUploadAdapter extends IContentUpl
           return;
         }
 
-        if (!ALLOWED_MIME_TYPES.has(file.mimetype)) {
+        if (!ALLOWED_CONTENT_MIME_TYPES.has(file.mimetype)) {
           cb(createUploadError({
             message: 'invalid mime type',
             reason: 'type',

--- a/src/shared/contentMimeTypes.js
+++ b/src/shared/contentMimeTypes.js
@@ -1,0 +1,26 @@
+const ALLOWED_CONTENT_MIME_TYPES = new Set([
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+  'video/mp4',
+  'video/webm',
+  'video/quicktime',
+]);
+
+const ALLOWED_CONTENT_EXTENSIONS = new Set([
+  '',
+  '.jpg',
+  '.jpeg',
+  '.png',
+  '.gif',
+  '.webp',
+  '.mp4',
+  '.webm',
+  '.mov',
+]);
+
+module.exports = {
+  ALLOWED_CONTENT_MIME_TYPES,
+  ALLOWED_CONTENT_EXTENSIONS,
+};


### PR DESCRIPTION
### Motivation
- `express.static` 経由の `/contents` 配信には共通ミドルウェアで付与するセキュリティヘッダが乗らない経路があり、`text/html` 等の意図しないコンテンツが返るリスクが存在していた。 
- アップロード許可の MIME リストと静的配信の許可拡張子が分離していると将来の差分で整合が崩れるため、一元管理したい。 
- 静的配信時にも `X-Content-Type-Options: nosniff` / `X-Frame-Options: DENY` / `Referrer-Policy` を確実に付与して防御層を強化する必要があった。 

### Description
- 新規ファイル `src/shared/contentMimeTypes.js` を追加し、`ALLOWED_CONTENT_MIME_TYPES` と `ALLOWED_CONTENT_EXTENSIONS` を定義して許可セットを共有化しました。 
- `src/app/setupMiddleware.js` の `/contents` ルートを `validateContentStaticPath` ガード → `express.static(..., { setHeaders })` の順で登録し、不許可拡張子は `404` を応答し、静的レスポンスには `setHeaders` で `nosniff` / `DENY` / `Referrer-Policy` を付与するようにしました。 
- アップロード処理の `src/infrastructure/MulterDiskStorageContentUploadAdapter.js` を更新してローカル定義ではなく共有の `ALLOWED_CONTENT_MIME_TYPES` を参照するように変更し、配信側とアップロード側の整合性を向上させました。 
- `/contents` のガード挙動を検証する小テストを `__tests__/small/app/setupMiddleware.test.js` に追加しました。 

### Testing
- 試行した自動テストコマンド：`npm run test:small -- __tests__/small/app/setupMiddleware.test.js __tests__/small/infrastructure/MulterDiskStorageContentUploadAdapter.test.js` はローカル環境で `cross-env: not found` のため実行できませんでした。 
- 依存取得を試みた結果：`npm install --include=dev` は `ENOTEMPTY` エラーで失敗し、個別の依存インストール `npm install cross-env jest` はレジストリアクセスで `403 Forbidden` により失敗しました。 
- 変更はユニットテストを追加済みでコミットしていますが、環境依存のため CI/ローカルでの全自動実行は未完了です。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d77f1997f8832b8f078fa93ef36f27)