### PR TITLE
test: E2E初期化からログイン依存パラメータを削除

### DIFF
--- a/__tests__/large/e2e/helpers/bootstrapE2eApp.js
+++ b/__tests__/large/e2e/helpers/bootstrapE2eApp.js
@@ -21,9 +21,6 @@ const resolveBaseUrl = server => {
 
 const bootstrapE2eApp = async ({
   prefix = 'mangaviewer-e2e-',
-  loginPassword = 'admin',
-  loginUserId = 'admin',
-  loginSessionTtlMs = 60_000,
   seed,
 } = {}) => {
   const tempRootDirectory = await createE2eTempDirectory(prefix);
@@ -33,9 +30,6 @@ const bootstrapE2eApp = async ({
   const app = createApp({
     databaseStoragePath: tempDatabasePath,
     contentRootDirectory: tempContentDirectory,
-    loginPassword,
-    loginUserId,
-    loginSessionTtlMs,
   });
 
   await app.locals.ready;


### PR DESCRIPTION
### Motivation
- E2Eテストの起動ヘルパーが認証情報のデフォルトに依存していたため、メディア閲覧を中心とした起動引数に整理しテストセットアップの責務を明確にするため。 

### Description
- `__tests__/large/e2e/helpers/bootstrapE2eApp.js` から `loginPassword` / `loginUserId` / `loginSessionTtlMs` の受け取りを削除し、`createApp` への委譲も除去しました。 
- `__tests__/large/e2e/helpers/seedMedia.js` にユーザー前提の初期化は存在しないことを確認し変更は行っていません。 

### Testing
- `npx jest --runInBand __tests__/large/e2e/summary/summary-search-sort-pagination.large.test.js` を実行しましたが、指定パターンに一致するテストが検出されませんでした（終了コード1）。
- `NODE_ENV=test LOG_OUTPUTS=memory npx playwright test __tests__/large/e2e/summary/summary-search-sort-pagination.large.test.js` を実行しましたが、Playwrightブラウザが未インストールのため失敗し、`npx playwright install` の実行が必要である旨のエラーが出力されました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edb420644c832bb1a0ef8bc616b7dc)