### PR TITLE
refactor: セッション依存を除去してCSRF検証をCookie前提へ統一

### DIFF
--- a/__tests__/medium/app/setupMiddleware.integration.test.js
+++ b/__tests__/medium/app/setupMiddleware.integration.test.js
@@ -13,7 +13,7 @@ const createApp = () => {
 
   app.get('/protected', (req, res) => {
     res.status(200).json({
-      csrfToken: req.session.csrf_token,
+      csrfToken: res.locals.csrfToken,
       requestId: req.context.requestId,
     });
   });

--- a/__tests__/medium/controller/router/media/setRouterApiMediaDelete.test.js
+++ b/__tests__/medium/controller/router/media/setRouterApiMediaDelete.test.js
@@ -14,21 +14,6 @@ const Tag = require('../../../../../src/domain/media/tag');
 const Category = require('../../../../../src/domain/media/category');
 const Label = require('../../../../../src/domain/media/label');
 
-const extractCsrfTokenFromCookie = cookieHeader => {
-  if (typeof cookieHeader !== 'string' || cookieHeader.length === 0) {
-    return undefined;
-  }
-  const pair = cookieHeader
-    .split(';')
-    .map(entry => entry.trim())
-    .find(entry => entry.startsWith('csrf_token='));
-  if (!pair) {
-    return undefined;
-  }
-  const [, value = ''] = pair.split('=');
-  return value || undefined;
-};
-
 describe('setRouterApiMediaDelete (middle)', () => {
   let sequelize;
   let unitOfWork;
@@ -64,9 +49,6 @@ describe('setRouterApiMediaDelete (middle)', () => {
     const router = express.Router();
 
     app.use((req, _res, next) => {
-      req.session = {
-        csrf_token: extractCsrfTokenFromCookie(req.header('cookie')),
-      };
       req.context = {};
       next();
     });

--- a/__tests__/medium/controller/router/media/setRouterApiMediaPatch.test.js
+++ b/__tests__/medium/controller/router/media/setRouterApiMediaPatch.test.js
@@ -18,21 +18,6 @@ const Tag = require('../../../../../src/domain/media/tag');
 const Category = require('../../../../../src/domain/media/category');
 const Label = require('../../../../../src/domain/media/label');
 
-const extractCsrfTokenFromCookie = cookieHeader => {
-  if (typeof cookieHeader !== 'string' || cookieHeader.length === 0) {
-    return undefined;
-  }
-  const pair = cookieHeader
-    .split(';')
-    .map(entry => entry.trim())
-    .find(entry => entry.startsWith('csrf_token='));
-  if (!pair) {
-    return undefined;
-  }
-  const [, value = ''] = pair.split('=');
-  return value || undefined;
-};
-
 describe('setRouterApiMediaPatch (middle)', () => {
   let sequelize;
   let unitOfWork;
@@ -73,9 +58,6 @@ describe('setRouterApiMediaPatch (middle)', () => {
     const router = express.Router();
 
     app.use((req, _res, next) => {
-      req.session = {
-        csrf_token: extractCsrfTokenFromCookie(req.header('cookie')),
-      };
       req.context = {};
       next();
     });

--- a/__tests__/medium/controller/router/media/setRouterApiMediaPost.test.js
+++ b/__tests__/medium/controller/router/media/setRouterApiMediaPost.test.js
@@ -11,21 +11,6 @@ const SequelizeUnitOfWork = require('../../../../../src/infrastructure/Sequelize
 const MediaId = require('../../../../../src/domain/media/mediaId');
 const MulterDiskStorageContentUploadAdapter = require('../../../../../src/infrastructure/MulterDiskStorageContentUploadAdapter');
 
-const extractCsrfTokenFromCookie = cookieHeader => {
-  if (typeof cookieHeader !== 'string' || cookieHeader.length === 0) {
-    return undefined;
-  }
-  const pair = cookieHeader
-    .split(';')
-    .map(entry => entry.trim())
-    .find(entry => entry.startsWith('csrf_token='));
-  if (!pair) {
-    return undefined;
-  }
-  const [, value = ''] = pair.split('=');
-  return value || undefined;
-};
-
 class FixedMediaIdValueGenerator {
   generate() {
     return '1234567890abcdef1234567890abcdef';
@@ -59,9 +44,6 @@ describe('setRouterApiMediaPost (middle)', () => {
     const router = express.Router();
 
     app.use((req, _res, next) => {
-      req.session = {
-        csrf_token: extractCsrfTokenFromCookie(req.header('cookie')),
-      };
       req.context = {};
       next();
     });

--- a/__tests__/medium/controller/router/screen/setRouterScreenSearchGet.test.js
+++ b/__tests__/medium/controller/router/screen/setRouterScreenSearchGet.test.js
@@ -50,7 +50,6 @@ describe('setRouterScreenSearchGet (middle)', () => {
     });
 
     app.use((req, _res, next) => {
-      req.session = {};
       req.context = {};
       next();
     });

--- a/__tests__/medium/controller/router/screen/setRouterScreenSummaryGet.test.js
+++ b/__tests__/medium/controller/router/screen/setRouterScreenSummaryGet.test.js
@@ -48,7 +48,6 @@ describe('setRouterScreenSummaryGet (middle)', () => {
     });
 
     app.use((req, _res, next) => {
-      req.session = {};
       req.context = {};
       next();
     });

--- a/__tests__/small/controller/router/media/setRouterApiMediaDelete.test.js
+++ b/__tests__/small/controller/router/media/setRouterApiMediaDelete.test.js
@@ -26,10 +26,10 @@ describe('setRouterApiMediaDelete', () => {
     expect(handlers).toHaveLength(3);
 
     const req = {
-      session: { csrf_token: 'csrf-1' },
       protocol: 'http',
       get: name => ({
         'x-csrf-token': 'csrf-1',
+        cookie: 'csrf_token=csrf-1',
       'x-admin-token': 'admin-token',
         origin: 'http://localhost',
         host: 'localhost',

--- a/__tests__/small/controller/router/media/setRouterApiMediaPatch.test.js
+++ b/__tests__/small/controller/router/media/setRouterApiMediaPatch.test.js
@@ -11,12 +11,10 @@ describe('setRouterApiMediaPatch', () => {
   };
 
   const createReq = () => ({
-    session: {
-            csrf_token: 'csrf-1',
-    },
     protocol: 'http',
     get: name => ({
       'x-csrf-token': 'csrf-1',
+      cookie: 'csrf_token=csrf-1',
       'x-admin-token': 'admin-token',
       origin: 'http://localhost',
       host: 'localhost',

--- a/__tests__/small/controller/router/media/setRouterApiMediaPost.test.js
+++ b/__tests__/small/controller/router/media/setRouterApiMediaPost.test.js
@@ -11,12 +11,10 @@ describe('setRouterApiMediaPost', () => {
   };
 
   const createReq = () => ({
-    session: {
-            csrf_token: 'csrf-1',
-    },
     protocol: 'http',
     get: name => ({
       'x-csrf-token': 'csrf-1',
+      cookie: 'csrf_token=csrf-1',
       'x-admin-token': 'admin-token',
       origin: 'http://localhost',
       host: 'localhost',

--- a/src/app/setupMiddleware.js
+++ b/src/app/setupMiddleware.js
@@ -29,21 +29,6 @@ const parseCookieHeader = cookieHeader => {
     }, {});
 };
 
-const attachSessionHelpers = req => {
-  req.session = req.session ?? {};
-  req.session.req = req;
-  req.session.regenerate = callback => {
-    req.session = {};
-    attachSessionHelpers(req);
-    callback(null);
-  };
-  req.session.destroy = callback => {
-    req.session = {};
-    attachSessionHelpers(req);
-    callback(null);
-  };
-};
-
 const createCsrfToken = () => crypto.randomBytes(32).toString('hex');
 
 const resolveCsrfCookiePolicy = env => {
@@ -164,7 +149,6 @@ const setupMiddleware = (app, { env = {}, dependencies: _dependencies } = {}) =>
 
   app.use((req, res, next) => {
     req.context = req.context ?? {};
-    attachSessionHelpers(req);
     const logger = req.app?.locals?.dependencies?.logger;
     const allowedHosts = resolveAllowedHosts(env);
     const rawHost = normalizeHost(req.header('host'));
@@ -200,12 +184,11 @@ const setupMiddleware = (app, { env = {}, dependencies: _dependencies } = {}) =>
     });
 
     const cookies = parseCookieHeader(req.header('cookie'));
-    if (typeof cookies.csrf_token === 'string' && cookies.csrf_token.length > 0) {
-      req.session.csrf_token = cookies.csrf_token;
-    } else {
-      req.session.csrf_token = createCsrfToken();
+    const hasCsrfCookie = typeof cookies.csrf_token === 'string' && cookies.csrf_token.length > 0;
+    const csrfToken = hasCsrfCookie ? cookies.csrf_token : createCsrfToken();
+    if (!hasCsrfCookie) {
       const policy = resolveCsrfCookiePolicy(env);
-      res.cookie?.('csrf_token', req.session.csrf_token, {
+      res.cookie?.('csrf_token', csrfToken, {
         httpOnly: false,
         path: '/',
         secure: policy.secure,
@@ -213,7 +196,7 @@ const setupMiddleware = (app, { env = {}, dependencies: _dependencies } = {}) =>
       });
     }
 
-    res.locals.csrfToken = req.session.csrf_token;
+    res.locals.csrfToken = csrfToken;
 
     const startedAt = Date.now();
     const requestId = req.header('x-request-id') || crypto.randomUUID();

--- a/src/controller/middleware/CsrfProtectionMiddleware.js
+++ b/src/controller/middleware/CsrfProtectionMiddleware.js
@@ -17,10 +17,10 @@ class CsrfProtectionMiddleware {
     }
 
     const logger = req.app?.locals?.dependencies?.logger;
-    const sessionToken = req?.session?.csrf_token;
+    const cookieToken = this.#resolveCsrfTokenFromCookie(req);
     const headerToken = req.get('x-csrf-token');
 
-    if (!this.#isNonEmptyString(sessionToken) || headerToken !== sessionToken) {
+    if (!this.#isNonEmptyString(cookieToken) || headerToken !== cookieToken) {
       logger?.warn('security.csrf.validation_failed', {
         request_id: req.context?.requestId,
         reason: 'csrf_token_mismatch',
@@ -119,6 +119,30 @@ class CsrfProtectionMiddleware {
     } catch (_error) {
       return false;
     }
+  }
+
+  #resolveCsrfTokenFromCookie(req) {
+    const cookieHeader = req.get('cookie');
+    if (!this.#isNonEmptyString(cookieHeader)) {
+      return null;
+    }
+
+    const csrfCookie = cookieHeader
+      .split(';')
+      .map(entry => entry.trim())
+      .find(entry => entry.startsWith('csrf_token='));
+
+    if (!this.#isNonEmptyString(csrfCookie)) {
+      return null;
+    }
+
+    const separatorIndex = csrfCookie.indexOf('=');
+    if (separatorIndex <= 0) {
+      return null;
+    }
+
+    const value = csrfCookie.slice(separatorIndex + 1).trim();
+    return this.#isNonEmptyString(value) ? value : null;
   }
 }
 


### PR DESCRIPTION
### Motivation
- セッション補助（`req.session` の自前初期化）に依存するとセッションミドルウェア未導入環境で前提が壊れるため、CSRF 関連処理をセッション非依存に簡素化する必要があった。 
- CSRF トークンは Cookie と要求ヘッダーの照合で十分に扱えるため、保持先を `res.locals` / Cookie に統一し保守コストを下げる。 

### Description
- `src/app/setupMiddleware.js` から `req.session` 補助ロジックを削除し、CSRF トークンは Cookie の有無を判定して `res.locals.csrfToken` に公開する実装へ変更し、Cookie 未設定時のみ新規採番して `csrf_token` を返却するようにした。  
- `src/controller/middleware/CsrfProtectionMiddleware.js` を修正し、検証元を `req.session.csrf_token` からリクエストの `cookie` ヘッダー内の `csrf_token` に切り替えた。  
- `__tests__/small/**` と `__tests__/medium/**` のテストを更新し、`req.session` 前提の初期化を削除して `cookie: 'csrf_token=...'` と `x-csrf-token` の組で CSRF 条件を満たす形に変更した。  
- medium のミドルウェア統合テストはレスポンス側の公開値を `req.session.csrf_token` から `res.locals.csrfToken` に合わせて期待値を更新した。  
- 影響ファイル（主な変更箇所）: `src/app/setupMiddleware.js`, `src/controller/middleware/CsrfProtectionMiddleware.js`, テスト群 `__tests__/small/**`, `__tests__/medium/**`。 

### Testing
- 実行コマンド: `npm run test:small` — 成功（全 44 スイート、235 テストがパス）。  
- 実行コマンド: `npm run test:medium` — 成功（全 17 スイート、66 テストがパス）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edc7964250832b84d9de1d94f83713)