### PR TITLE
docs: media削除シーケンス図のユーザー表現を中立表現へ置換する

### DIFF
--- a/doc/5_api/sequence/api/media.mediaId.delete.puml
+++ b/doc/5_api/sequence/api/media.mediaId.delete.puml
@@ -37,7 +37,7 @@ Service -> infrastructure: コンテンツ削除
 infrastructure -> ストレージ: コンテンツ削除
 note over Service, ストレージ
     コンテンツの削除に失敗してもメディア削除の失敗として扱わない。
-    コンテンツが残っていてもユーザーに参照されることは無いため問題ない。
+    コンテンツが残っていても利用主体から参照されることは無いため問題ない。
 end note
 Controller <-- Service: メディア削除成功
 クライアント <-- Controller: 200 成功


### PR DESCRIPTION
### Motivation
- 要件に沿ってドキュメント中の主体表現を中立化するために、`doc/5_api/sequence/api/media.mediaId.delete.puml` の「ユーザー」を別の中立表現へ置換しました。

### Description
- 対象ファイル `doc/5_api/sequence/api/media.mediaId.delete.puml` の注記文中の「ユーザー」を「利用主体」に置換し、該当ファイルのみを編集しました。

### Testing
- ファイル内の一致確認として `rg -n "user|ユーザー" doc/5_api/sequence/api/media.mediaId.delete.puml` を実行し、ヒットが 0 件であることを確認しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ede3d04be4832ba4878e7005bac485)