### PR TITLE
docs: ImportZipsServiceの依存と実行結果責務の境界を明確化する

### DIFF
--- a/doc/4_application/app/server/readme.md
+++ b/doc/4_application/app/server/readme.md
@@ -81,6 +81,8 @@
 
 ### 実行ログ仕様（人間可読 + JSONL）
 - ログは同一実行で **人間可読ログ** と **JSONLログ** の 2 系統を出力する。
+- CLI は `ImportZipsService` へログイベント出力ポート実装（例: JSONL writer を実装した `ImportZipsEventLogger`）を注入する。
+- ユースケース層はログイベントをポートへ通知し、JSONL 形式への整形・出力先ファイルパスの解決・書き込みは `src/controller` または `src/infrastructure` が担う。
 - 人間可読ログ:
   - 標準出力/標準エラーに、開始・進捗・zip単位結果・最終集計・終了コードを出力する。
   - 運用者が CLI 画面だけで状態判断できる粒度で記録する。

--- a/doc/4_application/media/command/ImportZipsService/readme.md
+++ b/doc/4_application/media/command/ImportZipsService/readme.md
@@ -23,17 +23,17 @@ struct ImportZipsInput #pink {
     + zipごとの最大画像数 : number
     + 画像ファイルの最大バイト数 : number
     + 1実行あたり最大zip処理件数 : number
-    + ログ出力先 : string
+    + ログイベント出力ポート : ImportZipsEventLogger
 }
 ```
 
 - 対象フォルダ: 取り込み対象 zip を探索するディレクトリ。
   - 探索対象は**対象フォルダ直下のみ**とし、サブフォルダ配下の zip は取り込み対象外として無視する。
 - 各上限値: 異常な入力による過負荷を防ぐためのガード。
-- ログ出力先: zip ごとの成否および集計結果を出力する先。
+- ログイベント出力ポート: zip ごとの成否および集計結果などのイベントを通知する依存（例: `ImportZipsEventLogger`）。
 
 ### 入力契約の検証責務
-- 入力契約（対象フォルダ未指定、上限値不正、ログ出力先不正など）の検証は `ImportZipsService` の責務とする。
+- 入力契約（対象フォルダ未指定、上限値不正など）の検証は `ImportZipsService` の責務とする。
 - 入力契約違反時は zip 処理を開始せず、`実行結果種別=INVALID_INPUT` を返す。
 
 ## 出力
@@ -71,8 +71,13 @@ ImportZipsOutput o- ImportZipsSummary
 - 実行結果種別:
   - `SUCCESS`: 全 zip 成功、または対象 zip が 0 件。
   - `PARTIAL_FAILURE`: 1件以上の zip が失敗。
-  - `INVALID_INPUT`: 入力契約（対象フォルダ未指定、上限値不正、ログ出力先不正など）を満たさず実行不可。
+  - `INVALID_INPUT`: 入力契約（対象フォルダ未指定、上限値不正など）を満たさず実行不可。
   - `INVALID_INPUT_RUN_ZIP_COUNT_LIMIT_EXCEEDED`: `1実行あたり最大zip処理件数` の上限超過により、実行全体を開始前に拒否。
+
+### 出力責務の境界
+- `ImportZipsService` の `実行結果` は、業務上必要な値（`zip単位結果一覧`・`全体サマリ`・`実行結果種別`）に限定する。
+- JSONL 形式への変換やファイルパス解決・ファイル書き込みなどの I/O 仕様は、`src/controller` または `src/infrastructure` 側の責務とする。
+- そのためユースケース層では、ログ保存形式（JSONL など）や出力先パスを公開契約に含めない。
 
 
 ## 対象 zip が 0 件のときの結果


### PR DESCRIPTION
### Motivation
- ユースケース層に I/O 形式（JSONL や出力ファイルパス）などの実装依存を混入させず、責務を業務ロジックに限定するため。
- CLI 側がログイベント出力の具体実装（例: JSONL writer）を注入する設計で、ユースケースと出力形式の境界を統一するため。

### Description
- `doc/4_application/media/command/ImportZipsService/readme.md` の入力定義で `ログ出力先 : string` を `ログイベント出力ポート : ImportZipsEventLogger` に差し替え、入力検証説明から「ログ出力先不正」を除外しました。  
- 同ファイルに `出力責務の境界` 節を追加し、`実行結果` を業務上必要な値（`zip単位結果一覧`・`全体サマリ`・`実行結果種別`）に限定し、JSONL 形式やファイル書き込み等の I/O 仕様は `src/controller` / `src/infrastructure` の責務である旨を明記しました。  
- `doc/4_application/app/server/readme.md` の実行ログ仕様に、CLI が `ImportZipsService` に対してログイベント出力ポート実装（例: JSONL writer を実装した `ImportZipsEventLogger`）を注入する構成を追記し、ユースケース層はイベント通知のみを行うことを明示しました。  
- 変更は設計ドキュメントのみで、実装コードの修正は行っていません（コミット済み: `b51aad9`）。

### Testing
- 自動化されたテストは実行していません（ドキュメントのみの変更のため）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e380a0fdf4832ba40766a73288ee73)