### PR TITLE
docs: import CLI運用仕様をserver起動設計書へ追加

### DIFF
--- a/doc/4_application/app/server/readme.md
+++ b/doc/4_application/app/server/readme.md
@@ -63,6 +63,46 @@
 - 固定セッションの優先順位は `x-session-token` → `session_token` Cookie → 開発用固定セッションであり、その実行仕様自体は [setupMiddleware 設計書](/doc/5_api/controller/middleware/setupMiddleware/readme.md) を参照する。
 - 詳細は [DevelopmentSession 設計書](/doc/5_api/controller/middleware/DevelopmentSession/readme.md) を参照する。
 
+
+## 運用CLI仕様: `npm run import -- <dir>`
+
+### コマンド形式と引数
+- 実行形式: `npm run import -- <dir>`
+- `<dir>`: 取り込み対象 zip を格納したディレクトリのパス（必須）。
+- `<dir>` は絶対パス/相対パスのどちらも受け付ける。相対パスは実行時カレントディレクトリ基準で解決する。
+
+### 実行前検証
+- 実処理開始前に、以下を順に検証する。
+  1. 引数 `<dir>` が指定されていること。
+  2. `<dir>` が存在すること。
+  3. `<dir>` がディレクトリであること。
+  4. `<dir>` に対して読み取り権限があること。
+- 上記のいずれかを満たさない場合、zip 走査・登録処理は実行せずに異常終了する。
+
+### 終了コード規約
+- `0`: 正常終了（対象 zip がすべて成功、または対象 zip が 0 件）。
+- `1`: 処理実行は完了したが、1件以上の zip が失敗。
+- `2`: 実行前検証エラー（引数不正、フォルダ不存在、権限不足など）により未実行終了。
+
+### 実行ログ仕様（人間可読 + JSONL）
+- ログは同一実行で **人間可読ログ** と **JSONLログ** の 2 系統を出力する。
+- 人間可読ログ:
+  - 標準出力/標準エラーに、開始・進捗・zip単位結果・最終集計・終了コードを出力する。
+  - 運用者が CLI 画面だけで状態判断できる粒度で記録する。
+- JSONLログ:
+  - 1行1JSON の形式で出力する。
+  - 少なくとも `event`, `timestamp`, `zipName`, `status`, `reason`, `mediaId`（成功時）, `ignoredFiles`, `summary`（集計時）を含める。
+  - `event` は `start` / `zip_result` / `summary` / `finish` を使い分ける。
+
+### 0件 zip 時の扱い
+- `<dir>` 配下に zip が 0 件の場合は、処理対象なしとして正常終了（終了コード `0`）する。
+- 人間可読ログと JSONLログの双方に「対象 0 件」である旨の集計を出力する。
+
+### 一部失敗時の扱い
+- ある zip が失敗しても、後続 zip の取り込みは継続実行する（fail-fast にしない）。
+- 実行終了時に失敗件数を最終集計へ反映し、失敗件数が 1 件以上の場合は終了コード `1` を返す。
+- 各 zip の成否は個別に記録し、どの zip が失敗したかを追跡可能にする。
+
 ## 関連ドキュメント
 - [createApp 設計書](/doc/4_application/app/createApp/readme.md)
 - [createDependencies 設計書](/doc/4_application/app/createDependencies/readme.md)


### PR DESCRIPTION
### Motivation
- `npm run import -- <dir>` の運用時に必要な判断基準（実行前検証・終了コード・ログ仕様など）が散在しており、運用者が実行前に挙動を把握しにくいため、起動設計書に一元化して参照しやすくする。 

### Description
- `doc/4_application/app/server/readme.md` に `## 運用CLI仕様: npm run import -- <dir>` 節を追加し、CLI の `コマンド形式と引数` を明記した。 
- 実行前検証ルールとして `引数必須` / `フォルダ存在` / `ディレクトリ判定` / `読み取り権限` の順でチェックし、不備あれば実処理を行わず異常終了する旨を追記した。 
- 終了コード規約を `0`（正常、対象0件含む）/ `1`（一部失敗）/ `2`（事前検証エラー）で定義した。 
- 実行ログ仕様として `人間可読ログ` と `JSONL` の二系統出力を要求し、JSONL の必須フィールド（`event`, `timestamp`, `zipName`, `status`, `reason`, `mediaId`, `ignoredFiles`, `summary`）とイベント種別を定義した。 
- 0件 zip の扱い（正常終了）と一部失敗時の扱い（継続実行し最終集計で終了コード反映）を明文化した。 

### Testing
- `git diff -- doc/4_application/app/server/readme.md` を実行して差分を確認し、追加内容が反映されていることを確認済み（成功）。 
- `git status --short` を実行して作業ツリーの状態を確認し、コミット済みであることを確認済み（成功）。 
- ドキュメントのみの変更であり、実装・テストコードの自動テストは実行していない（影響はドキュメント限定）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0c0ed41f8832b85ea15a5e5541cf2)