### PR TITLE
fix: Docker起動時のログイン認証情報を必須環境変数として明確化する

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,9 @@ DATABASE_STORAGE_PATH=
 CONTENT_ROOT_DIRECTORY=
 
 FIXED_LOGIN_USER_ID=
+# 必須: 各ユーザーで固有値を必ず設定する（共通値・デフォルト値の使い回し禁止）
 FIXED_LOGIN_USERNAME=
+# 必須: 平文またはハッシュのいずれかを必ず設定する（各ユーザーごとに設定）
 FIXED_LOGIN_PASSWORD=
 FIXED_LOGIN_PASSWORD_HASH=
 # true の場合のみ未設定時に insecure な admin/admin フォールバックを有効化（開発限定）

--- a/doc/README.md
+++ b/doc/README.md
@@ -27,6 +27,7 @@ MediaViewerは、漫画・動画などの複数種類のメディアを閲覧可
   - `FIXED_LOGIN_USER_ID`（または `LOGIN_USER_ID`）
   - `FIXED_LOGIN_USERNAME`（または `LOGIN_USERNAME`）
   - `FIXED_LOGIN_PASSWORD` または `FIXED_LOGIN_PASSWORD_HASH`（`LOGIN_*` 系でも可）
+  - 上記ログイン認証情報は**必ずユーザーごとに個別の値を設定**し、共通値・デフォルト値を使い回さないこと。
 - 禁止事項
   - `ALLOW_INSECURE_DEFAULT_LOGIN=true` は **ローカル開発を含め常時禁止**。
   - `admin/admin` のような弱いデフォルト認証を恒常運用しない。
@@ -69,6 +70,7 @@ MediaViewerは、漫画・動画などの複数種類のメディアを閲覧可
 ### 起動方法
 1. プロジェクトルートで以下を実行する
    - `docker compose up --build -d`
+   - `LOGIN_USERNAME` / `LOGIN_PASSWORD_HASH` など必須認証設定が未設定の場合、起動エラーになるのが正しい挙動。
 2. アプリケーションにアクセスする
    - `http://localhost:3000`
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,8 +18,8 @@ services:
       CONTENT_ROOT_DIRECTORY: /app/var/contents
       LOG_FILE_PATH: /app/var/logs/mangaviewer.log
       LOGIN_USER_ID: ${LOGIN_USER_ID:-mangaviewer-admin}
-      LOGIN_USERNAME: ${LOGIN_USERNAME:-mangaviewer-admin}
-      LOGIN_PASSWORD_HASH: ${LOGIN_PASSWORD_HASH:-2d3578888d9a9f46dbfd601ce8969d43685f4f3f1f8f9f0438f1dcfb8778dd53}
+      LOGIN_USERNAME: ${LOGIN_USERNAME}
+      LOGIN_PASSWORD_HASH: ${LOGIN_PASSWORD_HASH}
     ports:
       - "3000:3000"
     volumes:


### PR DESCRIPTION
### Motivation
- `createDependencies.js` の `resolveLoginAuthConfig` は認証情報不足時に例外で停止する fail-close 設計であるため、Compose 側に暗黙的なフォールバック値が残っていると設定漏れを見逃す恐れがある。 
- 起動時に誤って共通／既定の認証情報で動作するリスクを排除し、運用上の安全性を高めるため。 

### Description
- `docker-compose.yml` の `app.environment` から `LOGIN_USERNAME` と `LOGIN_PASSWORD_HASH` のフォールバック値（`${...:-...}`）を削除して、これらを必須の環境変数として扱うように変更しました。 
- `.env.example` に「各ユーザーで固有値を必ず設定する」旨と「平文またはハッシュのいずれかを必ず設定する」旨の注意書きを追加しました。 
- `doc/README.md` の固定ユーザー設定セクションへ、認証情報は必ずユーザーごとに個別設定することと、Docker 起動手順に「必須認証設定未入力時は起動エラーになるのが正しい挙動」であることを追記しました。 
- 実装仕様（`resolveLoginAuthConfig` が不足時に例外を投げる）とドキュメント／Compose 設定を整合させましたが、アプリ本体の例外動作自体は変更していません。 

### Testing
- リポジトリ内ファイル差分確認のために `git status --short` と `git diff -- docker-compose.yml .env.example doc/README.md` を実行し、意図した差分が作られていることを確認しました（成功）。 
- 変更内容の抜粋確認に `nl -ba docker-compose.yml | sed -n '12,30p'`、`nl -ba .env.example | sed -n '1,25p'`、`nl -ba doc/README.md | sed -n '20,90p'` を実行し、追記が反映されていることを確認しました（成功）。 
- 変更をステージしてコミットを行い（コミット成功）、該当ファイル群の更新がリポジトリに記録されていることを確認しました（成功）。 
- ユニット／統合テストの自動実行は行っておらず、起動時の動作確認は行っていないため、`docker compose up` 等による実環境での起動検証は別途実施してください。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7d1e8e41c832b99b99536dfe3130b)