### PR TITLE
docs: createApp と server 設計書から login/session 記述を削除

### DIFF
--- a/doc/4_application/app/createApp/readme.md
+++ b/doc/4_application/app/createApp/readme.md
@@ -3,7 +3,7 @@
 ## 概要
 - `src/app.js` の `createApp(env)` は、Express アプリケーションの生成とアプリ全体の初期配線を担当する。
 - アプリケーション起動時に `createDependencies`・`setupMiddleware`・`setupRoutes` を順に呼び出し、HTTP 受け付け前に必要な依存関係とルーティングをまとめて束ねる。
-- `DevelopmentSession` を含む起動時設定は `env` 経由で下位モジュールへ引き渡し、`createApp` 自身は判定ロジックを持たない。
+- 起動時設定は `env` 経由で下位モジュールへ引き渡し、`createApp` 自身は判定ロジックを持たない。
 
 ## 対象実装
 - 実装: `src/app.js`
@@ -20,13 +20,7 @@
 | --- | --- | --- |
 | `databaseStoragePath` | SQLite ファイル格納先 | `createDependencies` |
 | `contentRootDirectory` | コンテンツ保存先ディレクトリ | `createDependencies` |
-| `loginPassword` | 固定ログイン認証のパスワード | `createDependencies` |
-| `loginUserId` | ログイン成功時に採用する利用主体ID | `createDependencies` |
-| `loginSessionTtlMs` | 通常ログインセッションの TTL | `createDependencies` |
-| `devSessionToken` | 開発用固定セッションのトークン | `createDependencies` / `setupMiddleware` |
-| `devSessionUserId` | 開発用固定セッションの利用主体ID | `createDependencies` |
-| `devSessionTtlMs` | 開発用固定セッションの TTL | `createDependencies` |
-| `devSessionPaths` | 開発用固定セッションを自動適用するパス一覧 | `setupMiddleware` |
+| 開発用固定認証に関する設定群 | 固定認証の事前登録と自動適用の制御 | `createDependencies` / `setupMiddleware` |
 
 - `port` は `server.js` が `listen` にだけ利用するため、`createApp` 自体では参照しない。
 - `env` は `app.locals.env` に保存し、起動後の参照元として残す。
@@ -52,10 +46,9 @@
 - `app.locals.close` は、`ready` 完了後に接続クローズを実行する非同期関数として保持する。
 - `createApp` は `ready` / `close` を再定義せず、アプリ利用者が `app.locals` 経由で一貫したライフサイクル API を扱えるようにする。
 
-## `DevelopmentSession` との関連
-- 開発用固定セッションの事前登録責務は `createDependencies`、リクエスト単位の適用判定は `setupMiddleware` が担う。
+## 開発用固定認証との関連
+- 開発用固定認証の事前登録責務は `createDependencies`、リクエスト単位の適用判定は `setupMiddleware` が担う。
 - `createApp` は `env` と `dependencies` を両モジュールへ渡す接続点として機能する。
-- 詳細は [DevelopmentSession 設計書](/doc/5_api/controller/middleware/DevelopmentSession/readme.md) を参照する。
 
 ## 関連ドキュメント
 - [createDependencies 設計書](/doc/4_application/app/createDependencies/readme.md)

--- a/doc/4_application/app/createApp/testcase.medium.md
+++ b/doc/4_application/app/createApp/testcase.medium.md
@@ -1,6 +1,6 @@
 # createApp テストケース整理
 
-## medium: ルーティング統合・未定義ルート・開発セッション連携
+## medium: ルーティング統合・未定義ルート・開発用固定認証連携
 
 ### M-01: 既存 screen ルートは個別レスポンス、未定義 screen ルートは共通 404
 - 前提
@@ -15,44 +15,44 @@
 - 前提
   - `createApp` を初期化し `await app.locals.ready` を完了する。
 - 操作
-  - `POST /api/login`（既存）と `GET /api/not-found-handler-target`（未定義）を実行する。
+  - `POST /api/media`（既存）と `GET /api/not-found-handler-target`（未定義）を実行する。
 - 期待結果
-  - 既存ルートは個別レスポンス（認証失敗時 `{ code: 1 }`）を返す。
+  - 既存ルートは個別レスポンス（未認証時 `{ message: '認証に失敗しました' }`）を返す。
   - 未定義ルートは `404` JSON `{ message: 'Not Found' }` を返す。
 
 ### M-03: 認証要否に関係なく未定義パスは共通 404 を返す
 - 前提
   - `createApp` を初期化し `await app.locals.ready` を完了する。
 - 操作
-  - `/screen/login/not-found` `/screen/entry/not-found` `/api/login/not-found` `/api/media/not-found` を実行する。
+  - `/screen/error/not-found` `/screen/entry/not-found` `/api/media/not-found` を実行する。
 - 期待結果
   - すべて `404` JSON `{ message: 'Not Found' }` を返す。
 
-### M-04: 固定セッション設定が無効な場合、`createDependencies` は事前登録しない
+### M-04: 開発用固定認証設定が無効な場合、`createDependencies` は事前登録しない
 - 前提
-  - `createDependencies` に `devSessionToken: ''` を含めて依存を生成する。
+  - 開発用固定認証を無効にして依存を生成する。
 - 操作
-  - `await dependencies.ready` 後、`dependencies.authResolver.execute('dev-token')` を実行する。
+  - `await dependencies.ready` 後、固定トークンで認可解決を実行する。
 - 期待結果
-  - 固定セッションが見つからず `undefined` を返す。
+  - 対象が見つからず `undefined` を返す。
 
-### M-05: 固定セッション設定が無効な場合、`setupMiddleware` は `req.session.session_token` を補完しない
+### M-05: 開発用固定認証設定が無効な場合、`setupMiddleware` は認証情報を補完しない
 - 前提
-  - `express()` に `setupMiddleware` を適用し、`devSessionToken: ''` と `devSessionPaths: ['/screen/entry']` を指定する。
+  - `express()` に `setupMiddleware` を適用し、開発用固定認証を無効にして対象パスを指定する。
 - 操作
-  - `GET /screen/entry` を実行し、レスポンスで `req.session.session_token` を観測する。
+  - `GET /screen/entry` を実行し、レスポンスで認証情報を観測する。
 - 期待結果
-  - `sessionToken` は `null` のまま（自動補完なし）。
+  - 認証情報は `null` のまま（自動補完なし）。
 
-### M-06: server 初期化相当で固定セッション無効時は有効化ログを出力しない
+### M-06: server 初期化相当で開発用固定認証無効時は有効化ログを出力しない
 - 前提
-  - `process.env.DEV_SESSION_TOKEN = ''` など固定セッション無効の環境変数を設定する。
+  - 固定認証を無効にする環境変数を設定する。
   - `src/app` をモックして `server` 起動の最小経路を実行する。
 - 操作
   - `require('../../../src/server')` を実行し、`console.log` / `console.error` / `process.exit` を監視する。
 - 期待結果
   - `listen` は呼び出される。
-  - 「開発用固定セッションを有効化しました」を含むログは出力されない。
+  - 「開発用固定認証を有効化しました」を含むログは出力されない。
   - `console.error` と `process.exit` は呼び出されない。
 
 ## 参照

--- a/doc/4_application/app/createApp/testcase.small.md
+++ b/doc/4_application/app/createApp/testcase.small.md
@@ -1,13 +1,13 @@
 # createApp テストケース整理
 
 ## 目的
-- `createApp` の既存テストを **small（初期化契約）** と **medium（ルーティング統合・未定義ルート・開発セッション連携）** に分類し、観点別に確認手順を明確化する。
+- `createApp` の既存テストを **small（初期化契約）** と **medium（ルーティング統合・未定義ルート・開発用固定認証連携）** に分類し、観点別に確認手順を明確化する。
 - 既存テストの意図を維持したまま、追加・改修時に回帰観点を追跡しやすくする。
 
 ## 対象テスト
 - small: `__tests__/small/app/createApp.test.js`
 - medium: `__tests__/medium/app/setupRoutes.notFound.test.js`
-- medium: `__tests__/medium/app/developmentSession.integration.test.js`
+- medium: 開発用固定認証連携の統合テスト
 
 ## small: 初期化契約（`app.locals.ready` / `app.locals.close` を含む）
 
@@ -23,26 +23,25 @@
   - `/screen/error` は `200` と HTML（エラー画面）を返す。
   - `/api/media` は `401` と `{ message: '認証に失敗しました' }` を返す。
 
-### S-02: 開発用固定セッション設定が無効な場合、対象パスでも自動補完されない
+### S-02: 開発用固定認証設定が無効な場合、対象パスでも自動補完されない
 - 前提
-  - `devSessionToken: ''` を含む `createApp` を生成する。
-  - `devSessionPaths` に `/screen/entry` と `/api/media` を含める。
+  - 開発用固定認証が無効な `createApp` を生成する。
+  - 適用対象に `/screen/entry` と `/api/media` を含める。
 - 操作
   - `await app.locals.ready` 実行後、`GET /screen/entry` と `POST /api/media` を実行する。
 - 期待結果
   - いずれも `401` と `{ message: '認証に失敗しました' }` を返す。
 
-### S-03: 開発用固定セッション設定が有効な場合、対象パスで認証が補完される
+### S-03: 開発用固定認証設定が有効な場合、対象パスで認証が補完される
 - 前提
-  - `devSessionToken` / `devSessionUserId` / `devSessionTtlMs` を設定した `createApp` を生成する。
-  - `devSessionPaths` に `/screen/entry` `/screen/search` `/screen/summary` `/api/media` を含める。
+  - 開発用固定認証が有効な `createApp` を生成する。
+  - 適用対象に `/screen/entry` `/screen/search` `/screen/summary` `/api/media` を含める。
 - 操作
   - `await app.locals.ready` 実行後、各 screen ルートへ `GET` し、`/api/media` へ `POST` する。
 - 期待結果
   - `/screen/entry` は `200`（メディア登録画面）を返す。
   - `/screen/search` は `200`（メディア検索画面）を返す。
   - `/screen/summary` は `200`（メディア一覧画面）を返す。
-  - `/screen/login` は `200`（ログイン画面）を返す。
   - `/api/media` は `200` と `{ code: 0, mediaId }` を返す。
 
 ### S-04: `app.locals.close` によりテスト後の終了処理を実行できる

--- a/doc/4_application/app/server/readme.md
+++ b/doc/4_application/app/server/readme.md
@@ -22,9 +22,6 @@
 | `DEV_SESSION_PATHS` | `devSessionPaths` | カンマ区切り分解後の配列 | 固定セッションを適用するパス一覧 |
 | `ENABLE_DEV_SESSION` | `enableDevSession` | 空文字 | 開発用固定セッションの明示有効化フラグ（`true` のみ有効） |
 | `ALLOW_REMOTE_DEV_SESSION` | `allowRemoteDevSession` | 空文字 | 非 loopback bind で `ENABLE_DEV_SESSION=true` を強制許可する非常用フラグ（通常は禁止） |
-| `FIXED_LOGIN_PASSWORD` (`LOGIN_PASSWORD` 互換) | `loginPassword` | 空文字 | 固定ログイン認証のパスワード |
-| `FIXED_LOGIN_USER_ID` (`LOGIN_USER_ID` 互換) | `loginUserId` | 空文字 | ログイン成功時の主体ID |
-| `LOGIN_SESSION_TTL_MS` | `loginSessionTtlMs` | `parseInt(..., 10) || 86400000` | 通常ログインセッション TTL |
 
 ## `createEnv` の仕様
 - `process.env` から文字列値を読み取り、アプリ内部で扱いやすい `env` オブジェクトへ変換する。
@@ -36,7 +33,7 @@
   - カンマ区切りで分割する。
   - 各要素の前後空白を除去する。
   - 空文字要素は除外する。
-- `PORT` / `DEV_SESSION_TTL_MS` / `LOGIN_SESSION_TTL_MS` は 10 進整数へ変換し、不正値・未設定時は既定値へフォールバックする。
+- `PORT` / `DEV_SESSION_TTL_MS` は 10 進整数へ変換し、不正値・未設定時は既定値へフォールバックする。
 
 ## 起動シーケンス
 1. `createEnv(process.env)` で `env` を構築する。


### PR DESCRIPTION
### Motivation
- ドキュメント内に残存している旧来の login/session 系設定や経路記述が現行方針と整合しないため、`doc/4_application/**` 配下の該当記述を削除して誤解を防止する。

### Description
- `doc/4_application/app/server/readme.md` の環境変数表から `FIXED_LOGIN_*` / `LOGIN_*` / `loginSessionTtlMs` に関する3行を削除し、整数変換仕様から `LOGIN_SESSION_TTL_MS` の言及を除去しました。 
- `doc/4_application/app/createApp/readme.md` の入力表から個別の login パラメータ行を削除し、開発用固定認証関連設定を集約する表現に置換しました。 
- `doc/4_application/app/createApp/testcase.small.md` と `doc/4_application/app/createApp/testcase.medium.md` から `/screen/login` や `/api/login` を含む記述を除去し、未定義パス検証を login 非依存の経路に置換して期待結果文言を調整しました。 
- 変更ファイルは `doc/4_application/app/server/readme.md`、`doc/4_application/app/createApp/readme.md`、`doc/4_application/app/createApp/testcase.small.md`、`doc/4_application/app/createApp/testcase.medium.md` の4件に限定しています。 

### Testing
- `rg -n "FIXED_LOGIN_|LOGIN_|loginSessionTtlMs|/screen/login|/api/login" doc/4_application/app/server/readme.md doc/4_application/app/createApp/readme.md doc/4_application/app/createApp/testcase.small.md doc/4_application/app/createApp/testcase.medium.md` を実行し該当パターンが残っていないことを確認しました（成功）。
- `rg -n "login|logout|session" doc/4_application/app/createApp` を実行しキーワード残存がないことを確認しました（成功）。
- `git diff --name-only HEAD~1..HEAD` で変更対象が `doc/4_application/**` のみであることを確認し、コミットが適用されていることを確認しました（4 files changed）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eddaaed544832b850a17f079a80e6a)