### PR TITLE
refactor: 固定ログイン設定からユーザー名設定を廃止しユーザーIDへ統一する

### DIFF
--- a/__tests__/large/e2e/detail/detail-favorite-queue-actions.large.test.js
+++ b/__tests__/large/e2e/detail/detail-favorite-queue-actions.large.test.js
@@ -58,7 +58,6 @@ test.describe('large e2e: 詳細画面から favorite/queue の追加と解除�
     app = createApp({
       databaseStoragePath: tempDatabasePath,
       contentRootDirectory: tempContentDirectory,
-      loginUsername: 'admin',
       loginPassword: 'admin',
       loginUserId: 'admin',
       loginSessionTtlMs: 60_000,

--- a/__tests__/large/e2e/favorite-queue/favorite-queue-sort-pagination.large.test.js
+++ b/__tests__/large/e2e/favorite-queue/favorite-queue-sort-pagination.large.test.js
@@ -139,7 +139,6 @@ test.describe('large e2e: favorite/queue の並び替えとページング', () 
     app = createApp({
       databaseStoragePath: tempDatabasePath,
       contentRootDirectory: tempContentDirectory,
-      loginUsername: 'admin',
       loginPassword: 'admin',
       loginUserId: 'admin',
       loginSessionTtlMs: 60_000,

--- a/__tests__/large/e2e/helpers/bootstrapE2eApp.js
+++ b/__tests__/large/e2e/helpers/bootstrapE2eApp.js
@@ -5,7 +5,6 @@ const createApp = require('../../../../src/app');
 const { removePathIfExists } = require('./fsCleanup');
 const { createE2eTempDirectory } = require('./e2eTempDirectory');
 
-
 const listenServer = app => new Promise((resolve, reject) => {
   const listeningServer = app.listen(0, () => resolve(listeningServer));
   listeningServer.on('error', reject);
@@ -22,7 +21,6 @@ const resolveBaseUrl = server => {
 
 const bootstrapE2eApp = async ({
   prefix = 'mangaviewer-e2e-',
-  loginUsername = 'admin',
   loginPassword = 'admin',
   loginUserId = 'admin',
   loginSessionTtlMs = 60_000,
@@ -35,7 +33,6 @@ const bootstrapE2eApp = async ({
   const app = createApp({
     databaseStoragePath: tempDatabasePath,
     contentRootDirectory: tempContentDirectory,
-    loginUsername,
     loginPassword,
     loginUserId,
     loginSessionTtlMs,

--- a/__tests__/large/e2e/navigation/navigation-and-logout.large.test.js
+++ b/__tests__/large/e2e/navigation/navigation-and-logout.large.test.js
@@ -56,7 +56,6 @@ test.describe('large e2e: サマリー・詳細遷移とログアウト後導線
     app = createApp({
       databaseStoragePath: tempDatabasePath,
       contentRootDirectory: tempContentDirectory,
-      loginUsername: 'admin',
       loginPassword: 'admin',
       loginUserId: 'admin',
       loginSessionTtlMs: 60_000,

--- a/__tests__/large/e2e/summary/summary-search-sort-pagination.large.test.js
+++ b/__tests__/large/e2e/summary/summary-search-sort-pagination.large.test.js
@@ -87,7 +87,6 @@ test.describe('large e2e: summary の検索・並び替え・ページング', (
     app = createApp({
       databaseStoragePath: tempDatabasePath,
       contentRootDirectory: tempContentDirectory,
-      loginUsername: 'admin',
       loginPassword: 'admin',
       loginUserId: 'admin',
       loginSessionTtlMs: 60_000,

--- a/__tests__/medium/app/commonNavigator.integration.test.js
+++ b/__tests__/medium/app/commonNavigator.integration.test.js
@@ -1,6 +1,5 @@
 const createApp = require('../../../src/app');
 const createLoginEnv = () => ({
-  loginUsername: 'test-user',
   loginPassword: 'test-password',
   loginUserId: 'test-user-id',
 });

--- a/__tests__/medium/app/createDependencies.login.test.js
+++ b/__tests__/medium/app/createDependencies.login.test.js
@@ -17,7 +17,6 @@ describe('createDependencies login wiring', () => {
     dependencies = createDependencies({
       databaseStoragePath: path.join(databaseRoot, 'data.sqlite'),
       contentRootDirectory: path.join(contentRoot, 'contents'),
-      loginUsername: 'admin',
       loginPassword: 'secret',
       loginUserId: 'user-001',
       loginSessionTtlMs: 60_000,
@@ -41,7 +40,7 @@ describe('createDependencies login wiring', () => {
       regenerate: jest.fn((callback) => callback()),
     };
     const query = new Query({
-      username: 'admin',
+      username: 'user-001',
       password: 'secret',
       session,
     });
@@ -61,7 +60,6 @@ describe('createDependencies login wiring', () => {
       nodeEnv: 'development',
       databaseStoragePath: path.join(databaseRoot, 'production.sqlite'),
       contentRootDirectory: path.join(contentRoot, 'production-contents'),
-      loginUsername: 'admin',
       loginPassword: '',
       loginUserId: '',
     })).toThrow('ログイン認証設定が不足しています');
@@ -79,7 +77,6 @@ describe('createDependencies login wiring', () => {
       nodeEnv: 'production',
       databaseStoragePath: path.join(databaseRoot, 'hashed.sqlite'),
       contentRootDirectory: path.join(contentRoot, 'hashed-contents'),
-      loginUsername: 'admin',
       loginPasswordHash: sha256Hex('secret'),
       loginUserId: 'user-001',
       loginSessionTtlMs: 60_000,
@@ -91,7 +88,7 @@ describe('createDependencies login wiring', () => {
     };
 
     const result = await dependencies.loginService.execute(new Query({
-      username: 'admin',
+      username: 'user-001',
       password: 'secret',
       session,
     }));
@@ -105,7 +102,6 @@ describe('createDependencies login wiring', () => {
       allowInsecureDefaultLogin: 'true',
       databaseStoragePath: path.join(databaseRoot, 'development.sqlite'),
       contentRootDirectory: path.join(contentRoot, 'development-contents'),
-      loginUsername: '',
       loginPassword: '',
       loginUserId: '',
     })).toThrow('ALLOW_INSECURE_DEFAULT_LOGIN=true は許可できません');
@@ -117,7 +113,6 @@ describe('createDependencies login wiring', () => {
       allowInsecureDefaultLogin: 'true',
       databaseStoragePath: path.join(databaseRoot, 'production-insecure.sqlite'),
       contentRootDirectory: path.join(contentRoot, 'production-insecure-contents'),
-      loginUsername: '',
       loginPassword: '',
       loginUserId: '',
     })).toThrow('ALLOW_INSECURE_DEFAULT_LOGIN=true は許可できません');
@@ -128,7 +123,6 @@ describe('createDependencies login wiring', () => {
       nodeEnv: 'production',
       databaseStoragePath: path.join(databaseRoot, 'weak-password.sqlite'),
       contentRootDirectory: path.join(contentRoot, 'weak-password-contents'),
-      loginUsername: 'admin',
       loginPassword: 'admin',
       loginUserId: 'user-001',
     })).toThrow('既知の弱いパスワードは使用できません');
@@ -144,7 +138,6 @@ describe('createDependencies login wiring', () => {
       nodeEnv: 'development',
       databaseStoragePath: path.join(databaseRoot, 'weak-password-development.sqlite'),
       contentRootDirectory: path.join(contentRoot, 'weak-password-development-contents'),
-      loginUsername: 'admin',
       loginPassword: 'admin',
       loginUserId: 'admin',
       loginSessionTtlMs: 60_000,
@@ -173,7 +166,6 @@ describe('createDependencies login wiring', () => {
     dependencies = createDependencies({
       databaseStoragePath: path.join(databaseRoot, 'memory.sqlite'),
       contentRootDirectory: path.join(contentRoot, 'memory-contents'),
-      loginUsername: 'admin',
       loginPassword: 'secret',
       loginUserId: 'user-001',
       authStateStoreBackend: 'memory',
@@ -187,7 +179,6 @@ describe('createDependencies login wiring', () => {
     expect(() => createDependencies({
       databaseStoragePath: path.join(databaseRoot, 'redis.sqlite'),
       contentRootDirectory: path.join(contentRoot, 'redis-contents'),
-      loginUsername: 'admin',
       loginPassword: 'secret',
       loginUserId: 'user-001',
       authStateStoreBackend: 'redis',

--- a/__tests__/medium/app/developmentSession.integration.test.js
+++ b/__tests__/medium/app/developmentSession.integration.test.js
@@ -8,7 +8,6 @@ const request = require('supertest');
 const createDependencies = require('../../../src/app/createDependencies');
 const setupMiddleware = require('../../../src/app/setupMiddleware');
 const createLoginEnv = () => ({
-  loginUsername: 'test-user',
   loginPassword: 'test-password',
   loginUserId: 'test-user-id',
 });
@@ -124,7 +123,6 @@ describe('developmentSession wiring', () => {
     process.env.DEV_SESSION_USER_ID = 'admin-dev';
     process.env.DEV_SESSION_TTL_MS = '60000';
     process.env.DEV_SESSION_PATHS = '/screen/entry,/api/media';
-    process.env.LOGIN_USERNAME = 'admin-user';
     process.env.LOGIN_PASSWORD = 'admin-password';
     process.env.LOGIN_USER_ID = 'admin-user-id';
 
@@ -156,10 +154,8 @@ describe('developmentSession wiring', () => {
 
     process.env.NODE_ENV = 'development';
     process.env.PORT = '3457';
-    process.env.FIXED_LOGIN_USERNAME = '';
     process.env.FIXED_LOGIN_PASSWORD = '';
     process.env.FIXED_LOGIN_USER_ID = '';
-    process.env.LOGIN_USERNAME = '';
     process.env.LOGIN_PASSWORD = '';
     process.env.LOGIN_USER_ID = '';
     process.env.ALLOW_INSECURE_DEFAULT_LOGIN = '';
@@ -194,10 +190,8 @@ describe('developmentSession wiring', () => {
 
     process.env.NODE_ENV = 'development';
     process.env.PORT = '3458';
-    process.env.FIXED_LOGIN_USERNAME = '';
     process.env.FIXED_LOGIN_PASSWORD = '';
     process.env.FIXED_LOGIN_USER_ID = '';
-    process.env.LOGIN_USERNAME = '';
     process.env.LOGIN_PASSWORD = '';
     process.env.LOGIN_USER_ID = '';
     process.env.ALLOW_INSECURE_DEFAULT_LOGIN = 'true';
@@ -232,10 +226,8 @@ describe('developmentSession wiring', () => {
 
     process.env.NODE_ENV = 'production';
     process.env.PORT = '3459';
-    process.env.FIXED_LOGIN_USERNAME = '';
     process.env.FIXED_LOGIN_PASSWORD = '';
     process.env.FIXED_LOGIN_USER_ID = '';
-    process.env.LOGIN_USERNAME = '';
     process.env.LOGIN_PASSWORD = '';
     process.env.LOGIN_USER_ID = '';
     process.env.ALLOW_INSECURE_DEFAULT_LOGIN = 'true';
@@ -270,10 +262,8 @@ describe('developmentSession wiring', () => {
 
     process.env.NODE_ENV = 'production';
     process.env.PORT = '3460';
-    process.env.FIXED_LOGIN_USERNAME = 'admin-user';
     process.env.FIXED_LOGIN_PASSWORD = 'admin-password';
     process.env.FIXED_LOGIN_USER_ID = 'admin-user-id';
-    process.env.LOGIN_USERNAME = 'admin-user';
     process.env.LOGIN_PASSWORD = 'admin-password';
     process.env.LOGIN_USER_ID = 'admin-user-id';
     process.env.ALLOW_INSECURE_DEFAULT_LOGIN = '';
@@ -312,10 +302,8 @@ describe('developmentSession wiring', () => {
     process.env.NODE_ENV = 'production';
     process.env.PORT = '3461';
     process.env.SERVER_HOST = '0.0.0.0';
-    process.env.FIXED_LOGIN_USERNAME = 'admin-user';
     process.env.FIXED_LOGIN_PASSWORD = 'admin-password';
     process.env.FIXED_LOGIN_USER_ID = 'admin-user-id';
-    process.env.LOGIN_USERNAME = 'admin-user';
     process.env.LOGIN_PASSWORD = 'admin-password';
     process.env.LOGIN_USER_ID = 'admin-user-id';
 
@@ -345,7 +333,6 @@ describe('developmentSession wiring', () => {
     process.env.NODE_ENV = 'development';
     process.env.PORT = '3462';
     process.env.SERVER_HOST = '0.0.0.0';
-    process.env.LOGIN_USERNAME = 'admin-user';
     process.env.LOGIN_PASSWORD = 'admin-password';
     process.env.LOGIN_USER_ID = 'admin-user-id';
 
@@ -380,7 +367,6 @@ describe('developmentSession wiring', () => {
     process.env.DEV_SESSION_USER_ID = 'admin-dev';
     process.env.DEV_SESSION_TTL_MS = '60000';
     process.env.DEV_SESSION_PATHS = '/screen/entry';
-    process.env.LOGIN_USERNAME = 'admin-user';
     process.env.LOGIN_PASSWORD = 'admin-password';
     process.env.LOGIN_USER_ID = 'admin-user-id';
 

--- a/__tests__/medium/app/setupRoutes.notFound.test.js
+++ b/__tests__/medium/app/setupRoutes.notFound.test.js
@@ -6,7 +6,6 @@ const request = require('supertest');
 
 const createApp = require('../../../src/app');
 const createLoginEnv = () => ({
-  loginUsername: 'test-user',
   loginPassword: 'test-password',
   loginUserId: 'test-user-id',
 });

--- a/__tests__/small/app/createApp.test.js
+++ b/__tests__/small/app/createApp.test.js
@@ -6,7 +6,6 @@ const request = require('supertest');
 
 const createApp = require('../../../src/app');
 const createLoginEnv = () => ({
-  loginUsername: 'test-user',
   loginPassword: 'test-password',
   loginUserId: 'test-user-id',
 });
@@ -180,7 +179,6 @@ describe('createApp', () => {
     expect(() => createApp({
       databaseStoragePath: databasePath,
       contentRootDirectory,
-      loginUsername: '',
       loginPassword: '',
       loginUserId: '',
       allowInsecureDefaultLogin: 'true',

--- a/__tests__/small/app/setupRoutes.notFound.test.js
+++ b/__tests__/small/app/setupRoutes.notFound.test.js
@@ -6,7 +6,6 @@ const request = require('supertest');
 
 const createApp = require('../../../src/app');
 const createLoginEnv = () => ({
-  loginUsername: 'test-user',
   loginPassword: 'test-password',
   loginUserId: 'test-user-id',
 });

--- a/doc/4_application/app/createApp/readme.md
+++ b/doc/4_application/app/createApp/readme.md
@@ -20,7 +20,6 @@
 | --- | --- | --- |
 | `databaseStoragePath` | SQLite ファイル格納先 | `createDependencies` |
 | `contentRootDirectory` | コンテンツ保存先ディレクトリ | `createDependencies` |
-| `loginUsername` | 固定ログイン認証のユーザー名 | `createDependencies` |
 | `loginPassword` | 固定ログイン認証のパスワード | `createDependencies` |
 | `loginUserId` | ログイン成功時に採用するユーザーID | `createDependencies` |
 | `loginSessionTtlMs` | 通常ログインセッションの TTL | `createDependencies` |

--- a/doc/4_application/app/createDependencies/readme.md
+++ b/doc/4_application/app/createDependencies/readme.md
@@ -15,7 +15,6 @@
 | --- | --- | --- |
 | `databaseStoragePath` | 必須 | SQLite ファイルの保存先。親ディレクトリを自動生成する。 |
 | `contentRootDirectory` | 必須 | メディアコンテンツ保存先。ディレクトリを自動生成する。 |
-| `loginUsername` | 任意 | `StaticLoginAuthenticator` のユーザー名。未指定時は `admin`。 |
 | `loginPassword` | 任意 | `StaticLoginAuthenticator` のパスワード。未指定時は `admin`。 |
 | `loginUserId` | 任意 | ログイン成功時の利用者 ID。未指定時は `admin`。 |
 | `loginSessionTtlMs` | 任意 | 通常ログインセッションの TTL。未指定時は `86400000`。 |
@@ -32,7 +31,7 @@
 - `SequelizeMediaRepository` / `SequelizeMediaQueryRepository` / `SequelizeUserRepository` を生成する。
 - `InMemorySessionStateStore` を生成する。
 - `MulterDiskStorageContentUploadAdapter` と `UUIDMediaIdValueGenerator` を生成する。
-- `StaticLoginAuthenticator` を `env.loginUsername` / `env.loginPassword` / `env.loginUserId` から生成する。
+- `StaticLoginAuthenticator` を `env.loginUserId` / `env.loginPassword` から生成する。
 - `SessionStateRegistrar` / `SessionTerminator` / `SessionStateAuthAdapter` を生成する。
 
 ### アプリケーションサービスの生成

--- a/doc/4_application/app/createDependencies/testcase.medium.md
+++ b/doc/4_application/app/createDependencies/testcase.medium.md
@@ -6,7 +6,7 @@
 （対応テスト: `__tests__/medium/app/createDependencies.login.test.js`）
 
 **前提**
-- `loginUsername` / `loginPassword` / `loginUserId` / `loginSessionTtlMs` を明示した `env` で `createDependencies` を生成する。
+- `loginPassword` / `loginUserId` / `loginSessionTtlMs` を明示した `env` で `createDependencies` を生成する。
 - `session.regenerate` を持つセッションオブジェクトを用意する。
 
 **操作**

--- a/doc/4_application/app/createDependencies/testcase.small.md
+++ b/doc/4_application/app/createDependencies/testcase.small.md
@@ -22,7 +22,7 @@
 
 ### 2) デフォルト値適用
 **前提**
-- `loginUsername` / `loginPassword` / `loginUserId` / `loginSessionTtlMs` など、任意設定の一部または全部を省略した `env` を用意する。
+- `loginPassword` / `loginUserId` / `loginSessionTtlMs` など、任意設定の一部または全部を省略した `env` を用意する。
 
 **操作**
 - `createDependencies(env)` 実行後、`loginService` など関連依存の挙動を確認する。

--- a/doc/4_application/app/server/readme.md
+++ b/doc/4_application/app/server/readme.md
@@ -22,7 +22,6 @@
 | `DEV_SESSION_PATHS` | `devSessionPaths` | カンマ区切り分解後の配列 | 固定セッションを適用するパス一覧 |
 | `ENABLE_DEV_SESSION` | `enableDevSession` | 空文字 | 開発用固定セッションの明示有効化フラグ（`true` のみ有効） |
 | `ALLOW_REMOTE_DEV_SESSION` | `allowRemoteDevSession` | 空文字 | 非 loopback bind で `ENABLE_DEV_SESSION=true` を強制許可する非常用フラグ（通常は禁止） |
-| `FIXED_LOGIN_USERNAME` (`LOGIN_USERNAME` 互換) | `loginUsername` | 空文字 | 固定ログイン認証のユーザー名 |
 | `FIXED_LOGIN_PASSWORD` (`LOGIN_PASSWORD` 互換) | `loginPassword` | 空文字 | 固定ログイン認証のパスワード |
 | `FIXED_LOGIN_USER_ID` (`LOGIN_USER_ID` 互換) | `loginUserId` | 空文字 | ログイン成功時の利用者ID |
 | `LOGIN_SESSION_TTL_MS` | `loginSessionTtlMs` | `parseInt(..., 10) || 86400000` | 通常ログインセッション TTL |

--- a/doc/7_infrastructure/StaticLoginAuthenticator/readme.md
+++ b/doc/7_infrastructure/StaticLoginAuthenticator/readme.md
@@ -10,7 +10,7 @@
 
 ## 利用箇所
 - `src/app/createDependencies.js`
-  - `env.loginUsername` / `env.loginPassword` / `env.loginUserId` をもとに `StaticLoginAuthenticator` を生成する
+  - `env.loginUserId` / `env.loginPassword` をもとに `StaticLoginAuthenticator` を生成する
   - 生成した `loginAuthenticator` を `LoginService` へ注入する
 - 関連実装: [LoginService](/doc/4_application/user/command/LoginService/readme.md)
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -24,7 +24,6 @@ MediaViewerは、漫画・動画などの複数種類のメディアを閲覧可
 
 - 必須
   - `FIXED_LOGIN_USER_ID`（または `LOGIN_USER_ID`）
-  - `FIXED_LOGIN_USERNAME`（または `LOGIN_USERNAME`）
   - `FIXED_LOGIN_PASSWORD` または `FIXED_LOGIN_PASSWORD_HASH`（`LOGIN_*` 系でも可）
 - 禁止事項
   - `ALLOW_INSECURE_DEFAULT_LOGIN=true` は **ローカル開発を含め常時禁止**。
@@ -34,14 +33,13 @@ MediaViewerは、漫画・動画などの複数種類のメディアを閲覧可
 
 ### 初回起動時の必須設定手順
 1. `.env` または Secret に `FIXED_LOGIN_USER_ID`（または `LOGIN_USER_ID`）を設定する。
-2. `.env` または Secret に `FIXED_LOGIN_USERNAME`（または `LOGIN_USERNAME`）を設定する。
-3. `.env` または Secret に `FIXED_LOGIN_PASSWORD` または `FIXED_LOGIN_PASSWORD_HASH`（`LOGIN_*` 系でも可）を設定する。
-4. `APP_ORIGIN` を設定する（例: `http://127.0.0.1:3000`）。
-5. `ALLOW_INSECURE_DEFAULT_LOGIN` を設定しない（または `false` を明示）ことを確認する。
-6. `npm run start` で起動し、設定漏れや禁止設定があれば fail-close で起動失敗することを確認する。
+2. `.env` または Secret に `FIXED_LOGIN_PASSWORD` または `FIXED_LOGIN_PASSWORD_HASH`（`LOGIN_*` 系でも可）を設定する。
+3. `APP_ORIGIN` を設定する（例: `http://127.0.0.1:3000`）。
+4. `ALLOW_INSECURE_DEFAULT_LOGIN` を設定しない（または `false` を明示）ことを確認する。
+5. `npm run start` で起動し、設定漏れや禁止設定があれば fail-close で起動失敗することを確認する。
 
 ### 移行手順（既存運用向け）
-1. 既存の `.env` / Secret 設定に `*_LOGIN_USER_ID` / `*_LOGIN_USERNAME` / `*_LOGIN_PASSWORD or *_LOGIN_PASSWORD_HASH` を必ず追加する。
+1. 既存の `.env` / Secret 設定に `*_LOGIN_USER_ID` / `*_LOGIN_PASSWORD or *_LOGIN_PASSWORD_HASH` を必ず追加する。
 2. `ALLOW_INSECURE_DEFAULT_LOGIN` を未設定（または `false`）にする。
 3. CI/CD で `npm run start` もしくは起動ヘルスチェックを実行し、設定漏れがあれば起動失敗で検知する。
 

--- a/scripts/seed-fixed-user.js
+++ b/scripts/seed-fixed-user.js
@@ -11,14 +11,10 @@ const createDatabaseStoragePath = source => source.DATABASE_STORAGE_PATH
 
 const validateFixedUserEnv = source => {
   const userId = source.FIXED_LOGIN_USER_ID || source.LOGIN_USER_ID || '';
-  const username = source.FIXED_LOGIN_USERNAME || source.LOGIN_USERNAME || '';
   const password = source.FIXED_LOGIN_PASSWORD || source.LOGIN_PASSWORD || '';
 
   if (typeof userId !== 'string' || userId.length === 0) {
     throw new Error('FIXED_LOGIN_USER_ID (または LOGIN_USER_ID) を設定してください。');
-  }
-  if (typeof username !== 'string' || username.length === 0) {
-    throw new Error('FIXED_LOGIN_USERNAME (または LOGIN_USERNAME) を設定してください。');
   }
   if (typeof password !== 'string' || password.length === 0) {
     throw new Error('FIXED_LOGIN_PASSWORD (または LOGIN_PASSWORD) を設定してください。');
@@ -26,7 +22,7 @@ const validateFixedUserEnv = source => {
 
   return {
     userId,
-    username,
+    username: userId,
     password,
   };
 };
@@ -78,7 +74,7 @@ const seedFixedUser = async (source = process.env) => {
     if (!existingByUserId) {
       await FixedCredentialModel.create({
         user_id: userId,
-        username,
+        username: userId,
         password_hash: passwordHash,
       });
       credentialResult = '作成';
@@ -87,7 +83,7 @@ const seedFixedUser = async (source = process.env) => {
       if (shouldUpdate) {
         await FixedCredentialModel.update(
           {
-            username,
+            username: userId,
             password_hash: passwordHash,
           },
           { where: { user_id: userId } },

--- a/src/app/createDependencies.js
+++ b/src/app/createDependencies.js
@@ -91,13 +91,12 @@ const resolveLoginAuthConfig = env => {
   }
 
   const rawConfig = {
-    username: String(env.loginUsername || '').trim(),
+    username: String(env.loginUserId || '').trim(),
     password: String(env.loginPassword || '').trim(),
     passwordHash: String(env.loginPasswordHash || '').trim(),
     userId: String(env.loginUserId || '').trim(),
   };
   const missingKeys = [
-    !isConfiguredValue(rawConfig.username) ? 'username' : null,
     !isConfiguredValue(rawConfig.userId) ? 'userId' : null,
     !isConfiguredValue(rawConfig.password) && !isConfiguredValue(rawConfig.passwordHash)
       ? 'password/passwordHash'
@@ -108,7 +107,7 @@ const resolveLoginAuthConfig = env => {
     throw new Error([
       'ログイン認証設定が不足しています',
       `missing=${missingKeys.join(',')}`,
-      '必要な設定: LOGIN_USERNAME(or FIXED_LOGIN_USERNAME), LOGIN_USER_ID(or FIXED_LOGIN_USER_ID), LOGIN_PASSWORDまたはLOGIN_PASSWORD_HASH',
+      '必要な設定: LOGIN_USER_ID(or FIXED_LOGIN_USER_ID), LOGIN_PASSWORDまたはLOGIN_PASSWORD_HASH',
     ].join(': '));
   }
 

--- a/src/server.js
+++ b/src/server.js
@@ -80,7 +80,6 @@ const createEnv = source => ({
   devSessionPaths: parseSessionPaths(source.DEV_SESSION_PATHS),
   enableDevSession: source.ENABLE_DEV_SESSION || '',
   allowRemoteDevSession: source.ALLOW_REMOTE_DEV_SESSION || '',
-  loginUsername: source.FIXED_LOGIN_USERNAME || source.LOGIN_USERNAME || '',
   loginPassword: source.FIXED_LOGIN_PASSWORD || source.LOGIN_PASSWORD || '',
   loginPasswordHash: source.FIXED_LOGIN_PASSWORD_HASH || source.LOGIN_PASSWORD_HASH || '',
   loginUserId: source.FIXED_LOGIN_USER_ID || source.LOGIN_USER_ID || '',


### PR DESCRIPTION
### Motivation
- 環境変数で `username` と `userId` を二重に持つと設定漏れ・不整合を招くため、固定ログインの設定責務を `LOGIN_USER_ID` に一本化して保守性を高める。 

### Description
- `src/server.js` から `loginUsername` / `LOGIN_USERNAME` 系の環境解決を削除し、起動時の `env` を `loginUserId` とパスワード系に集約しました。 
- `src/app/createDependencies.js` の認証設定解決ロジックを修正し、`username` の値を `env.loginUserId` 由来に変更、必須設定メッセージから `LOGIN_USERNAME` 系を削除しました。 
- `scripts/seed-fixed-user.js` を修正し、シード時に `username` 環境変数を必須にせず `userId` を `username` として保存するようにしました。 
- テストおよび E2E ヘルパーを更新し、`loginUsername` の指定を削除し、ログイン検証で使用する `username` を `loginUserId` に合わせて修正しました。 
- ドキュメント（`doc/*`）の `LOGIN_USERNAME` / `FIXED_LOGIN_USERNAME` 記載を削除・更新しました。 

### Testing
- 実行した単体/結合テスト: `npx jest __tests__/medium/app/createDependencies.login.test.js --runInBand` は成功（該当 suite のテストは全て通過）。
- 追加で次のテスト群を実行し成功を確認しました: `__tests__/small/app/createApp.test.js`, `__tests__/medium/app/developmentSession.integration.test.js`, `__tests__/small/app/setupRoutes.notFound.test.js`, `__tests__/medium/app/setupRoutes.notFound.test.js`, `__tests__/medium/app/commonNavigator.integration.test.js`（いずれも該当 suite はパス）。
- 変更ファイルの構文チェックを `node -c` 相当で実施し問題なし（`OK`）。
- 補足: `npm test` の直接実行は `package.json` に汎用の `test` スクリプトがないため失敗しましたが、個別の `npx jest` コマンドで必要なテストは実行・検証済みです。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da06071e44832b82103c9d77b40d14)