### PR TITLE
feat: サーバー起動時のホスト解決と公開範囲可視化を追加する

### DIFF
--- a/__tests__/medium/app/developmentSession.integration.test.js
+++ b/__tests__/medium/app/developmentSession.integration.test.js
@@ -113,7 +113,7 @@ describe('developmentSession wiring', () => {
     const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {
       throw new Error('process.exit should not be called');
     });
-    const listenMock = jest.fn((port, callback) => {
+    const listenMock = jest.fn((port, host, callback) => {
       callback();
       return { on: jest.fn() };
     });
@@ -137,7 +137,7 @@ describe('developmentSession wiring', () => {
     require('../../../src/server');
     await Promise.resolve();
 
-    expect(listenMock).toHaveBeenCalledWith(3456, expect.any(Function));
+    expect(listenMock).toHaveBeenCalledWith(3456, '127.0.0.1', expect.any(Function));
     expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining('開発用固定セッションを有効化しました'));
     expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('開発用固定セッションは無効です: ENABLE_DEV_SESSION が未指定のため適用しません'));
     expect(errorSpy).not.toHaveBeenCalled();
@@ -148,7 +148,7 @@ describe('developmentSession wiring', () => {
     const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {});
-    const listenMock = jest.fn((port, callback) => {
+    const listenMock = jest.fn((port, host, callback) => {
       callback();
       return { on: jest.fn() };
     });
@@ -186,7 +186,7 @@ describe('developmentSession wiring', () => {
     const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {});
-    const listenMock = jest.fn((port, callback) => {
+    const listenMock = jest.fn((port, host, callback) => {
       callback();
       return { on: jest.fn() };
     });
@@ -211,7 +211,7 @@ describe('developmentSession wiring', () => {
     require('../../../src/server');
     await Promise.resolve();
 
-    expect(listenMock).toHaveBeenCalledWith(3458, expect.any(Function));
+    expect(listenMock).toHaveBeenCalledWith(3458, '127.0.0.1', expect.any(Function));
     expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('サーバーを起動しました'));
     expect(errorSpy).not.toHaveBeenCalled();
     expect(exitSpy).not.toHaveBeenCalled();
@@ -221,7 +221,7 @@ describe('developmentSession wiring', () => {
     const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {});
-    const listenMock = jest.fn((port, callback) => {
+    const listenMock = jest.fn((port, host, callback) => {
       callback();
       return { on: jest.fn() };
     });
@@ -259,7 +259,7 @@ describe('developmentSession wiring', () => {
     const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {});
-    const listenMock = jest.fn((port, callback) => {
+    const listenMock = jest.fn((port, host, callback) => {
       callback();
       return { on: jest.fn() };
     });
@@ -295,5 +295,68 @@ describe('developmentSession wiring', () => {
       expect.any(Error),
     );
     expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  test('server.js 相当の初期化では production かつ SERVER_HOST=0.0.0.0 の指定を許可する', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {});
+    const listenMock = jest.fn((port, host, callback) => {
+      callback();
+      return { on: jest.fn() };
+    });
+
+    process.env.NODE_ENV = 'production';
+    process.env.PORT = '3461';
+    process.env.SERVER_HOST = '0.0.0.0';
+    process.env.FIXED_LOGIN_USERNAME = 'admin-user';
+    process.env.FIXED_LOGIN_PASSWORD = 'admin-password';
+    process.env.FIXED_LOGIN_USER_ID = 'admin-user-id';
+    process.env.LOGIN_USERNAME = 'admin-user';
+    process.env.LOGIN_PASSWORD = 'admin-password';
+    process.env.LOGIN_USER_ID = 'admin-user-id';
+
+    jest.doMock('../../../src/app', () => jest.fn(() => ({
+      locals: {
+        ready: Promise.resolve(),
+      },
+      listen: listenMock,
+    })));
+
+    require('../../../src/server');
+    await Promise.resolve();
+
+    expect(listenMock).toHaveBeenCalledWith(3461, '0.0.0.0', expect.any(Function));
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  test('server.js 相当の初期化では non-production で SERVER_HOST=0.0.0.0 指定時に 127.0.0.1 へフォールバックする', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {});
+    const listenMock = jest.fn((port, host, callback) => {
+      callback();
+      return { on: jest.fn() };
+    });
+
+    process.env.NODE_ENV = 'development';
+    process.env.PORT = '3462';
+    process.env.SERVER_HOST = '0.0.0.0';
+    process.env.LOGIN_USERNAME = 'admin-user';
+    process.env.LOGIN_PASSWORD = 'admin-password';
+    process.env.LOGIN_USER_ID = 'admin-user-id';
+
+    jest.doMock('../../../src/app', () => jest.fn(() => ({
+      locals: {
+        ready: Promise.resolve(),
+      },
+      listen: listenMock,
+    })));
+
+    require('../../../src/server');
+    await Promise.resolve();
+
+    expect(listenMock).toHaveBeenCalledWith(3462, '127.0.0.1', expect.any(Function));
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(exitSpy).not.toHaveBeenCalled();
   });
 });

--- a/doc/4_application/app/server/readme.md
+++ b/doc/4_application/app/server/readme.md
@@ -72,4 +72,5 @@
 - 開発用固定セッションを使う場合は、`ENABLE_DEV_SESSION=true` を明示して起動する。
 - 本リポジトリでは `npm run dev:entry` が `ENABLE_DEV_SESSION=true` を付与した開発用起動コマンドになっている。
 - 外部公開が必要な運用（例: リバースプロキシ背後の本番公開）でのみ `NODE_ENV=production` かつ `SERVER_HOST=0.0.0.0` を明示する。
+- Docker Compose で `ports` 公開する場合は、コンテナ外から疎通できるように `SERVER_HOST=0.0.0.0` を必ず設定する。
 - 開発・検証用途では `SERVER_HOST` 未指定（既定値 `127.0.0.1`）を推奨し、不要な外部公開を防止する。

--- a/doc/4_application/app/server/readme.md
+++ b/doc/4_application/app/server/readme.md
@@ -13,6 +13,7 @@
 | 環境変数 | `env` 項目 | 既定値 / 変換 | 用途 |
 | --- | --- | --- | --- |
 | `PORT` | `port` | `parseInt(..., 10) || 3000` | HTTP listen ポート |
+| `SERVER_HOST` (`HOST` 互換) | `host` | 未指定時 `127.0.0.1`。`0.0.0.0` は `NODE_ENV=production` のときのみ許可し、それ以外は `127.0.0.1` へフォールバック | HTTP listen バインドアドレス |
 | `DATABASE_STORAGE_PATH` | `databaseStoragePath` | `var/data/mangaviewer.sqlite` | SQLite 保存先 |
 | `CONTENT_ROOT_DIRECTORY` | `contentRootDirectory` | `public/contents` | コンテンツ保存先 |
 | `DEV_SESSION_TOKEN` | `devSessionToken` | 空文字 | 開発用固定セッショントークン |
@@ -27,6 +28,10 @@
 
 ## `createEnv` の仕様
 - `process.env` から文字列値を読み取り、アプリ内部で扱いやすい `env` オブジェクトへ変換する。
+- `SERVER_HOST`（互換として `HOST`）は以下の規則で `env.host` を解決する。
+  - 未指定時は `127.0.0.1` を採用する。
+  - `0.0.0.0` が指定された場合は、`NODE_ENV=production` のときのみ採用する。
+  - `NODE_ENV` が `production` 以外で `0.0.0.0` が指定された場合は `127.0.0.1` へフォールバックする。
 - `DEV_SESSION_PATHS` は `parseSessionPaths` により、以下の規則で `string[]` へ変換する。
   - カンマ区切りで分割する。
   - 各要素の前後空白を除去する。
@@ -38,8 +43,8 @@
 2. `createApp(env)` で Express アプリを生成する。
 3. `await app.locals.ready` で初期化完了を待機する。
 4. 初期化失敗時は `console.error('アプリケーションの初期化に失敗しました', error)` を出力し、`process.exit(1)` で終了する。
-5. 初期化成功時のみ `app.listen(env.port, ...)` を実行する。
-6. listen 成功コールバックで `サーバーを起動しました: port=...` を出力する。
+5. 初期化成功時のみ `app.listen(env.port, env.host, ...)` を実行する。
+6. listen 成功コールバックで `サーバーを起動しました: host=..., port=...` を出力する。
 7. `NODE_ENV !== production` かつ `ENABLE_DEV_SESSION` が未指定の場合は、固定セッションが無効である旨を起動ログへ出力する。
 8. `hasDevelopmentSession(env)` が `true` の場合は、固定セッション有効化ログも追加出力する。
 9. `server.on('error', ...)` で起動失敗を監視し、失敗時は `process.exit(1)` で終了する。
@@ -66,3 +71,5 @@
 ## 運用メモ
 - 開発用固定セッションを使う場合は、`ENABLE_DEV_SESSION=true` を明示して起動する。
 - 本リポジトリでは `npm run dev:entry` が `ENABLE_DEV_SESSION=true` を付与した開発用起動コマンドになっている。
+- 外部公開が必要な運用（例: リバースプロキシ背後の本番公開）でのみ `NODE_ENV=production` かつ `SERVER_HOST=0.0.0.0` を明示する。
+- 開発・検証用途では `SERVER_HOST` 未指定（既定値 `127.0.0.1`）を推奨し、不要な外部公開を防止する。

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     environment:
       PORT: 3000
       NODE_ENV: production
+      SERVER_HOST: 0.0.0.0
       DATABASE_DIALECT: postgres
       DATABASE_HOST: db
       DATABASE_PORT: 5432

--- a/src/server.js
+++ b/src/server.js
@@ -16,10 +16,24 @@ const parseSessionPaths = value => (value || '')
 
 const isConfigured = value => String(value || '').trim().length > 0;
 const isNonProduction = nodeEnv => String(nodeEnv || '').toLowerCase() !== 'production';
+const isProduction = nodeEnv => String(nodeEnv || '').toLowerCase() === 'production';
+
+const resolveServerHost = (source = {}) => {
+  const requestedHost = String(source.SERVER_HOST || source.HOST || '').trim();
+  if (!requestedHost) {
+    return '127.0.0.1';
+  }
+  if (requestedHost !== '0.0.0.0') {
+    return requestedHost;
+  }
+  if (isProduction(source.NODE_ENV)) {
+    return '0.0.0.0';
+  }
+  return '127.0.0.1';
+};
 
 const assertDevelopmentSessionConfigurationAllowed = (env, source = {}) => {
-  const isProduction = String(env.nodeEnv || '').toLowerCase() === 'production';
-  if (!isProduction) {
+  if (!isProduction(env.nodeEnv)) {
     return;
   }
 
@@ -42,6 +56,7 @@ const assertDevelopmentSessionConfigurationAllowed = (env, source = {}) => {
 const createEnv = source => ({
   nodeEnv: source.NODE_ENV || 'development',
   port: Number.parseInt(source.PORT, 10) || 3000,
+  host: resolveServerHost(source),
   databaseDialect: source.DATABASE_DIALECT || 'sqlite',
   databaseUrl: source.DATABASE_URL || '',
   databaseHost: source.DATABASE_HOST || '',
@@ -112,8 +127,8 @@ const startServer = async () => {
     return;
   }
 
-  const server = app.listen(env.port, () => {
-    console.log(`サーバーを起動しました: port=${env.port}`);
+  const server = app.listen(env.port, env.host, () => {
+    console.log(`サーバーを起動しました: host=${env.host}, port=${env.port}`);
 
     if (isNonProduction(env.nodeEnv) && !isConfigured(process.env.ENABLE_DEV_SESSION)) {
       console.log('開発用固定セッションは無効です: ENABLE_DEV_SESSION が未指定のため適用しません');


### PR DESCRIPTION
### Motivation
- デフォルトでローカルバインド（127.0.0.1）とし、開発環境で意図せず外部公開されるリスクを低減するため。 
- 外部公開（0.0.0.0）を `NODE_ENV=production` に限定して運用上の意思表示を明確化するため。 
- 実際のバインド先を起動ログへ出力して、公開範囲を運用時に即時確認できるようにするため。

### Description
- `src/server.js` に `resolveServerHost` を追加して `SERVER_HOST` / `HOST` を解決し、未指定は `127.0.0.1`、`0.0.0.0` は `NODE_ENV=production` のときのみ許可するロジックを実装しました。 
- 既存の `createEnv` に `host` 項目を追加して `resolveServerHost` の結果を格納するようにしました。 
- `app.listen` を `app.listen(env.port, env.host, ...)` に変更し、起動ログを `host=..., port=...` を含めるようにしました。 
- 関連の統合テスト (`__tests__/medium/app/developmentSession.integration.test.js`) を更新・拡張し、`listen` の host 引数を検証するように変更するとともに `SERVER_HOST=0.0.0.0` の production/non-production の挙動を追加でテストするケースを追加しました。 
- 起動設計書 (`doc/4_application/app/server/readme.md`) に `SERVER_HOST` の仕様、`createEnv` の振る舞い、`app.listen` のシグネチャ変更、および運用方針（外部公開は production かつ `SERVER_HOST=0.0.0.0` を明示）を追記しました.

### Testing
- `node --check src/server.js` を実行して構文チェックを行い成功しました。 
- `node --check __tests__/medium/app/developmentSession.integration.test.js` を実行して構文チェックを行い成功しました。 
- `npm run test:medium` / `jest` による完全な実行はこの環境で依存ツール (`cross-env` / `jest`) が利用できない（ネットワーク制限または未インストール）ため実行できませんでした; CI 環境または依存を解決したローカル環境で `npm run test:medium` を実行して統合テスト全体の確認をお願いします。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d78b9c571c832b8bfd66e3251cbc4f)