### PR TITLE
fix: ALLOW_INSECURE_DEFAULT_LOGIN を常時拒否し起動を fail-close 化

### DIFF
--- a/__tests__/medium/app/createDependencies.login.test.js
+++ b/__tests__/medium/app/createDependencies.login.test.js
@@ -99,13 +99,8 @@ describe('createDependencies login wiring', () => {
     expect(result).toBeInstanceOf(LoginSucceededResult);
   });
 
-  test('ALLOW_INSECURE_DEFAULT_LOGIN=true の場合のみデフォルト資格情報でログインできる', async () => {
-    if (dependencies) {
-      await dependencies.close();
-      dependencies = undefined;
-    }
-
-    dependencies = createDependencies({
+  test('ALLOW_INSECURE_DEFAULT_LOGIN=true は development でも拒否して初期化失敗する', () => {
+    expect(() => createDependencies({
       nodeEnv: 'development',
       allowInsecureDefaultLogin: 'true',
       databaseStoragePath: path.join(databaseRoot, 'development.sqlite'),
@@ -113,22 +108,7 @@ describe('createDependencies login wiring', () => {
       loginUsername: '',
       loginPassword: '',
       loginUserId: '',
-      loginSessionTtlMs: 60_000,
-    });
-    await dependencies.ready;
-
-    const session = {
-      regenerate: jest.fn((callback) => callback()),
-    };
-
-    const result = await dependencies.loginService.execute(new Query({
-      username: 'admin',
-      password: 'admin',
-      session,
-    }));
-
-    expect(result).toBeInstanceOf(LoginSucceededResult);
-    await expect(dependencies.authResolver.execute(result.sessionToken)).resolves.toBe('admin');
+    })).toThrow('ALLOW_INSECURE_DEFAULT_LOGIN=true は許可できません');
   });
 
   test('production では ALLOW_INSECURE_DEFAULT_LOGIN=true を拒否して初期化失敗する', () => {
@@ -140,7 +120,7 @@ describe('createDependencies login wiring', () => {
       loginUsername: '',
       loginPassword: '',
       loginUserId: '',
-    })).toThrow('本番環境では ALLOW_INSECURE_DEFAULT_LOGIN=true を許可できません');
+    })).toThrow('ALLOW_INSECURE_DEFAULT_LOGIN=true は許可できません');
   });
 
   test('既知の弱い固定パスワードは拒否して初期化失敗する', () => {

--- a/__tests__/medium/app/developmentSession.integration.test.js
+++ b/__tests__/medium/app/developmentSession.integration.test.js
@@ -183,7 +183,7 @@ describe('developmentSession wiring', () => {
     expect(exitSpy).toHaveBeenCalledWith(1);
   });
 
-  test('server.js 相当の初期化では明示フラグ有効時に insecure デフォルト資格情報で起動できる', async () => {
+  test('server.js 相当の初期化では development でも ALLOW_INSECURE_DEFAULT_LOGIN=true 指定時に起動を中止する', async () => {
     const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {});
@@ -212,10 +212,13 @@ describe('developmentSession wiring', () => {
     require('../../../src/server');
     await Promise.resolve();
 
-    expect(listenMock).toHaveBeenCalledWith(3458, '127.0.0.1', expect.any(Function));
-    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('サーバーを起動しました'));
-    expect(errorSpy).not.toHaveBeenCalled();
-    expect(exitSpy).not.toHaveBeenCalled();
+    expect(listenMock).not.toHaveBeenCalled();
+    expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining('サーバーを起動しました'));
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('サーバーの起動を中止しました: ALLOW_INSECURE_DEFAULT_LOGIN=true は使用できません'),
+      expect.any(Error),
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
   });
 
   test('server.js 相当の初期化では production かつ insecure login 指定時に起動を中止する', async () => {
@@ -250,7 +253,7 @@ describe('developmentSession wiring', () => {
     expect(listenMock).not.toHaveBeenCalled();
     expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining('サーバーを起動しました'));
     expect(errorSpy).toHaveBeenCalledWith(
-      expect.stringContaining('サーバーの起動を中止しました: 本番環境で insecure login(ALLOW_INSECURE_DEFAULT_LOGIN=true) は禁止されています'),
+      expect.stringContaining('サーバーの起動を中止しました: ALLOW_INSECURE_DEFAULT_LOGIN=true は使用できません'),
       expect.any(Error),
     );
     expect(exitSpy).toHaveBeenCalledWith(1);

--- a/__tests__/small/app/createApp.test.js
+++ b/__tests__/small/app/createApp.test.js
@@ -175,4 +175,15 @@ describe('createApp', () => {
       mediaId: expect.stringMatching(/^[0-9a-f]{32}$/),
     });
   });
+
+  test('ALLOW_INSECURE_DEFAULT_LOGIN=true を指定しても弱いデフォルト認証は有効化されない', () => {
+    expect(() => createApp({
+      databaseStoragePath: databasePath,
+      contentRootDirectory,
+      loginUsername: '',
+      loginPassword: '',
+      loginUserId: '',
+      allowInsecureDefaultLogin: 'true',
+    })).toThrow('ALLOW_INSECURE_DEFAULT_LOGIN=true は許可できません');
+  });
 });

--- a/doc/README.md
+++ b/doc/README.md
@@ -27,18 +27,24 @@ MediaViewerは、漫画・動画などの複数種類のメディアを閲覧可
   - `FIXED_LOGIN_USER_ID`（または `LOGIN_USER_ID`）
   - `FIXED_LOGIN_USERNAME`（または `LOGIN_USERNAME`）
   - `FIXED_LOGIN_PASSWORD` または `FIXED_LOGIN_PASSWORD_HASH`（`LOGIN_*` 系でも可）
-- 任意（開発時の一時回避）
-  - `ALLOW_INSECURE_DEFAULT_LOGIN=true`
-    - 明示指定時のみ `admin/admin` の簡易ログインを許可する。
-    - CI・本番では設定しないこと。
+- 禁止事項
+  - `ALLOW_INSECURE_DEFAULT_LOGIN=true` は **ローカル開発を含め常時禁止**。
+  - `admin/admin` のような弱いデフォルト認証を恒常運用しない。
 
 `.env.example` には変数名のみを置き、実値は安全な共有手段（シークレットマネージャーなど）で管理すること。
+
+### 初回起動時の必須設定手順
+1. `.env` または Secret に `FIXED_LOGIN_USER_ID`（または `LOGIN_USER_ID`）を設定する。
+2. `.env` または Secret に `FIXED_LOGIN_USERNAME`（または `LOGIN_USERNAME`）を設定する。
+3. `.env` または Secret に `FIXED_LOGIN_PASSWORD` または `FIXED_LOGIN_PASSWORD_HASH`（`LOGIN_*` 系でも可）を設定する。
+4. `APP_ORIGIN` を設定する（例: `http://127.0.0.1:3000`）。
+5. `ALLOW_INSECURE_DEFAULT_LOGIN` を設定しない（または `false` を明示）ことを確認する。
+6. `npm run start` で起動し、設定漏れや禁止設定があれば fail-close で起動失敗することを確認する。
 
 ### 移行手順（既存運用向け）
 1. 既存の `.env` / Secret 設定に `*_LOGIN_USER_ID` / `*_LOGIN_USERNAME` / `*_LOGIN_PASSWORD or *_LOGIN_PASSWORD_HASH` を必ず追加する。
 2. `ALLOW_INSECURE_DEFAULT_LOGIN` を未設定（または `false`）にする。
 3. CI/CD で `npm run start` もしくは起動ヘルスチェックを実行し、設定漏れがあれば起動失敗で検知する。
-4. やむを得ずローカル開発でのみ簡易ログインが必要な場合に限り、個人環境で `ALLOW_INSECURE_DEFAULT_LOGIN=true` を一時設定する（コミットしない）。
 
 ### npm script の用途
 - `npm run start`

--- a/src/app/createDependencies.js
+++ b/src/app/createDependencies.js
@@ -84,9 +84,9 @@ const resolveLoginHashOptions = env => ({
 const resolveLoginAuthConfig = env => {
   const isProduction = String(env.nodeEnv || '').toLowerCase() === 'production';
   const isAllowedInsecureDefaultLogin = String(env.allowInsecureDefaultLogin || '').toLowerCase() === 'true';
-  if (isProduction && isAllowedInsecureDefaultLogin) {
-    const error = new Error('本番環境では ALLOW_INSECURE_DEFAULT_LOGIN=true を許可できません');
-    error.code = 'INSECURE_DEFAULT_LOGIN_DISALLOWED_IN_PRODUCTION';
+  if (isAllowedInsecureDefaultLogin) {
+    const error = new Error('ALLOW_INSECURE_DEFAULT_LOGIN=true は許可できません');
+    error.code = 'INSECURE_DEFAULT_LOGIN_DISALLOWED';
     throw error;
   }
 
@@ -110,17 +110,6 @@ const resolveLoginAuthConfig = env => {
       `missing=${missingKeys.join(',')}`,
       '必要な設定: LOGIN_USERNAME(or FIXED_LOGIN_USERNAME), LOGIN_USER_ID(or FIXED_LOGIN_USER_ID), LOGIN_PASSWORDまたはLOGIN_PASSWORD_HASH',
     ].join(': '));
-  }
-
-  if (isAllowedInsecureDefaultLogin && missingKeys.length > 0) {
-    return {
-      username: 'admin',
-      password: 'admin',
-      passwordHash: '',
-      userId: 'admin',
-      isUsingDefaultCredentials: true,
-      isInsecureDefaultLoginEnabled: true,
-    };
   }
 
   if (isProduction && isConfiguredValue(rawConfig.password)) {

--- a/src/server.js
+++ b/src/server.js
@@ -136,8 +136,8 @@ const startServer = async () => {
       process.exit(1);
       return;
     }
-    if (error?.code === 'INSECURE_DEFAULT_LOGIN_DISALLOWED_IN_PRODUCTION') {
-      console.error('サーバーの起動を中止しました: 本番環境で insecure login(ALLOW_INSECURE_DEFAULT_LOGIN=true) は禁止されています', error);
+    if (error?.code === 'INSECURE_DEFAULT_LOGIN_DISALLOWED') {
+      console.error('サーバーの起動を中止しました: ALLOW_INSECURE_DEFAULT_LOGIN=true は使用できません', error);
       process.exit(1);
       return;
     }


### PR DESCRIPTION
### Motivation
- ローカル環境や誤設定で `admin/admin` のような弱いデフォルト認証が恒常的に有効化されるリスクを排除するため。 

### Description
- `src/app/createDependencies.js` の `resolveLoginAuthConfig` から `ALLOW_INSECURE_DEFAULT_LOGIN` によるフォールバック経路を削除し、設定が存在する場合は即時エラーとするよう変更しました。 
- `src/server.js` の起動時エラーハンドリングで `ALLOW_INSECURE_DEFAULT_LOGIN=true` 検出時に警告ではなく起動中止（fail-close）するよう統一しました。 
- `doc/README.md` に「ローカルを含め弱い認証の恒常利用禁止」と「初回起動時に必須となる環境変数設定手順（`APP_ORIGIN` 等）」を追記しました。 
- 関連テストを更新して `ALLOW_INSECURE_DEFAULT_LOGIN=true` が有効化されないことを検証するケースを追加・修正しました（`__tests__/small/app/createApp.test.js`、`__tests__/medium/app/createDependencies.login.test.js`、`__tests__/medium/app/developmentSession.integration.test.js`）。

### Testing
- 変更したテスト群を修正・追加し、`ALLOW_INSECURE_DEFAULT_LOGIN=true` が `development` / `production` いずれでも拒否されることを期待するアサーションを追加しました。 
- ローカルでの自動実行は試みましたが、`cross-env` が存在しないため `npm run test:small` は実行できませんでした。 
- `npx jest ...` による実行は外部 npm registry へのアクセス制限（`403 Forbidden`）のため完走できませんでした。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7cb0ef45c832b801bb16f7c191af5)