### PR TITLE
docs: 分析モデルからユーザー要素を除去する

### DIFF
--- a/doc/2_domain/分析モデル.drawio.svg
+++ b/doc/2_domain/分析モデル.drawio.svg
@@ -72,64 +72,6 @@
                         </g>
                     </g>
                 </g>
-                <g data-cell-id="23">
-                    <g transform="translate(0.5,0.5)">
-                        <rect x="230" y="240" width="120" height="60" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-                    </g>
-                    <g>
-                        <g>
-                            <switch>
-                                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 270px; margin-left: 231px;">
-                                        <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
-                                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                                ピックアップ
-                                            </div>
-                                        </div>
-                                    </div>
-                                </foreignObject>
-                                <text x="290" y="274" fill="light-dark(#000000, #ffffff)" font-family="Helvetica" font-size="12px" text-anchor="middle">
-                                    ピックアップ
-                                </text>
-                            </switch>
-                        </g>
-                    </g>
-                </g>
-                <g data-cell-id="24">
-                    <g transform="translate(0.5,0.5)">
-                        <rect x="0" y="240" width="120" height="60" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-                    </g>
-                    <g>
-                        <g>
-                            <switch>
-                                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 270px; margin-left: 1px;">
-                                        <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
-                                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                                閲覧予定
-                                            </div>
-                                        </div>
-                                    </div>
-                                </foreignObject>
-                                <text x="60" y="274" fill="light-dark(#000000, #ffffff)" font-family="Helvetica" font-size="12px" text-anchor="middle">
-                                    閲覧予定
-                                </text>
-                            </switch>
-                        </g>
-                    </g>
-                </g>
-                <g data-cell-id="27">
-                    <g transform="translate(0.5,0.5)">
-                        <path d="M 170 157.99 L 170 185 Q 170 195 180 195 L 280 195 Q 290 195 290 205 L 290 240" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-                        <path d="M 170 150.99 L 172.06 154.49 L 170 157.99 L 167.94 154.49 Z" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-                    </g>
-                </g>
-                <g data-cell-id="28">
-                    <g transform="translate(0.5,0.5)">
-                        <path d="M 170 157.99 L 170 185 Q 170 195 160 195 L 70 195 Q 60 195 60 205 L 60 240" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-                        <path d="M 170 150.99 L 172.06 154.49 L 170 157.99 L 167.94 154.49 Z" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-                    </g>
-                </g>
                 <g data-cell-id="36">
                     <g transform="translate(0.5,0.5)">
                         <path d="M 170 447.99 L 170 460 Q 170 470 160 470 L 80 470 Q 70 470 70 480 L 70 500" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
@@ -156,58 +98,6 @@
                                     コンテンツ
                                 </text>
                             </switch>
-                        </g>
-                    </g>
-                </g>
-                <g data-cell-id="37">
-                    <g transform="translate(0.5,0.5)">
-                        <path d="M 290 300 L 290 330 Q 290 340 280 340 L 180 340 Q 170 340 170 350 L 170 373.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-                        <path d="M 170 378.88 L 167.67 371.88 L 170 373.63 L 172.33 371.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-                    </g>
-                    <g data-cell-id="43">
-                        <g>
-                            <g>
-                                <switch>
-                                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 331px; margin-left: 231px;">
-                                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; background-color: #ffffff; ">
-                                                <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; background-color: light-dark(#ffffff, var(--ge-dark-color, #121212)); white-space: nowrap; ">
-                                                    参照
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </foreignObject>
-                                    <text x="231" y="334" fill="light-dark(#000000, #ffffff)" font-family="Helvetica" font-size="11px" text-anchor="middle">
-                                        参照
-                                    </text>
-                                </switch>
-                            </g>
-                        </g>
-                    </g>
-                </g>
-                <g data-cell-id="38">
-                    <g transform="translate(0.5,0.5)">
-                        <path d="M 60 300 L 60 330 Q 60 340 70 340 L 160 340 Q 170 340 170 350 L 170 373.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-                        <path d="M 170 378.88 L 167.67 371.88 L 170 373.63 L 172.33 371.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-                    </g>
-                    <g data-cell-id="44">
-                        <g>
-                            <g>
-                                <switch>
-                                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 331px; margin-left: 121px;">
-                                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; background-color: #ffffff; ">
-                                                <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; background-color: light-dark(#ffffff, var(--ge-dark-color, #121212)); white-space: nowrap; ">
-                                                    参照
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </foreignObject>
-                                    <text x="121" y="334" fill="light-dark(#000000, #ffffff)" font-family="Helvetica" font-size="11px" text-anchor="middle">
-                                        参照
-                                    </text>
-                                </switch>
-                            </g>
                         </g>
                     </g>
                 </g>


### PR DESCRIPTION
### Motivation
- ドメイン設計方針に合わせて、分析図からユーザー集約（ユーザーID／お気に入り／あとで見るに相当する要素）を取り除き、メディア中心の表現に統一する必要があったため。 

### Description
- `doc/2_domain/分析モデル.drawio.svg` の図から「閲覧予定」「ピックアップ」に該当するノードと、それらに接続していた参照線・ラベルを削除した。 
- `doc/2_domain/ドメインモデル.puml` と `doc/2_domain/ユビキタス言語.md` は確認したところ既に該当エントリが存在しなかったため変更していない。 
- 変更範囲は `doc/2_domain/` 配下の `分析モデル.drawio.svg` のみで、実装コードやテストコードには影響を与えない。 

### Testing
- キーワード検索で該当語が残っていないことを確認するために `rg -n "ユーザー|ユーザーID|user|favorite|queue|userId|お気に入り|あとで見る|閲覧予定|ピックアップ" doc/2_domain/ドメインモデル.puml doc/2_domain/ユビキタス言語.md doc/2_domain/分析モデル.drawio.svg` を実行し、該当なし（終了コードは非ゼロ）を確認した。 
- `git status --short` と `git log --oneline -1` によりファイルの差分と最新コミット（本PRの変更）が正しく作成されていることを確認した。 
- 上記自動確認はいずれも期待どおりに完了した。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edb6309000832b9e421ecfaef0b7fe)