### PR TITLE
test: mediumテストを新認証仕様に合わせてセッション前提を整理

### DIFF
--- a/__tests__/medium/app/commonNavigator.integration.test.js
+++ b/__tests__/medium/app/commonNavigator.integration.test.js
@@ -30,19 +30,18 @@ const requestApp = async ({ app, method, targetPath } = {}) => {
 };
 
 describe('medium: common navigator integration', () => {
-  const createTestApp = ({ userId }) => createApp({
+  const createTestApp = () => createApp({
     databaseStoragePath: ':memory:',
     contentRootDirectory: '/tmp/mangaviewer-medium-common-nav-contents',
     ...createLoginEnv(),
     enableDevSession: 'true',
     devSessionToken: 'dev-token',
-    devSessionUserId: userId,
     devSessionTtlMs: 60_000,
     devSessionPaths: ['/screen/summary'],
   });
 
-  test('管理者ログイン時は /screen/summary にメディア登録リンクが表示される', async () => {
-    const app = createTestApp({ userId: 'admin' });
+  test('/screen/summary にメディア登録リンクが表示される', async () => {
+    const app = createTestApp();
 
     try {
       await app.locals.ready;
@@ -54,24 +53,7 @@ describe('medium: common navigator integration', () => {
 
       expect(response.status).toBe(200);
       expect(response.bodyText).toContain('共通ナビゲーター');
-      expect(response.bodyText).toContain('メディア一覧');      expect(response.bodyText).toContain('メディア登録');    } finally {
-      await app.locals.close();
-    }
-  });
-
-  test('一般ユーザー時も /screen/summary にメディア登録リンクが表示される', async () => {
-    const app = createTestApp({ userId: 'user-001' });
-
-    try {
-      await app.locals.ready;
-      const response = await requestApp({
-        app,
-        method: 'GET',
-        targetPath: '/screen/summary',
-      });
-
-      expect(response.status).toBe(200);
-      expect(response.bodyText).toContain('共通ナビゲーター');
+      expect(response.bodyText).toContain('メディア一覧');
       expect(response.bodyText).toContain('>メディア登録<');
     } finally {
       await app.locals.close();

--- a/__tests__/medium/app/setupMiddleware.integration.test.js
+++ b/__tests__/medium/app/setupMiddleware.integration.test.js
@@ -14,6 +14,7 @@ const createApp = () => {
   app.get('/protected', (req, res) => {
     res.status(200).json({
       csrfToken: req.session.csrf_token,
+      sessionToken: req.session.session_token,
       requestId: req.context.requestId,
     });
   });
@@ -56,5 +57,16 @@ describe('setupMiddleware の接続 (medium)', () => {
     expect(response.status).toBe(200);
     expect(response.headers['x-request-id']).toBe('req-123');
     expect(response.body.requestId).toBe('req-123');
+  });
+
+  test('session_token Cookie があっても認証セッションは補完しない', async () => {
+    const { app } = createApp();
+
+    const response = await request(app)
+      .get('/protected')
+      .set('cookie', 'session_token=legacy-token');
+
+    expect(response.status).toBe(200);
+    expect(response.body.sessionToken).toBeUndefined();
   });
 });

--- a/__tests__/medium/controller/router/screen/setRouterRootGet.test.js
+++ b/__tests__/medium/controller/router/screen/setRouterRootGet.test.js
@@ -1,5 +1,4 @@
 const express = require('express');
-const { extractSessionTokenFromCookie } = require('../../../../helpers/extractSessionTokenFromCookie');
 
 const setRouterRootGet = require('../../../../../src/controller/router/screen/setRouterRootGet');
 const requestApp = async ({ app, method, targetPath, headers = {} } = {}) => {
@@ -40,13 +39,6 @@ describe('setRouterRootGet (middle)', () => {
     const app = express();
     const router = express.Router();
 
-    app.use((req, _res, next) => {
-      req.session = {
-        session_token: extractSessionTokenFromCookie(req.header('cookie')),
-      };
-      next();
-    });
-
     setRouterRootGet({
       router,
     });
@@ -62,23 +54,6 @@ describe('setRouterRootGet (middle)', () => {
       app,
       method: 'GET',
       targetPath: '/',
-    });
-
-    expect(response.status).toBeGreaterThanOrEqual(300);
-    expect(response.status).toBeLessThan(400);
-    expect(response.headers.get('location')).toBe('/screen/summary');
-  });
-
-  test('認証済みアクセス GET / は /screen/summary へリダイレクトする', async () => {
-    const app = createApp();
-
-    const response = await requestApp({
-      app,
-      method: 'GET',
-      targetPath: '/',
-      headers: {
-        cookie: 'session_token=valid-token',
-      },
     });
 
     expect(response.status).toBeGreaterThanOrEqual(300);

--- a/__tests__/medium/controller/router/screen/setRouterScreenSearchGet.test.js
+++ b/__tests__/medium/controller/router/screen/setRouterScreenSearchGet.test.js
@@ -1,6 +1,5 @@
 const express = require('express');
 const path = require('path');
-const { extractSessionTokenFromCookie } = require('../../../../helpers/extractSessionTokenFromCookie');
 
 const setRouterScreenSearchGet = require('../../../../../src/controller/router/screen/setRouterScreenSearchGet');
 const requestApp = async ({ app, method, targetPath, headers = {} } = {}) => {
@@ -51,9 +50,7 @@ describe('setRouterScreenSearchGet (middle)', () => {
     });
 
     app.use((req, _res, next) => {
-      req.session = {
-        session_token: extractSessionTokenFromCookie(req.header('cookie')),
-      };
+      req.session = {};
       req.context = {};
       next();
     });
@@ -73,9 +70,6 @@ describe('setRouterScreenSearchGet (middle)', () => {
       app,
       method: 'GET',
       targetPath: '/screen/search',
-      headers: {
-        cookie: 'session_token=valid-token',
-      },
     });
 
     expect(response.status).toBe(200);

--- a/__tests__/medium/controller/router/screen/setRouterScreenSummaryGet.test.js
+++ b/__tests__/medium/controller/router/screen/setRouterScreenSummaryGet.test.js
@@ -1,6 +1,5 @@
 const express = require('express');
 const path = require('path');
-const { extractSessionTokenFromCookie } = require('../../../../helpers/extractSessionTokenFromCookie');
 
 const setRouterScreenSummaryGet = require('../../../../../src/controller/router/screen/setRouterScreenSummaryGet');
 const requestApp = async ({ app, targetPath, headers = {} }) => {
@@ -49,7 +48,7 @@ describe('setRouterScreenSummaryGet (middle)', () => {
     });
 
     app.use((req, _res, next) => {
-      req.session = { session_token: extractSessionTokenFromCookie(req.header('cookie')) };
+      req.session = {};
       req.context = {};
       next();
     });
@@ -68,7 +67,6 @@ describe('setRouterScreenSummaryGet (middle)', () => {
     const response = await requestApp({
       app,
       targetPath: '/screen/summary?summaryPage=1&start=11&size=5&title=%E5%A4%AA%E9%83%8E&tags=%E4%BD%9C%E8%80%85%3A%E5%B1%B1%E7%94%B0&tags=%E4%B8%8D%E6%AD%A3&sort=title_desc',
-      headers: { cookie: 'session_token=valid-token' },
     });
 
     expect(response.status).toBe(200);


### PR DESCRIPTION
### Motivation
- 画面ルートは認証レスで提供する新仕様に合わせて、`__tests__/medium` に残っていた `session_token` Cookie 注入前提や `userId` 差分検証を解消するため変更を行いました。
- レガシーな `session_token` Cookie が `setupMiddleware` によって認証セッションとして補完されないことを明示的に検証する必要があったためテストを追加しました。

### Description
- `__tests__/medium/controller/router/screen/setRouterScreenSummaryGet.test.js` で `session_token` 注入を削除し、テスト用アプリで `req.session = {}` を渡すように変更しました。
- `__tests__/medium/controller/router/screen/setRouterRootGet.test.js` でセッション注入ミドルウェアと認証済み専用ケースを削除してルートのリダイレクト仕様のみを検証するように整理しました。
- `__tests__/medium/controller/router/screen/setRouterScreenSearchGet.test.js` でも `session_token` 前提を削除して描画検証へ統一しました。
- `__tests__/medium/app/commonNavigator.integration.test.js` の管理者/一般ユーザー `userId` 差分検証を廃止して単一ケースに統合し、`devSessionUserId` の注入を削除しました。
- `__tests__/medium/app/setupMiddleware.integration.test.js` にレスポンスの `sessionToken` フィールドを追加し、`session_token` Cookie を送っても `req.session.session_token` が補完されないことを検証するテストを追加しました。
- 変更はすべて `__tests__/medium/**` 下のテストのみで、`src/**` の実装コードには変更を加えていません。

### Testing
- 以下コマンドで対象の medium テストを実行し、すべて成功しました: `npm run test:medium -- __tests__/medium/controller/router/screen/setRouterScreenSummaryGet.test.js __tests__/medium/controller/router/screen/setRouterRootGet.test.js __tests__/medium/controller/router/screen/setRouterScreenSearchGet.test.js __tests__/medium/app/commonNavigator.integration.test.js __tests__/medium/app/setupMiddleware.integration.test.js`.
- medium テストスイート全体でも `17` 件のテストが `PASS` しました（`17 passed, 17 total`）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edb41f0b64832ba2e53d0c7ea22c24)