### PR TITLE
docs: media削除シーケンスの表現を中立化する

### DIFF
--- a/doc/5_api/sequence/api/media.mediaId.delete.puml
+++ b/doc/5_api/sequence/api/media.mediaId.delete.puml
@@ -37,7 +37,7 @@ Service -> infrastructure: コンテンツ削除
 infrastructure -> ストレージ: コンテンツ削除
 note over Service, ストレージ
     コンテンツの削除に失敗してもメディア削除の失敗として扱わない。
-    コンテンツが残っていても利用主体から参照されることは無いため問題ない。
+    コンテンツが残っていても外部インターフェースから参照されることは無いため問題ない。
 end note
 Controller <-- Service: メディア削除成功
 クライアント <-- Controller: 200 成功


### PR DESCRIPTION
### Motivation
- `doc/5_api/sequence/api/media.mediaId.delete.puml` 内の注記表現が利用者を想起させる記述になっていたため、仕様記述をより中立的で解釈しやすい表現に統一する目的で修正しました。

### Description
- `doc/5_api/sequence/api/media.mediaId.delete.puml` の注記文を1行置換し「コンテンツが残っていても利用主体から参照されることは無いため問題ない。」を「コンテンツが残っていても外部インターフェースから参照されることは無いため問題ない。」に変更し、該当ファイルのみを編集しました。

### Testing
- `nl -ba doc/5_api/sequence/api/media.mediaId.delete.puml` で差分を確認し、`rg -n 'ユーザー|user' doc/5_api/sequence/api/media.mediaId.delete.puml` を実行して該当語が残っていないことを確認しました（両コマンドとも成功）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ede483d3e0832b874600dd611b2048)