### PR TITLE
docs: ImportZipsServiceの失敗理由をreasonCode/reasonDetailに分割

### DIFF
--- a/doc/4_application/media/command/ImportZipsService/readme.md
+++ b/doc/4_application/media/command/ImportZipsService/readme.md
@@ -46,7 +46,8 @@ struct ImportZipResult {
     + 成否 : enum(SUCCESS, FAILED)
     + mediaId : string?
     + 無視ファイル一覧 : array<string>
-    + 理由 : string?
+    + reasonCode : enum(NO_IMAGES, ZIP_IMAGE_COUNT_LIMIT_EXCEEDED, IMAGE_FILE_SIZE_LIMIT_EXCEEDED, INVALID_ZIP, IO_ERROR)
+    + reasonDetail : string?
 }
 
 struct ImportZipsSummary {
@@ -65,7 +66,7 @@ ImportZipsOutput o- ImportZipResult
 ImportZipsOutput o- ImportZipsSummary
 ```
 
-- zip単位結果: 各 zip の成功/失敗、無視ファイル、失敗理由、mediaId を返す。
+- zip単位結果: 各 zip の成功/失敗、無視ファイル、失敗理由コード（`reasonCode`）、任意詳細（`reasonDetail`）、mediaId を返す。
 - 全体サマリ: 実行全体の成功件数・失敗件数を返す。
 - 実行結果種別:
   - `SUCCESS`: 全 zip 成功、または対象 zip が 0 件。
@@ -105,22 +106,21 @@ ImportZipsOutput o- ImportZipsSummary
 - zip名
 - 成否
 - 無視ファイル一覧
-- 理由（失敗理由、または補足）
+- reasonCode（失敗理由の分類コード）
+- reasonDetail（失敗理由の補足。必要時のみ）
 - mediaId（成功時のみ）
 
-### `reason` の分類規約
-- `reason` は、**分類識別子（必須）** と **任意詳細（任意）** の 2 要素で表現する。
-- 形式は `識別子` または `識別子: 詳細` とする。
-  - 例: `NO_IMAGES`
-  - 例: `IMAGE_FILE_SIZE_LIMIT_EXCEEDED: page-001.png (12,345,678 bytes)`
-- 識別子は大文字スネークケース（`[A-Z0-9_]+`）を採用し、機械判定可能な固定語彙として扱う。
-- 詳細は人間向け補足として扱い、テストの主要期待値は識別子で判定する。
+### `reasonCode` / `reasonDetail` の規約
+- `reasonCode` は**必須**とし、失敗理由の分類識別子を保持する。
+- `reasonDetail` は**任意**とし、人間向け補足（対象ファイル名、超過値など）を保持する。
+- 表示用文言は `reasonDetail` または呼び出し側のメッセージマッピングで生成する。
+- テストの主要期待値は `reasonCode` の完全一致で判定する。
 
-#### 候補と採用識別子
+#### `reasonCode` の採用列挙値
 - `NO_IMAGES`: 画像ファイルが 0 件で取り込み不可。
 - `ZIP_IMAGE_COUNT_LIMIT_EXCEEDED`: zipごとの最大画像数の上限超過。
 - `IMAGE_FILE_SIZE_LIMIT_EXCEEDED`: 画像ファイルサイズ上限超過。
 - `INVALID_ZIP`: zip 破損や非対応フォーマット等で展開不可。
 - `IO_ERROR`: ファイルシステム I/O 失敗（読取/書込/移動/削除など）。
 
-上記 5 つを **採用識別子** とし、今後の失敗理由は原則この分類規約に従って記録する。
+上記 5 つを `reasonCode` の採用列挙値とし、今後の失敗理由は原則この分類規約に従って記録する。

--- a/doc/4_application/media/command/ImportZipsService/testcase.medium.md
+++ b/doc/4_application/media/command/ImportZipsService/testcase.medium.md
@@ -8,7 +8,7 @@
 - [ログに zip 名・成否・無視ファイル一覧が出力される](#ログに-zip-名成否無視ファイル一覧が出力される)
 - [JSONL ログのキー整合性を満たす](#jsonl-ログのキー整合性を満たす)
 - [zipごとの最大画像数の境界値で失敗隔離とロールバックを満たす](#zipごとの最大画像数の境界値で失敗隔離とロールバックを満たす)
-- [画像ファイルの最大バイト数の境界値で reason 分類とログ整合を満たす](#画像ファイルの最大バイト数の境界値で-reason-分類とログ整合を満たす)
+- [画像ファイルの最大バイト数の境界値で reasonCode 分類とログ整合を満たす](#画像ファイルの最大バイト数の境界値で-reasoncode-分類とログ整合を満たす)
 - [1実行あたり最大zip処理件数の境界値で実行全体ポリシーを満たす](#1実行あたり最大zip処理件数の境界値で実行全体ポリシーを満たす)
 
 ---
@@ -102,10 +102,10 @@
   - ImportZipsService を実行し、出力された JSONL を1行ずつ JSON として読み込む。
 - **結果**
   - zip 単位ログの必須キー（`zipName`, `status`, `ignoredFiles`）が常に存在する。
-  - `status=SUCCESS` の行は `mediaId` を持ち、`reason` は未設定または空である。
-  - `status=FAILED` の行は `reason` を持ち、`mediaId` は未設定である。
-  - `status=FAILED` の `reason` は `識別子` または `識別子: 任意詳細` の形式である。
-  - `reason` の識別子は大文字スネークケース（`[A-Z0-9_]+`）で、`NO_IMAGES` / `ZIP_IMAGE_COUNT_LIMIT_EXCEEDED` / `IMAGE_FILE_SIZE_LIMIT_EXCEEDED` / `INVALID_ZIP` / `IO_ERROR` の採用語彙に一致する。
+  - `status=SUCCESS` の行は `mediaId` を持ち、`reasonCode`/`reasonDetail` は未設定または空である。
+  - `status=FAILED` の行は `reasonCode` を持ち、`mediaId` は未設定である。
+  - `status=FAILED` の `reasonCode` は採用列挙値のいずれかに一致する。
+  - `reasonDetail` は任意項目とし、存在する場合は補助情報（対象ファイル名など）を含められる。
   - 配列キー `ignoredFiles` は常に配列型である（空配列を許容）。
   - 集計値（成功/失敗件数）が zip 単位ログ件数と矛盾しない。
 
@@ -127,12 +127,12 @@
   - ケースA/B は成功し、メディア永続化が完了する。
   - ケースC は失敗し、当該 zip の永続化は行われない（zip 単位原子性）。
   - ケースC に対応する一時展開物・中間生成物は残らない（ロールバック）。
-  - ケースC の `reason` は `ZIP_IMAGE_COUNT_LIMIT_EXCEEDED` で分類一致する。
+  - ケースC の `reasonCode` は `ZIP_IMAGE_COUNT_LIMIT_EXCEEDED` と完全一致する（`reasonDetail` は任意）。
   - ケースC の失敗があっても他 zip の処理継続性が保たれる。
 
 ---
 
-### 画像ファイルの最大バイト数の境界値で reason 分類とログ整合を満たす
+### 画像ファイルの最大バイト数の境界値で reasonCode 分類とログ整合を満たす
 
 - **前提**
   - `画像ファイルの最大バイト数=MAX_IMAGE_BYTES` を設定する。
@@ -145,9 +145,9 @@
   - ImportZipsService を実行し、zip 単位結果と JSONL を照合する。
 - **結果**
   - ケースA/B は成功し、`status=SUCCESS` と `mediaId` が記録される。
-  - ケースC は失敗し、`status=FAILED` と `reason` が記録される。
-  - ケースC の `reason` 識別子は `IMAGE_FILE_SIZE_LIMIT_EXCEEDED` と一致する。
-  - `reason` は文字列部分一致ではなく分類識別子一致で検証する。
+  - ケースC は失敗し、`status=FAILED` と `reasonCode` が記録される（`reasonDetail` は任意）。
+  - ケースC の `reasonCode` は `IMAGE_FILE_SIZE_LIMIT_EXCEEDED` と完全一致する。
+  - `reasonDetail` は補助文字列レベル（存在/非存在や部分一致）で検証する。
   - ケースC 失敗時もケースA/B の永続化結果は維持される（失敗隔離）。
 
 ---

--- a/doc/4_application/media/command/ImportZipsService/testcase.small.md
+++ b/doc/4_application/media/command/ImportZipsService/testcase.small.md
@@ -63,7 +63,8 @@
 
 **期待結果**
 - その zip の結果は `FAILED` になる。
-- `理由` は文字列部分一致ではなく分類識別子で判定し、期待値は `NO_IMAGES` とする（任意詳細の有無は許容）。
+- `reasonCode` は `NO_IMAGES` と完全一致で判定する。
+- `reasonDetail` は存在/非存在の許容範囲で検証する（補助文字列の部分一致は任意）。
 - 失敗 zip に対する永続化は行われない（zip 単位原子性）。
 
 ### 6) 全成功時は `SUCCESS` を返す
@@ -136,8 +137,9 @@
 
 **期待結果**
 - `FAILED`（拒否）になる。
-- `reason` は分類識別子で `ZIP_IMAGE_COUNT_LIMIT_EXCEEDED` と一致する。
-- `reason` 判定はメッセージ本文の部分一致に依存しない。
+- `reasonCode` は `ZIP_IMAGE_COUNT_LIMIT_EXCEEDED` と完全一致する。
+- `reasonDetail` は存在/非存在の許容範囲で検証する（本文の完全一致は要求しない）。
+- `reasonDetail` 判定はメッセージ本文の完全一致に依存しない。
 
 ### 12) `画像ファイルの最大バイト数` が `上限-1` のとき許可される
 **前提**
@@ -173,8 +175,9 @@
 
 **期待結果**
 - `FAILED`（拒否）になる。
-- `reason` は分類識別子で `IMAGE_FILE_SIZE_LIMIT_EXCEEDED` と一致する。
-- `reason` 判定はメッセージ本文の部分一致に依存しない。
+- `reasonCode` は `IMAGE_FILE_SIZE_LIMIT_EXCEEDED` と完全一致する。
+- `reasonDetail` は存在/非存在の許容範囲で検証する（本文の完全一致は要求しない）。
+- `reasonDetail` 判定はメッセージ本文の完全一致に依存しない。
 
 ### 15) `1実行あたり最大zip処理件数` が `上限-1` のとき受理される
 **前提**


### PR DESCRIPTION
### Motivation
- `ImportZipsService` の失敗理由表現が単一文字列（`reason`）で混在しており、機械判定と表示文言の責務が混在していたため、分類コードと表示補助を分離して仕様とテストの安定性を高めるために変更します。

### Description
- `doc/4_application/media/command/ImportZipsService/readme.md` の `ImportZipResult` 定義で `理由` を廃止し、必須の `reasonCode`（`NO_IMAGES`, `ZIP_IMAGE_COUNT_LIMIT_EXCEEDED`, `IMAGE_FILE_SIZE_LIMIT_EXCEEDED`, `INVALID_ZIP`, `IO_ERROR` の列挙）と任意の `reasonDetail` を追加しました。 
- ログ項目定義と規約を `reasonCode`（必須、機械判定用）と `reasonDetail`（任意、表示補助）に合わせて整理し、表示文言は `reasonDetail` または呼び出し側のメッセージマッピングに移す旨を追記しました。 
- `doc/4_application/media/command/ImportZipsService/testcase.small.md` と `doc/4_application/media/command/ImportZipsService/testcase.medium.md` の検証観点を `reasonCode` の完全一致を主判定に変更し、`reasonDetail` は存在/非存在や補助文字列レベルで確認するように更新し、JSONL ログ期待値も `reasonCode`/`reasonDetail` モデルへ合わせて調整しました。 

### Testing
- ドキュメントのみの変更のため自動テストスイートは実行していません（変更内容は文書化・テスト仕様の更新に限定）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e37faf7518832b9b4456c7ec744340)